### PR TITLE
Add storage directory to release packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,9 @@ archives:
       - src: release_deps/plugins/*
         dst: plugins
         strip_parent: true
+      - src: release_deps/storage/*
+        dst: storage
+        strip_parent: true
 
     format_overrides:
       - goos: windows
@@ -206,6 +209,7 @@ brews:
       bin.install "observiq-otel-collector"
       prefix.install "LICENSE", "config.yaml"
       prefix.install Dir["plugins"]
+      prefix.install Dir["storage"]
       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -206,7 +206,6 @@ brews:
       bin.install "observiq-otel-collector"
       prefix.install "LICENSE", "config.yaml"
       prefix.install Dir["plugins"]
-      FileUtils.mkdir_p(File.expand_path("~/observiq-otel-collector/storage")) unless File.exists?(File.expand_path("~/observiq-otel-collector/storage"))
       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>
@@ -236,5 +235,3 @@ brews:
       </plist>
     # For local testing
     # skip_upload: "true"
-
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,7 +110,7 @@ nfpms:
       - dst: /opt/observiq-otel-collector/storage
         type: dir
         file_info:
-          mode: 0755
+          mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
     scripts:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,9 +47,6 @@ archives:
       - src: release_deps/plugins/*
         dst: plugins
         strip_parent: true
-      - src: release_deps/storage/*
-        dst: storage
-        strip_parent: true
 
     format_overrides:
       - goos: windows
@@ -209,7 +206,7 @@ brews:
       bin.install "observiq-otel-collector"
       prefix.install "LICENSE", "config.yaml"
       prefix.install Dir["plugins"]
-      prefix.install Dir["storage"]
+      FileUtils.mkdir_p(File.expand_path("~/observiq-otel-collector/storage")) unless File.exists?(File.expand_path("~/observiq-otel-collector/storage"))
       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
     plist: |
       <?xml version="1.0" encoding="UTF-8"?>
@@ -239,3 +236,5 @@ brews:
       </plist>
     # For local testing
     # skip_upload: "true"
+
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,6 +100,14 @@ nfpms:
       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
       - src: release_deps/plugins/*
         dst: /opt/observiq-otel-collector/plugins
+      # Storage dir is used by stateful receivers, such as filelog receiver. It allows
+      # receivers to track their progress and buffer data.
+      - dst: /opt/observiq-otel-collector/storage
+        type: dir
+        file_info:
+          mode: 0755
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
     scripts:
       preinstall: "./scripts/package/preinstall.sh"
       postinstall: ./scripts/package/postinstall.sh

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ release:
 # Build and sign, skip release and ignore dirty git tree
 .PHONY: release-test
 release-test:
-	goreleaser release --parallelism 4 --skip-validate --skip-publish --skip-sign --rm-dist
+	goreleaser release --parallelism 4 --skip-validate --skip-publish --skip-sign --rm-dist --snapshot
 
 .PHONY: for-all
 for-all:

--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -42,6 +42,3 @@ cd "$START_DIR"
 
 cp -r "$DOWNLOAD_DIR/stanza-plugins/plugins" "$DOWNLOAD_DIR"
 rm -rf "$DOWNLOAD_DIR/stanza-plugins"
-
-mkdir "$DOWNLOAD_DIR/storage"
-touch "$DOWNLOAD_DIR/storage/.include"

--- a/buildscripts/download-dependencies.sh
+++ b/buildscripts/download-dependencies.sh
@@ -42,3 +42,6 @@ cd "$START_DIR"
 
 cp -r "$DOWNLOAD_DIR/stanza-plugins/plugins" "$DOWNLOAD_DIR"
 rm -rf "$DOWNLOAD_DIR/stanza-plugins"
+
+mkdir "$DOWNLOAD_DIR/storage"
+touch "$DOWNLOAD_DIR/storage/.include"

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -43,6 +43,7 @@ Type=simple
 User=observiq-otel-collector
 Group=observiq-otel-collector
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
 ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
 SuccessExitStatus=0

--- a/windows/scripts/build-msi.sh
+++ b/windows/scripts/build-msi.sh
@@ -17,6 +17,10 @@ set -e
 BASEDIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 PROJECT_BASE="$BASEDIR/../.."
 
+# Empty storage directory required by wix.json
+mkdir -p storage
+touch storage/.include
+
 cp "$PROJECT_BASE/dist/collector_windows_amd64.exe" "observiq-otel-collector.exe"
 
 vagrant winrm -c \

--- a/windows/test/install.rb
+++ b/windows/test/install.rb
@@ -1,7 +1,8 @@
 collector_home="C:/Program Files/observIQ OpenTelemetry Collector"
 
 [
-    "#{collector_home}/plugins"
+    "#{collector_home}/plugins",
+    "#{collector_home}/storage"
 ].each do |dir|
     describe file(dir) do
         it { should exist }

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -32,6 +32,9 @@
   "directories": [
     {
       "name": "plugins"
+    },
+    {
+      "name": "storage"
     }
   ],
   "registries": [

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -40,11 +40,11 @@
   "environments": [
     {
       "name": "OIQ_OTEL_COLLECTOR_STORAGE",
-      "value": "C:\\Program Files\\observIQ OpenTelemetry Collector",
-      "permanent": "yes",
+      "value": "[INSTALLDIR]storage",
+      "permanent": "no",
       "system": "yes",
       "action": "set",
-      "part": "last"
+      "part": "all"
     }
   ],
   "registries": [

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -37,6 +37,16 @@
       "name": "storage"
     }
   ],
+  "environments": [
+    {
+      "name": "OIQ_OTEL_COLLECTOR_STORAGE",
+      "value": "C:\\Program Files\\observIQ OpenTelemetry Collector",
+      "permanent": "yes",
+      "system": "yes",
+      "action": "set",
+      "part": "last"
+    }
+  ],
   "registries": [
     {
       "path": "HKCU\\Software\\observiq\\observIQ OpenTelemetry Collector",


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Stateful receivers will likely make use of the storage extension. For example, reading log files (saving state and buffering).

**Linux**

- Added directory `/opt/observiq-otel-collector/storage`
- Added environment `OIQ_OTEL_COLLECTOR_STORAGE` pointing to the directory, allowing configs to read `$OIQ_OTEL_COLLECTOR_STORAGE` instead of hard coding the value.

**Windows**

- Added storage directory to install directory. The `.include` file is required for WIX to copy the directory, afaik. 

Windows test output
```
  File C:/Program Files/observIQ OpenTelemetry Collector/plugins
     [PASS]  should exist
     [PASS]  should be directory
  File C:/Program Files/observIQ OpenTelemetry Collector/storage
     [PASS]  should exist
     [PASS]  should be directory
  File C:/Program Files/observIQ OpenTelemetry Collector/observiq-otel-collector.exe
     [PASS]  should exist
     [PASS]  should be file
  File C:/Program Files/observIQ OpenTelemetry Collector/config.yaml
     [PASS]  should exist
     [PASS]  should be file
  File C:/Program Files/observIQ OpenTelemetry Collector/plugins/aerospike.yaml
     [PASS]  should exist
     [PASS]  should be file
  File C:/Program Files/observIQ OpenTelemetry Collector/plugins/microsoft_iis.yaml
     [PASS]  should exist
     [PASS]  should be file
  File C:/Program Files/observIQ OpenTelemetry Collector/plugins/zookeeper.yaml
     [PASS]  should exist
     [PASS]  should be file
  Service observiq-otel-collector
     [PASS]  should be installed
     [PASS]  should be enabled
     [PASS]  should be running

Test Summary: 17 successful, 0 failures, 0 skipped
```

**Other**

Also updated make release-test to build with `--snapshot`, allowing the package to be installed over the previous tagged release. Useful when testing locally.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
