### PR TITLE
Dockerfile refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,7 @@ jobs:
           file: ./Dockerfile
           # Supporting only linux/amd64 to keep builds fast. arm can
           # be enabled anytime by updating the `platforms` key.
-          #platforms: linux/amd64,linux/arm64
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY . /collector
 ARG JMX_JAR_VERSION=v1.7.0
 ARG GITHUB_TOKEN
 RUN \
-    make install-tools-goreleaser && \
+    make install-tools && \
     goreleaser build --single-target --skip-validate --rm-dist
 
 RUN cp "dist/collector_linux_$(go env GOARCH)/observiq-otel-collector" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,46 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Golang has multi arch manifests for amd64 and arm64
+
+# Build stage builds the release version of observiq-otel-collector
+# and downloads the opentelemetry-jmx-metrics.jar used by JMX receivers
+#
 FROM golang:1.17 as build
 WORKDIR /collector
 COPY . /collector
 ARG JMX_JAR_VERSION=v1.7.0
 ARG GITHUB_TOKEN
 RUN \
-    make install-tools && \
+    make install-tools-goreleaser && \
     goreleaser build --single-target --skip-validate --rm-dist
 
-# Find built executable, there is only one, and copy it to working dir
-RUN find /collector/dist -name observiq-otel-collector -exec cp {} . \;
+RUN cp "dist/collector_linux_$(go env GOARCH)/observiq-otel-collector" .
 
 RUN curl -L \
     --output /opt/opentelemetry-java-contrib-jmx-metrics.jar \
     "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_JAR_VERSION}/opentelemetry-jmx-metrics.jar"
 
-# Official OpenJDK has multi arch manifests for amd64 and arm64
-# Java is required for JMX receiver
+
+# OpenJDK stage provides the Java runtime used by JMX receivers.
 # Contrib's integration tests use openjdk 1.8.0
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/testdata/Dockerfile.cassandra
+#
 FROM openjdk:8u312-slim-buster as openjdk
 
 
-FROM gcr.io/observiq-container-images/stanza-base:v1.1.0
+# Certs stage stages ca-certificates
+#
+FROM debian:11-slim as certs
+RUN apt-get update -qq && apt-get install -qq -y ca-certificates
+
+
+# Final Stage
+#
+FROM debian:11-slim
 WORKDIR /
 
-# configure java runtime
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --no-create-home \
+    --uid 10005 \
+    otel
+
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
 ENV PATH=$PATH:/usr/local/openjdk-8/bin
 
-# config directory
-RUN mkdir -p /etc/otel
-
-# copy binary
 COPY --from=build /collector/observiq-otel-collector /collector/
-
-# copy jmx receiver dependency
 COPY --from=build /opt/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+USER otel
 
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap
 ENTRYPOINT [ "/collector/observiq-otel-collector" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,23 +39,10 @@ RUN curl -L \
 FROM openjdk:8u312-slim-buster as openjdk
 
 
-# Certs stage stages ca-certificates
-#
-FROM debian:11-slim as certs
-RUN apt-get update -qq && apt-get install -qq -y ca-certificates
-
-
 # Final Stage
 #
-FROM debian:11-slim
+FROM gcr.io/observiq-container-images/stanza-base:v1.2.0
 WORKDIR /
-
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --no-create-home \
-    --uid 10005 \
-    otel
 
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
@@ -63,7 +50,13 @@ ENV PATH=$PATH:/usr/local/openjdk-8/bin
 
 COPY --from=build /collector/observiq-otel-collector /collector/
 COPY --from=build /opt/opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --no-create-home \
+    --uid 10005 \
+    otel
 
 USER otel
 

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,9 @@ build-darwin-arm64:
 build-windows-amd64:
 	GOOS=windows GOARCH=amd64 $(MAKE) collector
 
-.PHONY: install-tools-goreleaser
-install-tools-goreleaser:
-	go install github.com/goreleaser/goreleaser@v1.6.3
-
 # tool-related commands
 .PHONY: install-tools
-install-tools: install-tools-goreleaser
+install-tools:
 	go install github.com/mgechev/revive@v1.2.0
 	go install github.com/google/addlicense@v1.0.0
 	go install golang.org/x/tools/cmd/goimports@latest

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,13 @@ build-darwin-arm64:
 build-windows-amd64:
 	GOOS=windows GOARCH=amd64 $(MAKE) collector
 
+.PHONY: install-tools-goreleaser
+install-tools-goreleaser:
+	go install github.com/goreleaser/goreleaser@v1.6.3
+
 # tool-related commands
 .PHONY: install-tools
-install-tools:
+install-tools: install-tools-goreleaser
 	go install github.com/mgechev/revive@v1.2.0
 	go install github.com/google/addlicense@v1.0.0
 	go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

I will be writing some documentation on how to run the collector within Docker and Kubernetes. Before I do, I wanted to make sure the collector image is up to date.

- Enabled arm64 image builds when running the release workflow
- Refactored Dockerfile
  - Use Ubuntu 22.04 based stanza base image (previous 20.10 based image is no longer supported, apt repos do not work)
  - Run as non root user by default: `otel`
  - Removed /etc/otel, this is created when mounting a config.yaml.

The largest change is the switch from root to otel user. Generally, we should be running container processes with a non root user. The documentation will include examples on how to run as root (and more importantly, when it is necessary).

**Testing**

I have tested the following usecases
- Docker / Docker compose
- Kubernetes w/ root for reading container logs
- Kubernetes using [the OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator), w/ root for reading container logs

**Inspec Testing**

I ran some inspec tests against a running collector container to test the user change

```
  User otel
     ✔  is expected to exist
     ✔  uid is expected to eq 10005
     ✔  group is expected to eq "otel"
     ✔  lastlogin is expected to eq nil
  Processes observiq-otel-collector
     ✔  users is expected to eq ["otel"]

Test Summary: 5 successful, 0 failures, 0 skipped
```

**Example Configs**

<details>
  <summary>Docker Compose Config</summary>
  
```yaml
version: "3.9"
services:
  collector:
    restart: always
    # Run as root if using a configuration that requires
    # root privileges.
    #user: root
    build:
      context: .
      args:
        - "GITHUB_TOKEN=${GITHUB_TOKEN}"
    restart: always
    deploy:
      resources:
        limits:
          cpus: 0.50
          memory: 256M
    volumes:
      - ${PWD}/config.yaml:/etc/otel/config.yaml
```
</details>

<details>
  <summary>Kubernetes Config</summary>
  
```yaml
---
kind: ConfigMap
metadata:
  name: otel-config
  namespace: default
apiVersion: v1
data:
  config.yaml: |2-
    receivers:
      prometheus:
        config:
          scrape_configs:
          - job_name: collector
            scrape_interval: 60s
            static_configs:
            - targets:
              - '127.0.0.1:8888'

      filelog:
        include: [ /var/log/containers/* ]

    processors:
      resourcedetection:
        detectors: ["system"]
        system:
          hostname_sources: ["os"]

      resourceattributetransposer:
        operations:
        - from: "host.name"
          to: "hostname"
        - from: "instance"
          to: "instance"
        - from: "service.name"
          to: "service"

      normalizesums:

      batch:

    exporters: 
      logging:
        logLevel: debug

    service:
      pipelines:
        metrics:
          receivers:
          - prometheus
          processors:
          - resourcedetection
          - resourceattributetransposer
          - normalizesums
          - batch
          exporters:
          - logging

        logs:
          receivers:
          - filelog
          exporters:
          - logging        
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: otel
  namespace: default
spec:
  selector:
    matchLabels:
      name: otel
  template:
    metadata:
      labels:
        name: otel
    spec:
      securityContext:
        # Run as root in order to read from /var/log/containers
        # and /var/lib/docker/containers
        runAsUser: 0
      containers:
        - name: otel
          # Production deployments should use an image tag other than latest
          image: observiq/observiq-otel-collector:latest
          imagePullPolicy: Never
          resources:
            limits:
              memory: "250Mi"
              cpu: 100m
            requests:
              memory: "250Mi"
              cpu: 100m
          volumeMounts:
            - mountPath: /etc/otel/config.yaml
              name: config
              subPath: config.yaml
            - mountPath: /var/log
              name: varlog
            - mountPath: /var/lib/docker/containers
              name: dockerlogs
      restartPolicy: Always
      terminationGracePeriodSeconds: 5
      volumes:
        - name: varlog
          hostPath:
            path: /var/log
        - name: dockerlogs
          hostPath:
            path: /var/lib/docker/containers
        - name: config
          configMap:
            name: otel-config
```
</details>

##### Checklist
- [x] Changes are tested
- [x] CI has passed
