### PR TITLE
Disable arm64 container image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,8 @@ jobs:
           file: ./Dockerfile
           # Supporting only linux/amd64 to keep builds fast. arm can
           # be enabled anytime by updating the `platforms` key.
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          #platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Release CI is failing due to timeouts, disabling arm64 builds will resolve this issue. ARM64 will be re-enabled after a container image build process refactor.

##### Checklist
- [ ] Changes are tested
- [x] CI has passed
