### PR TITLE
fix: Add correct setup instructions to host metrics and prometheus

### DIFF
--- a/config/google_cloud_exporter/hostmetrics/README.md
+++ b/config/google_cloud_exporter/hostmetrics/README.md
@@ -15,17 +15,7 @@ An example configuration is located [here](./config.yaml).
 
 ## Setup
 
-This example assumes that [node exporter](https://github.com/prometheus/node_exporter) is running on the host system, on port 9100. Generally, all prometheus style exporters are supported, such as the [aerospike exporter](https://github.com/aerospike/aerospike-prometheus-exporter).
-
-If you wish to scrape metrics from external systems, update `config.yaml`'s prometheus scrape config with a list of IP addresses:
-```yaml
-- targets:
-    - '127.0.0.1:9100'
-    - '10.128.1.30:9100'
-    - '10.128.1.31:9100'
-    - '10.128.1.32:9100'
-    - '10.128.1.33:9100'
-```
+Host Metrics does not have setup requirements.
 
 ## Process metrics
 

--- a/config/google_cloud_exporter/prometheus/README.md
+++ b/config/google_cloud_exporter/prometheus/README.md
@@ -13,6 +13,20 @@ An example configuration is located [here](./config.yaml).
 1. Copy [config.yaml](./config.yaml) to `/opt/observiq-otel-collector/config.yaml`
 2. Restart the collector: `sudo systemctl restart observiq-otel-collector`
 
+## Setup
+
+This example assumes that [node exporter](https://github.com/prometheus/node_exporter) is running on the host system, on port 9100. Generally, all prometheus style exporters are supported, such as the [aerospike exporter](https://github.com/aerospike/aerospike-prometheus-exporter).
+
+If you wish to scrape metrics from external systems, update `config.yaml`'s prometheus scrape config with a list of IP addresses:
+```yaml
+- targets:
+    - '127.0.0.1:9100'
+    - '10.128.1.30:9100'
+    - '10.128.1.31:9100'
+    - '10.128.1.32:9100'
+    - '10.128.1.33:9100'
+```
+
 ## Metrics
 
 Metrics can be found with the `custom.googleapis.com` prefix.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The initial documentation for hostmetrics and prometheus had mismatched setup instructions.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
