### PR TITLE
fix(test): Fixed config tests for varnish to work on any OS

### DIFF
--- a/receiver/varnishreceiver/config.go
+++ b/receiver/varnishreceiver/config.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	errWorkingDirNotExist = errors.New(`"working_dir" does not exists %q`)
-	errExecDirNotExist    = errors.New(`"exec_dir" does not exists %q`)
+	errWorkingDirNotExist = errors.New(`"working_dir" does not exists`)
+	errExecDirNotExist    = errors.New(`"exec_dir" does not exists`)
 )
 
 // Config defines configuration for varnish metrics receiver.

--- a/receiver/varnishreceiver/config.go
+++ b/receiver/varnishreceiver/config.go
@@ -15,19 +15,12 @@
 package varnishreceiver // import "github.com/observiq/observiq-otel-collector/receiver/varnishreceiver"
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	"go.uber.org/multierr"
 
 	"github.com/observiq/observiq-otel-collector/receiver/varnishreceiver/internal/metadata"
-)
-
-var (
-	errWorkingDirNotExist = errors.New(`"working_dir" does not exists`)
-	errExecDirNotExist    = errors.New(`"exec_dir" does not exists`)
 )
 
 // Config defines configuration for varnish metrics receiver.
@@ -40,17 +33,16 @@ type Config struct {
 
 // Validate validates the config.
 func (c *Config) Validate() error {
-	var err error
 	if c.WorkingDir != "" {
-		if _, pathErr := os.Stat(c.WorkingDir); pathErr != nil {
-			err = multierr.Append(err, fmt.Errorf(errWorkingDirNotExist.Error(), pathErr))
+		if _, err := os.Stat(c.WorkingDir); err != nil {
+			return fmt.Errorf(`"working_dir" does not exists: %w`, err)
 		}
 	}
 	if c.ExecDir != "" {
-		if _, pathErr := os.Stat(c.ExecDir); pathErr != nil {
-			err = multierr.Append(err, fmt.Errorf(errExecDirNotExist.Error(), pathErr))
+		if _, err := os.Stat(c.ExecDir); err != nil {
+			return fmt.Errorf(`"exec_dir" does not exists: %w`, err)
 		}
 	}
 
-	return err
+	return nil
 }

--- a/receiver/varnishreceiver/config_test.go
+++ b/receiver/varnishreceiver/config_test.go
@@ -25,26 +25,26 @@ func TestValidate(t *testing.T) {
 	testCases := []struct {
 		desc                string
 		cfg                 Config
-		expectedErrContains error
+		expectedErrContains string
 	}{
 		{
 			desc:                "empty config",
 			cfg:                 Config{},
-			expectedErrContains: nil,
+			expectedErrContains: "",
 		},
 		{
 			desc: "missing exec dir",
 			cfg: Config{
 				ExecDir: "missing/exec",
 			},
-			expectedErrContains: errExecDirNotExist,
+			expectedErrContains: `"exec_dir" does not exists`,
 		},
 		{
 			desc: "missing working dir",
 			cfg: Config{
 				WorkingDir: "missing/working",
 			},
-			expectedErrContains: errWorkingDirNotExist,
+			expectedErrContains: `"working_dir" does not exists`,
 		},
 		{
 			desc: "valid exec and working dir",
@@ -52,14 +52,14 @@ func TestValidate(t *testing.T) {
 				WorkingDir: testDir,
 				ExecDir:    testDir,
 			},
-			expectedErrContains: nil,
+			expectedErrContains: "",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			actualErr := tc.cfg.Validate()
-			if tc.expectedErrContains != nil {
-				require.Contains(t, actualErr.Error(), tc.expectedErrContains.Error())
+			if tc.expectedErrContains != "" {
+				require.Contains(t, actualErr.Error(), tc.expectedErrContains)
 			} else {
 				require.NoError(t, actualErr)
 			}

--- a/receiver/varnishreceiver/config_test.go
+++ b/receiver/varnishreceiver/config_test.go
@@ -15,59 +15,51 @@
 package varnishreceiver // import "github.com/observiq/observiq-otel-collector/receiver/varnishreceiver"
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidate(t *testing.T) {
+	testDir := t.TempDir()
 	testCases := []struct {
-		desc        string
-		cfg         Config
-		expectedErr error
+		desc                string
+		cfg                 Config
+		expectedErrContains error
 	}{
 		{
-			desc:        "empty config",
-			cfg:         Config{},
-			expectedErr: nil,
+			desc:                "empty config",
+			cfg:                 Config{},
+			expectedErrContains: nil,
 		},
 		{
 			desc: "missing exec dir",
 			cfg: Config{
 				ExecDir: "missing/exec",
 			},
-			expectedErr: fmt.Errorf(errExecDirNotExist.Error(), "stat missing/exec: no such file or directory"),
+			expectedErrContains: errExecDirNotExist,
 		},
 		{
 			desc: "missing working dir",
 			cfg: Config{
 				WorkingDir: "missing/working",
 			},
-			expectedErr: fmt.Errorf(errWorkingDirNotExist.Error(), "stat missing/working: no such file or directory"),
-		},
-		{
-			desc: "missing exec and working dir",
-			cfg: Config{
-				WorkingDir: "missing/working",
-				ExecDir:    "missing/exec",
-			},
-			expectedErr: fmt.Errorf("\"working_dir\" does not exists \"stat missing/working: no such file or directory\"; \"exec_dir\" does not exists \"stat missing/exec: no such file or directory\""),
+			expectedErrContains: errWorkingDirNotExist,
 		},
 		{
 			desc: "valid exec and working dir",
 			cfg: Config{
-				WorkingDir: "config_test.go",
-				ExecDir:    "config_test.go",
+				WorkingDir: testDir,
+				ExecDir:    testDir,
 			},
-			expectedErr: nil,
+			expectedErrContains: nil,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			actualErr := tc.cfg.Validate()
-			if tc.expectedErr != nil {
-				require.EqualError(t, actualErr, tc.expectedErr.Error())
+			if tc.expectedErrContains != nil {
+				require.Contains(t, actualErr.Error(), tc.expectedErrContains.Error())
 			} else {
 				require.NoError(t, actualErr)
 			}


### PR DESCRIPTION
### Proposed Change
The previous varnish tests depended on an os specific string for path errors. Due to using multierror it makes error checking a bit difficult using `errors.Is` so I removed the compound test and update tests to check errors for string contains of base error.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
