### PR TITLE
feat(varnish metrics): Add client request error code metrics

### DIFF
--- a/receiver/varnishreceiver/documentation.md
+++ b/receiver/varnishreceiver/documentation.md
@@ -8,16 +8,17 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| **varnish.backend.connections.count** | The backend connection type count. | {connections} | Sum(Int) | <ul> <li>backend_connection_type</li> </ul> |
-| **varnish.backend.requests.count** | The backend requests count. | {requests} | Sum(Int) | <ul> </ul> |
-| **varnish.cache.operations.count** | The cache operation type count. | {operations} | Sum(Int) | <ul> <li>cache_operations</li> </ul> |
-| **varnish.client.requests.count** | The client request count. | {requests} | Sum(Int) | <ul> <li>state</li> </ul> |
+| **varnish.backend.connection.count** | The backend connection type count. | {connections} | Sum(Int) | <ul> <li>backend_connection_type</li> </ul> |
+| **varnish.backend.request.count** | The backend requests count. | {requests} | Sum(Int) | <ul> </ul> |
+| **varnish.cache.operation.count** | The cache operation type count. | {operations} | Sum(Int) | <ul> <li>cache_operations</li> </ul> |
+| **varnish.client.request.count** | The client request count. | {requests} | Sum(Int) | <ul> <li>state</li> </ul> |
+| **varnish.client.request.error.count** | The client request errors received by status code. | {requests} | Sum(Int) | <ul> <li>http.status_code</li> </ul> |
 | **varnish.object.count** | The HTTP objects in the cache count. | {objects} | Sum(Int) | <ul> </ul> |
-| **varnish.object.expired.count** | The expired objects from old age count. | {objects} | Sum(Int) | <ul> </ul> |
-| **varnish.object.moved.count** | The moved operations done on the LRU list count. | {objects} | Sum(Int) | <ul> </ul> |
-| **varnish.object.nuked.count** | The objects that have been forcefully evicted from storage count. | {objects} | Sum(Int) | <ul> </ul> |
+| **varnish.object.expired** | The expired objects from old age count. | {objects} | Sum(Int) | <ul> </ul> |
+| **varnish.object.moved** | The moved operations done on the LRU list count. | {objects} | Sum(Int) | <ul> </ul> |
+| **varnish.object.nuked** | The objects that have been forcefully evicted from storage count. | {objects} | Sum(Int) | <ul> </ul> |
 | **varnish.session.count** | The session connection type count. | {connections} | Sum(Int) | <ul> <li>session_type</li> </ul> |
-| **varnish.thread.operations.count** | The thread operation type count. | {operations} | Sum(Int) | <ul> <li>thread_operations</li> </ul> |
+| **varnish.thread.operation.count** | The thread operation type count. | {operations} | Sum(Int) | <ul> <li>thread_operations</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:
@@ -35,6 +36,7 @@ metrics:
 | backend_connection_type | The backend connection types. |
 | cache_name | The varnish cache name. |
 | cache_operations | The cache operation types |
+| http.status_code | An HTTP status code. |
 | session_type | The session connection types. |
 | state | The client request states. |
 | thread_operations | The thread operation types. |

--- a/receiver/varnishreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/varnishreceiver/internal/metadata/generated_metrics_v2.go
@@ -15,62 +15,66 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for varnishreceiver metrics.
 type MetricsSettings struct {
-	VarnishBackendConnectionsCount MetricSettings `mapstructure:"varnish.backend.connections.count"`
-	VarnishBackendRequestsCount    MetricSettings `mapstructure:"varnish.backend.requests.count"`
-	VarnishCacheOperationsCount    MetricSettings `mapstructure:"varnish.cache.operations.count"`
-	VarnishClientRequestsCount     MetricSettings `mapstructure:"varnish.client.requests.count"`
+	VarnishBackendConnectionCount  MetricSettings `mapstructure:"varnish.backend.connection.count"`
+	VarnishBackendRequestCount     MetricSettings `mapstructure:"varnish.backend.request.count"`
+	VarnishCacheOperationCount     MetricSettings `mapstructure:"varnish.cache.operation.count"`
+	VarnishClientRequestCount      MetricSettings `mapstructure:"varnish.client.request.count"`
+	VarnishClientRequestErrorCount MetricSettings `mapstructure:"varnish.client.request.error.count"`
 	VarnishObjectCount             MetricSettings `mapstructure:"varnish.object.count"`
-	VarnishObjectExpiredCount      MetricSettings `mapstructure:"varnish.object.expired.count"`
-	VarnishObjectMovedCount        MetricSettings `mapstructure:"varnish.object.moved.count"`
-	VarnishObjectNukedCount        MetricSettings `mapstructure:"varnish.object.nuked.count"`
+	VarnishObjectExpired           MetricSettings `mapstructure:"varnish.object.expired"`
+	VarnishObjectMoved             MetricSettings `mapstructure:"varnish.object.moved"`
+	VarnishObjectNuked             MetricSettings `mapstructure:"varnish.object.nuked"`
 	VarnishSessionCount            MetricSettings `mapstructure:"varnish.session.count"`
-	VarnishThreadOperationsCount   MetricSettings `mapstructure:"varnish.thread.operations.count"`
+	VarnishThreadOperationCount    MetricSettings `mapstructure:"varnish.thread.operation.count"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
 	return MetricsSettings{
-		VarnishBackendConnectionsCount: MetricSettings{
+		VarnishBackendConnectionCount: MetricSettings{
 			Enabled: true,
 		},
-		VarnishBackendRequestsCount: MetricSettings{
+		VarnishBackendRequestCount: MetricSettings{
 			Enabled: true,
 		},
-		VarnishCacheOperationsCount: MetricSettings{
+		VarnishCacheOperationCount: MetricSettings{
 			Enabled: true,
 		},
-		VarnishClientRequestsCount: MetricSettings{
+		VarnishClientRequestCount: MetricSettings{
+			Enabled: true,
+		},
+		VarnishClientRequestErrorCount: MetricSettings{
 			Enabled: true,
 		},
 		VarnishObjectCount: MetricSettings{
 			Enabled: true,
 		},
-		VarnishObjectExpiredCount: MetricSettings{
+		VarnishObjectExpired: MetricSettings{
 			Enabled: true,
 		},
-		VarnishObjectMovedCount: MetricSettings{
+		VarnishObjectMoved: MetricSettings{
 			Enabled: true,
 		},
-		VarnishObjectNukedCount: MetricSettings{
+		VarnishObjectNuked: MetricSettings{
 			Enabled: true,
 		},
 		VarnishSessionCount: MetricSettings{
 			Enabled: true,
 		},
-		VarnishThreadOperationsCount: MetricSettings{
+		VarnishThreadOperationCount: MetricSettings{
 			Enabled: true,
 		},
 	}
 }
 
-type metricVarnishBackendConnectionsCount struct {
+type metricVarnishBackendConnectionCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.backend.connections.count metric with initial data.
-func (m *metricVarnishBackendConnectionsCount) init() {
-	m.data.SetName("varnish.backend.connections.count")
+// init fills varnish.backend.connection.count metric with initial data.
+func (m *metricVarnishBackendConnectionCount) init() {
+	m.data.SetName("varnish.backend.connection.count")
 	m.data.SetDescription("The backend connection type count.")
 	m.data.SetUnit("{connections}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -79,7 +83,7 @@ func (m *metricVarnishBackendConnectionsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVarnishBackendConnectionsCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, backendConnectionTypeAttributeValue string) {
+func (m *metricVarnishBackendConnectionCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, backendConnectionTypeAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -91,14 +95,14 @@ func (m *metricVarnishBackendConnectionsCount) recordDataPoint(start pdata.Times
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishBackendConnectionsCount) updateCapacity() {
+func (m *metricVarnishBackendConnectionCount) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishBackendConnectionsCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishBackendConnectionCount) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -106,8 +110,8 @@ func (m *metricVarnishBackendConnectionsCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishBackendConnectionsCount(settings MetricSettings) metricVarnishBackendConnectionsCount {
-	m := metricVarnishBackendConnectionsCount{settings: settings}
+func newMetricVarnishBackendConnectionCount(settings MetricSettings) metricVarnishBackendConnectionCount {
+	m := metricVarnishBackendConnectionCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -115,15 +119,15 @@ func newMetricVarnishBackendConnectionsCount(settings MetricSettings) metricVarn
 	return m
 }
 
-type metricVarnishBackendRequestsCount struct {
+type metricVarnishBackendRequestCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.backend.requests.count metric with initial data.
-func (m *metricVarnishBackendRequestsCount) init() {
-	m.data.SetName("varnish.backend.requests.count")
+// init fills varnish.backend.request.count metric with initial data.
+func (m *metricVarnishBackendRequestCount) init() {
+	m.data.SetName("varnish.backend.request.count")
 	m.data.SetDescription("The backend requests count.")
 	m.data.SetUnit("{requests}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -131,7 +135,7 @@ func (m *metricVarnishBackendRequestsCount) init() {
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricVarnishBackendRequestsCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricVarnishBackendRequestCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -142,14 +146,14 @@ func (m *metricVarnishBackendRequestsCount) recordDataPoint(start pdata.Timestam
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishBackendRequestsCount) updateCapacity() {
+func (m *metricVarnishBackendRequestCount) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishBackendRequestsCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishBackendRequestCount) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -157,8 +161,8 @@ func (m *metricVarnishBackendRequestsCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishBackendRequestsCount(settings MetricSettings) metricVarnishBackendRequestsCount {
-	m := metricVarnishBackendRequestsCount{settings: settings}
+func newMetricVarnishBackendRequestCount(settings MetricSettings) metricVarnishBackendRequestCount {
+	m := metricVarnishBackendRequestCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -166,15 +170,15 @@ func newMetricVarnishBackendRequestsCount(settings MetricSettings) metricVarnish
 	return m
 }
 
-type metricVarnishCacheOperationsCount struct {
+type metricVarnishCacheOperationCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.cache.operations.count metric with initial data.
-func (m *metricVarnishCacheOperationsCount) init() {
-	m.data.SetName("varnish.cache.operations.count")
+// init fills varnish.cache.operation.count metric with initial data.
+func (m *metricVarnishCacheOperationCount) init() {
+	m.data.SetName("varnish.cache.operation.count")
 	m.data.SetDescription("The cache operation type count.")
 	m.data.SetUnit("{operations}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -183,7 +187,7 @@ func (m *metricVarnishCacheOperationsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVarnishCacheOperationsCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, cacheOperationsAttributeValue string) {
+func (m *metricVarnishCacheOperationCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, cacheOperationsAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -195,14 +199,14 @@ func (m *metricVarnishCacheOperationsCount) recordDataPoint(start pdata.Timestam
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishCacheOperationsCount) updateCapacity() {
+func (m *metricVarnishCacheOperationCount) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishCacheOperationsCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishCacheOperationCount) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -210,8 +214,8 @@ func (m *metricVarnishCacheOperationsCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishCacheOperationsCount(settings MetricSettings) metricVarnishCacheOperationsCount {
-	m := metricVarnishCacheOperationsCount{settings: settings}
+func newMetricVarnishCacheOperationCount(settings MetricSettings) metricVarnishCacheOperationCount {
+	m := metricVarnishCacheOperationCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -219,15 +223,15 @@ func newMetricVarnishCacheOperationsCount(settings MetricSettings) metricVarnish
 	return m
 }
 
-type metricVarnishClientRequestsCount struct {
+type metricVarnishClientRequestCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.client.requests.count metric with initial data.
-func (m *metricVarnishClientRequestsCount) init() {
-	m.data.SetName("varnish.client.requests.count")
+// init fills varnish.client.request.count metric with initial data.
+func (m *metricVarnishClientRequestCount) init() {
+	m.data.SetName("varnish.client.request.count")
 	m.data.SetDescription("The client request count.")
 	m.data.SetUnit("{requests}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -236,7 +240,7 @@ func (m *metricVarnishClientRequestsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVarnishClientRequestsCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, stateAttributeValue string) {
+func (m *metricVarnishClientRequestCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, stateAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -248,14 +252,14 @@ func (m *metricVarnishClientRequestsCount) recordDataPoint(start pdata.Timestamp
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishClientRequestsCount) updateCapacity() {
+func (m *metricVarnishClientRequestCount) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishClientRequestsCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishClientRequestCount) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -263,8 +267,61 @@ func (m *metricVarnishClientRequestsCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishClientRequestsCount(settings MetricSettings) metricVarnishClientRequestsCount {
-	m := metricVarnishClientRequestsCount{settings: settings}
+func newMetricVarnishClientRequestCount(settings MetricSettings) metricVarnishClientRequestCount {
+	m := metricVarnishClientRequestCount{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricVarnishClientRequestErrorCount struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills varnish.client.request.error.count metric with initial data.
+func (m *metricVarnishClientRequestErrorCount) init() {
+	m.data.SetName("varnish.client.request.error.count")
+	m.data.SetDescription("The client request errors received by status code.")
+	m.data.SetUnit("{requests}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricVarnishClientRequestErrorCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, httpStatusCodeAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert(A.HTTPStatusCode, pdata.NewAttributeValueString(httpStatusCodeAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricVarnishClientRequestErrorCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricVarnishClientRequestErrorCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricVarnishClientRequestErrorCount(settings MetricSettings) metricVarnishClientRequestErrorCount {
+	m := metricVarnishClientRequestErrorCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -323,15 +380,15 @@ func newMetricVarnishObjectCount(settings MetricSettings) metricVarnishObjectCou
 	return m
 }
 
-type metricVarnishObjectExpiredCount struct {
+type metricVarnishObjectExpired struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.object.expired.count metric with initial data.
-func (m *metricVarnishObjectExpiredCount) init() {
-	m.data.SetName("varnish.object.expired.count")
+// init fills varnish.object.expired metric with initial data.
+func (m *metricVarnishObjectExpired) init() {
+	m.data.SetName("varnish.object.expired")
 	m.data.SetDescription("The expired objects from old age count.")
 	m.data.SetUnit("{objects}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -339,7 +396,7 @@ func (m *metricVarnishObjectExpiredCount) init() {
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricVarnishObjectExpiredCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricVarnishObjectExpired) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -350,14 +407,14 @@ func (m *metricVarnishObjectExpiredCount) recordDataPoint(start pdata.Timestamp,
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishObjectExpiredCount) updateCapacity() {
+func (m *metricVarnishObjectExpired) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishObjectExpiredCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishObjectExpired) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -365,8 +422,8 @@ func (m *metricVarnishObjectExpiredCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishObjectExpiredCount(settings MetricSettings) metricVarnishObjectExpiredCount {
-	m := metricVarnishObjectExpiredCount{settings: settings}
+func newMetricVarnishObjectExpired(settings MetricSettings) metricVarnishObjectExpired {
+	m := metricVarnishObjectExpired{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -374,15 +431,15 @@ func newMetricVarnishObjectExpiredCount(settings MetricSettings) metricVarnishOb
 	return m
 }
 
-type metricVarnishObjectMovedCount struct {
+type metricVarnishObjectMoved struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.object.moved.count metric with initial data.
-func (m *metricVarnishObjectMovedCount) init() {
-	m.data.SetName("varnish.object.moved.count")
+// init fills varnish.object.moved metric with initial data.
+func (m *metricVarnishObjectMoved) init() {
+	m.data.SetName("varnish.object.moved")
 	m.data.SetDescription("The moved operations done on the LRU list count.")
 	m.data.SetUnit("{objects}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -390,7 +447,7 @@ func (m *metricVarnishObjectMovedCount) init() {
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricVarnishObjectMovedCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricVarnishObjectMoved) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -401,14 +458,14 @@ func (m *metricVarnishObjectMovedCount) recordDataPoint(start pdata.Timestamp, t
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishObjectMovedCount) updateCapacity() {
+func (m *metricVarnishObjectMoved) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishObjectMovedCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishObjectMoved) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -416,8 +473,8 @@ func (m *metricVarnishObjectMovedCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishObjectMovedCount(settings MetricSettings) metricVarnishObjectMovedCount {
-	m := metricVarnishObjectMovedCount{settings: settings}
+func newMetricVarnishObjectMoved(settings MetricSettings) metricVarnishObjectMoved {
+	m := metricVarnishObjectMoved{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -425,15 +482,15 @@ func newMetricVarnishObjectMovedCount(settings MetricSettings) metricVarnishObje
 	return m
 }
 
-type metricVarnishObjectNukedCount struct {
+type metricVarnishObjectNuked struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.object.nuked.count metric with initial data.
-func (m *metricVarnishObjectNukedCount) init() {
-	m.data.SetName("varnish.object.nuked.count")
+// init fills varnish.object.nuked metric with initial data.
+func (m *metricVarnishObjectNuked) init() {
+	m.data.SetName("varnish.object.nuked")
 	m.data.SetDescription("The objects that have been forcefully evicted from storage count.")
 	m.data.SetUnit("{objects}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -441,7 +498,7 @@ func (m *metricVarnishObjectNukedCount) init() {
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricVarnishObjectNukedCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricVarnishObjectNuked) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -452,14 +509,14 @@ func (m *metricVarnishObjectNukedCount) recordDataPoint(start pdata.Timestamp, t
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishObjectNukedCount) updateCapacity() {
+func (m *metricVarnishObjectNuked) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishObjectNukedCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishObjectNuked) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -467,8 +524,8 @@ func (m *metricVarnishObjectNukedCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishObjectNukedCount(settings MetricSettings) metricVarnishObjectNukedCount {
-	m := metricVarnishObjectNukedCount{settings: settings}
+func newMetricVarnishObjectNuked(settings MetricSettings) metricVarnishObjectNuked {
+	m := metricVarnishObjectNuked{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -529,15 +586,15 @@ func newMetricVarnishSessionCount(settings MetricSettings) metricVarnishSessionC
 	return m
 }
 
-type metricVarnishThreadOperationsCount struct {
+type metricVarnishThreadOperationCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills varnish.thread.operations.count metric with initial data.
-func (m *metricVarnishThreadOperationsCount) init() {
-	m.data.SetName("varnish.thread.operations.count")
+// init fills varnish.thread.operation.count metric with initial data.
+func (m *metricVarnishThreadOperationCount) init() {
+	m.data.SetName("varnish.thread.operation.count")
 	m.data.SetDescription("The thread operation type count.")
 	m.data.SetUnit("{operations}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
@@ -546,7 +603,7 @@ func (m *metricVarnishThreadOperationsCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVarnishThreadOperationsCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, threadOperationsAttributeValue string) {
+func (m *metricVarnishThreadOperationCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, threadOperationsAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -558,14 +615,14 @@ func (m *metricVarnishThreadOperationsCount) recordDataPoint(start pdata.Timesta
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricVarnishThreadOperationsCount) updateCapacity() {
+func (m *metricVarnishThreadOperationCount) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricVarnishThreadOperationsCount) emit(metrics pdata.MetricSlice) {
+func (m *metricVarnishThreadOperationCount) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -573,8 +630,8 @@ func (m *metricVarnishThreadOperationsCount) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricVarnishThreadOperationsCount(settings MetricSettings) metricVarnishThreadOperationsCount {
-	m := metricVarnishThreadOperationsCount{settings: settings}
+func newMetricVarnishThreadOperationCount(settings MetricSettings) metricVarnishThreadOperationCount {
+	m := metricVarnishThreadOperationCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -586,16 +643,17 @@ func newMetricVarnishThreadOperationsCount(settings MetricSettings) metricVarnis
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
 	startTime                            pdata.Timestamp
-	metricVarnishBackendConnectionsCount metricVarnishBackendConnectionsCount
-	metricVarnishBackendRequestsCount    metricVarnishBackendRequestsCount
-	metricVarnishCacheOperationsCount    metricVarnishCacheOperationsCount
-	metricVarnishClientRequestsCount     metricVarnishClientRequestsCount
+	metricVarnishBackendConnectionCount  metricVarnishBackendConnectionCount
+	metricVarnishBackendRequestCount     metricVarnishBackendRequestCount
+	metricVarnishCacheOperationCount     metricVarnishCacheOperationCount
+	metricVarnishClientRequestCount      metricVarnishClientRequestCount
+	metricVarnishClientRequestErrorCount metricVarnishClientRequestErrorCount
 	metricVarnishObjectCount             metricVarnishObjectCount
-	metricVarnishObjectExpiredCount      metricVarnishObjectExpiredCount
-	metricVarnishObjectMovedCount        metricVarnishObjectMovedCount
-	metricVarnishObjectNukedCount        metricVarnishObjectNukedCount
+	metricVarnishObjectExpired           metricVarnishObjectExpired
+	metricVarnishObjectMoved             metricVarnishObjectMoved
+	metricVarnishObjectNuked             metricVarnishObjectNuked
 	metricVarnishSessionCount            metricVarnishSessionCount
-	metricVarnishThreadOperationsCount   metricVarnishThreadOperationsCount
+	metricVarnishThreadOperationCount    metricVarnishThreadOperationCount
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -611,16 +669,17 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                            pdata.NewTimestampFromTime(time.Now()),
-		metricVarnishBackendConnectionsCount: newMetricVarnishBackendConnectionsCount(settings.VarnishBackendConnectionsCount),
-		metricVarnishBackendRequestsCount:    newMetricVarnishBackendRequestsCount(settings.VarnishBackendRequestsCount),
-		metricVarnishCacheOperationsCount:    newMetricVarnishCacheOperationsCount(settings.VarnishCacheOperationsCount),
-		metricVarnishClientRequestsCount:     newMetricVarnishClientRequestsCount(settings.VarnishClientRequestsCount),
+		metricVarnishBackendConnectionCount:  newMetricVarnishBackendConnectionCount(settings.VarnishBackendConnectionCount),
+		metricVarnishBackendRequestCount:     newMetricVarnishBackendRequestCount(settings.VarnishBackendRequestCount),
+		metricVarnishCacheOperationCount:     newMetricVarnishCacheOperationCount(settings.VarnishCacheOperationCount),
+		metricVarnishClientRequestCount:      newMetricVarnishClientRequestCount(settings.VarnishClientRequestCount),
+		metricVarnishClientRequestErrorCount: newMetricVarnishClientRequestErrorCount(settings.VarnishClientRequestErrorCount),
 		metricVarnishObjectCount:             newMetricVarnishObjectCount(settings.VarnishObjectCount),
-		metricVarnishObjectExpiredCount:      newMetricVarnishObjectExpiredCount(settings.VarnishObjectExpiredCount),
-		metricVarnishObjectMovedCount:        newMetricVarnishObjectMovedCount(settings.VarnishObjectMovedCount),
-		metricVarnishObjectNukedCount:        newMetricVarnishObjectNukedCount(settings.VarnishObjectNukedCount),
+		metricVarnishObjectExpired:           newMetricVarnishObjectExpired(settings.VarnishObjectExpired),
+		metricVarnishObjectMoved:             newMetricVarnishObjectMoved(settings.VarnishObjectMoved),
+		metricVarnishObjectNuked:             newMetricVarnishObjectNuked(settings.VarnishObjectNuked),
 		metricVarnishSessionCount:            newMetricVarnishSessionCount(settings.VarnishSessionCount),
-		metricVarnishThreadOperationsCount:   newMetricVarnishThreadOperationsCount(settings.VarnishThreadOperationsCount),
+		metricVarnishThreadOperationCount:    newMetricVarnishThreadOperationCount(settings.VarnishThreadOperationCount),
 	}
 	for _, op := range options {
 		op(mb)
@@ -632,36 +691,42 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 // another set of data points. This function will be doing all transformations required to produce metric representation
 // defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricVarnishBackendConnectionsCount.emit(metrics)
-	mb.metricVarnishBackendRequestsCount.emit(metrics)
-	mb.metricVarnishCacheOperationsCount.emit(metrics)
-	mb.metricVarnishClientRequestsCount.emit(metrics)
+	mb.metricVarnishBackendConnectionCount.emit(metrics)
+	mb.metricVarnishBackendRequestCount.emit(metrics)
+	mb.metricVarnishCacheOperationCount.emit(metrics)
+	mb.metricVarnishClientRequestCount.emit(metrics)
+	mb.metricVarnishClientRequestErrorCount.emit(metrics)
 	mb.metricVarnishObjectCount.emit(metrics)
-	mb.metricVarnishObjectExpiredCount.emit(metrics)
-	mb.metricVarnishObjectMovedCount.emit(metrics)
-	mb.metricVarnishObjectNukedCount.emit(metrics)
+	mb.metricVarnishObjectExpired.emit(metrics)
+	mb.metricVarnishObjectMoved.emit(metrics)
+	mb.metricVarnishObjectNuked.emit(metrics)
 	mb.metricVarnishSessionCount.emit(metrics)
-	mb.metricVarnishThreadOperationsCount.emit(metrics)
+	mb.metricVarnishThreadOperationCount.emit(metrics)
 }
 
-// RecordVarnishBackendConnectionsCountDataPoint adds a data point to varnish.backend.connections.count metric.
-func (mb *MetricsBuilder) RecordVarnishBackendConnectionsCountDataPoint(ts pdata.Timestamp, val int64, backendConnectionTypeAttributeValue string) {
-	mb.metricVarnishBackendConnectionsCount.recordDataPoint(mb.startTime, ts, val, backendConnectionTypeAttributeValue)
+// RecordVarnishBackendConnectionCountDataPoint adds a data point to varnish.backend.connection.count metric.
+func (mb *MetricsBuilder) RecordVarnishBackendConnectionCountDataPoint(ts pdata.Timestamp, val int64, backendConnectionTypeAttributeValue string) {
+	mb.metricVarnishBackendConnectionCount.recordDataPoint(mb.startTime, ts, val, backendConnectionTypeAttributeValue)
 }
 
-// RecordVarnishBackendRequestsCountDataPoint adds a data point to varnish.backend.requests.count metric.
-func (mb *MetricsBuilder) RecordVarnishBackendRequestsCountDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricVarnishBackendRequestsCount.recordDataPoint(mb.startTime, ts, val)
+// RecordVarnishBackendRequestCountDataPoint adds a data point to varnish.backend.request.count metric.
+func (mb *MetricsBuilder) RecordVarnishBackendRequestCountDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricVarnishBackendRequestCount.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordVarnishCacheOperationsCountDataPoint adds a data point to varnish.cache.operations.count metric.
-func (mb *MetricsBuilder) RecordVarnishCacheOperationsCountDataPoint(ts pdata.Timestamp, val int64, cacheOperationsAttributeValue string) {
-	mb.metricVarnishCacheOperationsCount.recordDataPoint(mb.startTime, ts, val, cacheOperationsAttributeValue)
+// RecordVarnishCacheOperationCountDataPoint adds a data point to varnish.cache.operation.count metric.
+func (mb *MetricsBuilder) RecordVarnishCacheOperationCountDataPoint(ts pdata.Timestamp, val int64, cacheOperationsAttributeValue string) {
+	mb.metricVarnishCacheOperationCount.recordDataPoint(mb.startTime, ts, val, cacheOperationsAttributeValue)
 }
 
-// RecordVarnishClientRequestsCountDataPoint adds a data point to varnish.client.requests.count metric.
-func (mb *MetricsBuilder) RecordVarnishClientRequestsCountDataPoint(ts pdata.Timestamp, val int64, stateAttributeValue string) {
-	mb.metricVarnishClientRequestsCount.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+// RecordVarnishClientRequestCountDataPoint adds a data point to varnish.client.request.count metric.
+func (mb *MetricsBuilder) RecordVarnishClientRequestCountDataPoint(ts pdata.Timestamp, val int64, stateAttributeValue string) {
+	mb.metricVarnishClientRequestCount.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+}
+
+// RecordVarnishClientRequestErrorCountDataPoint adds a data point to varnish.client.request.error.count metric.
+func (mb *MetricsBuilder) RecordVarnishClientRequestErrorCountDataPoint(ts pdata.Timestamp, val int64, httpStatusCodeAttributeValue string) {
+	mb.metricVarnishClientRequestErrorCount.recordDataPoint(mb.startTime, ts, val, httpStatusCodeAttributeValue)
 }
 
 // RecordVarnishObjectCountDataPoint adds a data point to varnish.object.count metric.
@@ -669,19 +734,19 @@ func (mb *MetricsBuilder) RecordVarnishObjectCountDataPoint(ts pdata.Timestamp, 
 	mb.metricVarnishObjectCount.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordVarnishObjectExpiredCountDataPoint adds a data point to varnish.object.expired.count metric.
-func (mb *MetricsBuilder) RecordVarnishObjectExpiredCountDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricVarnishObjectExpiredCount.recordDataPoint(mb.startTime, ts, val)
+// RecordVarnishObjectExpiredDataPoint adds a data point to varnish.object.expired metric.
+func (mb *MetricsBuilder) RecordVarnishObjectExpiredDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricVarnishObjectExpired.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordVarnishObjectMovedCountDataPoint adds a data point to varnish.object.moved.count metric.
-func (mb *MetricsBuilder) RecordVarnishObjectMovedCountDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricVarnishObjectMovedCount.recordDataPoint(mb.startTime, ts, val)
+// RecordVarnishObjectMovedDataPoint adds a data point to varnish.object.moved metric.
+func (mb *MetricsBuilder) RecordVarnishObjectMovedDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricVarnishObjectMoved.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordVarnishObjectNukedCountDataPoint adds a data point to varnish.object.nuked.count metric.
-func (mb *MetricsBuilder) RecordVarnishObjectNukedCountDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricVarnishObjectNukedCount.recordDataPoint(mb.startTime, ts, val)
+// RecordVarnishObjectNukedDataPoint adds a data point to varnish.object.nuked metric.
+func (mb *MetricsBuilder) RecordVarnishObjectNukedDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricVarnishObjectNuked.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordVarnishSessionCountDataPoint adds a data point to varnish.session.count metric.
@@ -689,9 +754,9 @@ func (mb *MetricsBuilder) RecordVarnishSessionCountDataPoint(ts pdata.Timestamp,
 	mb.metricVarnishSessionCount.recordDataPoint(mb.startTime, ts, val, sessionTypeAttributeValue)
 }
 
-// RecordVarnishThreadOperationsCountDataPoint adds a data point to varnish.thread.operations.count metric.
-func (mb *MetricsBuilder) RecordVarnishThreadOperationsCountDataPoint(ts pdata.Timestamp, val int64, threadOperationsAttributeValue string) {
-	mb.metricVarnishThreadOperationsCount.recordDataPoint(mb.startTime, ts, val, threadOperationsAttributeValue)
+// RecordVarnishThreadOperationCountDataPoint adds a data point to varnish.thread.operation.count metric.
+func (mb *MetricsBuilder) RecordVarnishThreadOperationCountDataPoint(ts pdata.Timestamp, val int64, threadOperationsAttributeValue string) {
+	mb.metricVarnishThreadOperationCount.recordDataPoint(mb.startTime, ts, val, threadOperationsAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,
@@ -721,6 +786,8 @@ var Attributes = struct {
 	CacheName string
 	// CacheOperations (The cache operation types)
 	CacheOperations string
+	// HTTPStatusCode (An HTTP status code.)
+	HTTPStatusCode string
 	// SessionType (The session connection types.)
 	SessionType string
 	// State (The client request states.)
@@ -731,6 +798,7 @@ var Attributes = struct {
 	"kind",
 	"cache_name",
 	"operation",
+	"status_code",
 	"kind",
 	"state",
 	"operation",

--- a/receiver/varnishreceiver/metadata.yaml
+++ b/receiver/varnishreceiver/metadata.yaml
@@ -23,9 +23,12 @@ attributes:
     value: state
     description: The client request states.
     enum: [received, dropped]
+  http.status_code:
+    value: status_code
+    description: An HTTP status code.
 
 metrics:
-  varnish.backend.connections.count:
+  varnish.backend.connection.count:
     enabled: true
     description: The backend connection type count.
     unit: "{connections}"
@@ -34,7 +37,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [backend_connection_type]
-  varnish.cache.operations.count:
+  varnish.cache.operation.count:
     enabled: true
     description: The cache operation type count.
     unit: "{operations}"
@@ -43,7 +46,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [cache_operations]
-  varnish.thread.operations.count:
+  varnish.thread.operation.count:
     enabled: true
     description: The thread operation type count.
     unit: "{operations}"
@@ -61,7 +64,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [session_type]
-  varnish.object.nuked.count:
+  varnish.object.nuked:
     enabled: true
     description: The objects that have been forcefully evicted from storage count.
     unit: "{objects}"
@@ -70,7 +73,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: []
-  varnish.object.moved.count:
+  varnish.object.moved:
     enabled: true
     description: The moved operations done on the LRU list count.
     unit: "{objects}"
@@ -79,7 +82,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: []
-  varnish.object.expired.count:
+  varnish.object.expired:
     enabled: true
     description: The expired objects from old age count.
     unit: "{objects}"
@@ -97,7 +100,7 @@ metrics:
       monotonic: false
       aggregation: cumulative
     attributes: []
-  varnish.client.requests.count:
+  varnish.client.request.count:
     enabled: true
     description: The client request count.
     unit: "{requests}"
@@ -106,7 +109,16 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [state]
-  varnish.backend.requests.count:
+  varnish.client.request.error.count:
+    enabled: true
+    description: The client request errors received by status code.
+    unit: "{requests}"
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: [http.status_code]
+  varnish.backend.request.count:
     enabled: true
     description: The backend requests count.
     unit: "{requests}"

--- a/receiver/varnishreceiver/metrics.go
+++ b/receiver/varnishreceiver/metrics.go
@@ -112,7 +112,7 @@ func (v *varnishScraper) recordVarnishBackendConnectionsCountDataPoint(now pdata
 	}
 
 	for attributeName, attributeValue := range attributeMappings {
-		v.mb.RecordVarnishBackendConnectionsCountDataPoint(now, attributeValue, attributeName)
+		v.mb.RecordVarnishBackendConnectionCountDataPoint(now, attributeValue, attributeName)
 	}
 }
 
@@ -124,7 +124,7 @@ func (v *varnishScraper) recordVarnishCacheOperationsCountDataPoint(now pdata.Ti
 	}
 
 	for attributeName, attributeValue := range attributeMappings {
-		v.mb.RecordVarnishCacheOperationsCountDataPoint(now, attributeValue, attributeName)
+		v.mb.RecordVarnishCacheOperationCountDataPoint(now, attributeValue, attributeName)
 	}
 }
 
@@ -136,7 +136,7 @@ func (v *varnishScraper) recordVarnishThreadOperationsCountDataPoint(now pdata.T
 	}
 
 	for attributeName, attributeValue := range attributeMappings {
-		v.mb.RecordVarnishThreadOperationsCountDataPoint(now, attributeValue, attributeName)
+		v.mb.RecordVarnishThreadOperationCountDataPoint(now, attributeValue, attributeName)
 	}
 }
 
@@ -159,6 +159,6 @@ func (v *varnishScraper) recordVarnishClientRequestsCountDataPoint(now pdata.Tim
 	}
 
 	for attributeName, attributeValue := range attributeMappings {
-		v.mb.RecordVarnishClientRequestsCountDataPoint(now, attributeValue, attributeName)
+		v.mb.RecordVarnishClientRequestCountDataPoint(now, attributeValue, attributeName)
 	}
 }

--- a/receiver/varnishreceiver/scraper.go
+++ b/receiver/varnishreceiver/scraper.go
@@ -85,11 +85,11 @@ func (v *varnishScraper) scrape(context.Context) (pdata.Metrics, error) {
 	v.recordVarnishSessionCountDataPoint(now, stats)
 	v.recordVarnishClientRequestsCountDataPoint(now, stats)
 
-	v.mb.RecordVarnishObjectExpiredCountDataPoint(now, stats.MAINNExpired.Value)
-	v.mb.RecordVarnishObjectNukedCountDataPoint(now, stats.MAINNLruNuked.Value)
-	v.mb.RecordVarnishObjectMovedCountDataPoint(now, stats.MAINNLruMoved.Value)
+	v.mb.RecordVarnishObjectExpiredDataPoint(now, stats.MAINNExpired.Value)
+	v.mb.RecordVarnishObjectNukedDataPoint(now, stats.MAINNLruNuked.Value)
+	v.mb.RecordVarnishObjectMovedDataPoint(now, stats.MAINNLruMoved.Value)
 	v.mb.RecordVarnishObjectCountDataPoint(now, stats.MAINNObject.Value)
-	v.mb.RecordVarnishBackendRequestsCountDataPoint(now, stats.MAINBackendReq.Value)
+	v.mb.RecordVarnishBackendRequestCountDataPoint(now, stats.MAINBackendReq.Value)
 
 	v.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
 	return md, nil

--- a/receiver/varnishreceiver/scraper.go
+++ b/receiver/varnishreceiver/scraper.go
@@ -84,6 +84,7 @@ func (v *varnishScraper) scrape(context.Context) (pdata.Metrics, error) {
 	v.recordVarnishThreadOperationsCountDataPoint(now, stats)
 	v.recordVarnishSessionCountDataPoint(now, stats)
 	v.recordVarnishClientRequestsCountDataPoint(now, stats)
+	v.recordVarnishClientRequestErrorCountDataPoint(now, stats)
 
 	v.mb.RecordVarnishObjectExpiredDataPoint(now, stats.MAINNExpired.Value)
 	v.mb.RecordVarnishObjectNukedDataPoint(now, stats.MAINNLruNuked.Value)

--- a/receiver/varnishreceiver/scraper_test.go
+++ b/receiver/varnishreceiver/scraper_test.go
@@ -88,8 +88,8 @@ func TestScrape(t *testing.T) {
 }
 
 func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
-	require.Equal(t, actualMetrics.MetricCount(), 10)
-	require.Equal(t, actualMetrics.DataPointCount(), 23)
+	require.Equal(t, actualMetrics.MetricCount(), 11)
+	require.Equal(t, actualMetrics.DataPointCount(), 26)
 
 	ilms := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
 	require.Equal(t, 1, ilms.Len())
@@ -194,6 +194,22 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 			require.Equal(t, map[string]int64{
 				"varnish.client.request.count method:map[state:received]": int64(3),
 				"varnish.client.request.count method:map[state:dropped]":  int64(23),
+			},
+				attributeMappings)
+		case "varnish.client.request.error.count":
+			dps := m.Sum().DataPoints()
+			require.Equal(t, 3, dps.Len())
+			attributeMappings := map[string]int64{}
+			for j := 0; j < dps.Len(); j++ {
+				dp := dps.At(j)
+				method := dp.Attributes().AsRaw()
+				label := fmt.Sprintf("%s method:%s", m.Name(), method)
+				attributeMappings[label] = dp.IntVal()
+			}
+			require.Equal(t, map[string]int64{
+				"varnish.client.request.error.count method:map[status_code:400]": int64(24),
+				"varnish.client.request.error.count method:map[status_code:417]": int64(25),
+				"varnish.client.request.error.count method:map[status_code:500]": int64(26),
 			},
 				attributeMappings)
 		case "varnish.backend.request.count":

--- a/receiver/varnishreceiver/scraper_test.go
+++ b/receiver/varnishreceiver/scraper_test.go
@@ -8,7 +8,8 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied// See the License for the specific language governing permissions and
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 package varnishreceiver // import "github.com/observiq/observiq-otel-collector/receiver/varnishreceiver"

--- a/receiver/varnishreceiver/scraper_test.go
+++ b/receiver/varnishreceiver/scraper_test.go
@@ -8,8 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied// See the License for the specific language governing permissions and
 // limitations under the License.
 
 package varnishreceiver // import "github.com/observiq/observiq-otel-collector/receiver/varnishreceiver"
@@ -98,7 +97,7 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 	for i := 0; i < ms.Len(); i++ {
 		m := ms.At(i)
 		switch m.Name() {
-		case "varnish.backend.connections.count":
+		case "varnish.backend.connection.count":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 7, dps.Len())
 			attributeMappings := map[string]int64{}
@@ -109,16 +108,16 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 				attributeMappings[label] = dp.IntVal()
 			}
 			require.Equal(t, map[string]int64{
-				"varnish.backend.connections.count method:map[kind:busy]":      int64(9),
-				"varnish.backend.connections.count method:map[kind:fail]":      int64(10),
-				"varnish.backend.connections.count method:map[kind:recycle]":   int64(12),
-				"varnish.backend.connections.count method:map[kind:retry]":     int64(13),
-				"varnish.backend.connections.count method:map[kind:reuse]":     int64(11),
-				"varnish.backend.connections.count method:map[kind:success]":   int64(7),
-				"varnish.backend.connections.count method:map[kind:unhealthy]": int64(8),
+				"varnish.backend.connection.count method:map[kind:busy]":      int64(9),
+				"varnish.backend.connection.count method:map[kind:fail]":      int64(10),
+				"varnish.backend.connection.count method:map[kind:recycle]":   int64(12),
+				"varnish.backend.connection.count method:map[kind:retry]":     int64(13),
+				"varnish.backend.connection.count method:map[kind:reuse]":     int64(11),
+				"varnish.backend.connection.count method:map[kind:success]":   int64(7),
+				"varnish.backend.connection.count method:map[kind:unhealthy]": int64(8),
 			},
 				attributeMappings)
-		case "varnish.cache.operations.count":
+		case "varnish.cache.operation.count":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 3, dps.Len())
 			attributeMappings := map[string]int64{}
@@ -129,12 +128,12 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 				attributeMappings[label] = dp.IntVal()
 			}
 			require.Equal(t, map[string]int64{
-				"varnish.cache.operations.count method:map[operation:hit]":      int64(4),
-				"varnish.cache.operations.count method:map[operation:hit_pass]": int64(5),
-				"varnish.cache.operations.count method:map[operation:miss]":     int64(6),
+				"varnish.cache.operation.count method:map[operation:hit]":      int64(4),
+				"varnish.cache.operation.count method:map[operation:hit_pass]": int64(5),
+				"varnish.cache.operation.count method:map[operation:miss]":     int64(6),
 			},
 				attributeMappings)
-		case "varnish.thread.operations.count":
+		case "varnish.thread.operation.count":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 3, dps.Len())
 			attributeMappings := map[string]int64{}
@@ -145,9 +144,9 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 				attributeMappings[label] = dp.IntVal()
 			}
 			require.Equal(t, map[string]int64{
-				"varnish.thread.operations.count method:map[operation:created]":   int64(14),
-				"varnish.thread.operations.count method:map[operation:destroyed]": int64(15),
-				"varnish.thread.operations.count method:map[operation:failed]":    int64(16),
+				"varnish.thread.operation.count method:map[operation:created]":   int64(14),
+				"varnish.thread.operation.count method:map[operation:destroyed]": int64(15),
+				"varnish.thread.operation.count method:map[operation:failed]":    int64(16),
 			},
 				attributeMappings)
 		case "varnish.session.count":
@@ -166,15 +165,15 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 				"varnish.session.count method:map[kind:failed]":   int64(2),
 			},
 				attributeMappings)
-		case "varnish.object.nuked.count":
+		case "varnish.object.nuked":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 1, dps.Len())
 			require.EqualValues(t, int64(20), dps.At(0).IntVal())
-		case "varnish.object.moved.count":
+		case "varnish.object.moved":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 1, dps.Len())
 			require.EqualValues(t, int64(21), dps.At(0).IntVal())
-		case "varnish.object.expired.count":
+		case "varnish.object.expired":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 1, dps.Len())
 			require.EqualValues(t, int64(19), dps.At(0).IntVal())
@@ -182,7 +181,7 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 1, dps.Len())
 			require.EqualValues(t, int64(18), dps.At(0).IntVal())
-		case "varnish.client.requests.count":
+		case "varnish.client.request.count":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 2, dps.Len())
 			attributeMappings := map[string]int64{}
@@ -193,11 +192,11 @@ func validateScraperResult(t *testing.T, actualMetrics pdata.Metrics) {
 				attributeMappings[label] = dp.IntVal()
 			}
 			require.Equal(t, map[string]int64{
-				"varnish.client.requests.count method:map[state:received]": int64(3),
-				"varnish.client.requests.count method:map[state:dropped]":  int64(23),
+				"varnish.client.request.count method:map[state:received]": int64(3),
+				"varnish.client.request.count method:map[state:dropped]":  int64(23),
 			},
 				attributeMappings)
-		case "varnish.backend.requests.count":
+		case "varnish.backend.request.count":
 			dps := m.Sum().DataPoints()
 			require.Equal(t, 1, dps.Len())
 			require.EqualValues(t, int64(22), dps.At(0).IntVal())

--- a/receiver/varnishreceiver/testdata/scraper/mock_response6_0.json
+++ b/receiver/varnishreceiver/testdata/scraper/mock_response6_0.json
@@ -136,5 +136,23 @@
             "flag": "c",
             "format": "i",
             "value": 23
+        },
+        "MAIN.client_req_400": {
+            "description": "Client requests received, subject to 400 errors",
+            "flag": "c",
+            "format": "i",
+            "value": 24
+        },
+        "MAIN.client_req_417": {
+            "description": "Client requests received, subject to 417 errors",
+            "flag": "c",
+            "format": "i",
+            "value": 25
+        },
+        "MAIN.client_resp_500": {
+            "description": "Delivery failed due to insufficient workspace.",
+            "flag": "c",
+            "format": "i",
+            "value": 26
         }
 }

--- a/receiver/varnishreceiver/testdata/scraper/mock_response6_5.json
+++ b/receiver/varnishreceiver/testdata/scraper/mock_response6_5.json
@@ -139,6 +139,24 @@
             "flag": "c",
             "format": "i",
             "value": 23
+        },
+        "MAIN.client_req_400": {
+            "description": "Client requests received, subject to 400 errors",
+            "flag": "c",
+            "format": "i",
+            "value": 24
+        },
+        "MAIN.client_req_417": {
+            "description": "Client requests received, subject to 417 errors",
+            "flag": "c",
+            "format": "i",
+            "value": 25
+        },
+        "MAIN.client_resp_500": {
+            "description": "Delivery failed due to insufficient workspace.",
+            "flag": "c",
+            "format": "i",
+            "value": 26
         }
     }
 }


### PR DESCRIPTION
### Proposed Change
This pr updates the metadata to reflect the scope doc. Small plural changes have been made to the names and a `client.request.error.count` metric is now collected with 3 codes(400, 417, 500).

Note, attributes of ints cannot be generated in the metadata and in the past the enum has been left blank intentionally like in [couchdb](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/couchdbreceiver/metadata.yaml#L12-L13). I have posted an image to show that the attribute can still be labeled though.

<img width="619" alt="Screen Shot 2022-03-30 at 4 06 23 PM" src="https://user-images.githubusercontent.com/13648435/160921695-c0825f3b-9d70-4f6c-b150-8ec6b7833a8c.png">

##### Checklist

- [x] Changes are tested
- [x] CI has passed
