### PR TITLE
feat: Print the package version on install

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -80,6 +80,20 @@ download_package() {
     echo "${out_file_path} successfully downloaded!"
 }
 
+package_version() {
+    case "$package_type" in
+        deb)
+            dpkg -s observiq-otel-collector | grep -i '^Version:' | cut -d' ' -f2
+            ;;
+        rpm)
+            rpm -q --queryformat '%{VERSION}' "observiq-otel-collector"
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
+}
+
 install_package() {
     case "$package_type" in
         deb)
@@ -143,7 +157,9 @@ main() {
             # Download and install the package
             download_package
             install_package
-            echo "Successfully installed the observIQ OpenTelemetry collector."
+            echo ""
+            echo ""
+            echo "Successfully installed version $(package_version) of the observIQ OpenTelemetry collector."
             ;;
         uninstall)
             echo "Uninstalling the observIQ OpenTelemetry collector..."


### PR DESCRIPTION
### Proposed Change
* When installing on linux through the install script, print the version that was just installed
  * Final line of installer is something like: `Successfully installed version 0.4.0 of the observIQ OpenTelemetry collector.` 
* Add some newlines to add some space after post-install script message. 

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
