### PR TITLE
Use generic node for Mysql and Redis Google examples

### DIFF
--- a/config/google_cloud_exporter/mysql/config.yaml
+++ b/config/google_cloud_exporter/mysql/config.yaml
@@ -21,7 +21,7 @@ processors:
       value: "mysql"
       action: upsert
     - key: location
-      value: "us-east1-b"
+      value: "global"
       action: upsert
 
   normalizesums:

--- a/config/google_cloud_exporter/mysql/config.yaml
+++ b/config/google_cloud_exporter/mysql/config.yaml
@@ -14,10 +14,15 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
+  # Used for Google generic_node mapping.
+  resource:
+    attributes:
+    - key: namespace
+      value: "mysql"
+      action: upsert
+    - key: location
+      value: "us-east1-b"
+      action: upsert
 
   normalizesums:
 
@@ -29,6 +34,16 @@ exporters:
       enabled: false
     metric:
       prefix: custom.googleapis.com
+    resource_mappings:
+    - source_type: ""
+      target_type: generic_node
+      label_mappings:
+      - source_key: host.name
+        target_key: node_id
+      - source_key: location
+        target_key: location
+      - source_key: namespace
+        target_key: namespace
 
 service:
   pipelines:
@@ -37,7 +52,7 @@ service:
       - mysql
       processors:
       - resourcedetection
-      - resourceattributetransposer
+      - resource
       - normalizesums
       - batch
       exporters:

--- a/config/google_cloud_exporter/redis/config.yaml
+++ b/config/google_cloud_exporter/redis/config.yaml
@@ -12,10 +12,15 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
+  # Used for Google generic_node mapping.
+  resource:
+    attributes:
+    - key: namespace
+      value: "redis"
+      action: upsert
+    - key: location
+      value: "us-east1-b"
+      action: upsert
 
   normalizesums:
 
@@ -27,6 +32,16 @@ exporters:
       enabled: false
     metric:
       prefix: custom.googleapis.com
+    resource_mappings:
+    - source_type: ""
+      target_type: generic_node
+      label_mappings:
+      - source_key: host.name
+        target_key: node_id
+      - source_key: location
+        target_key: location
+      - source_key: namespace
+        target_key: namespace
 
 service:
   pipelines:
@@ -35,7 +50,7 @@ service:
       - redis
       processors:
       - resourcedetection
-      - resourceattributetransposer
+      - resource
       - normalizesums
       - batch
       exporters:

--- a/config/google_cloud_exporter/redis/config.yaml
+++ b/config/google_cloud_exporter/redis/config.yaml
@@ -19,7 +19,7 @@ processors:
       value: "redis"
       action: upsert
     - key: location
-      value: "us-east1-b"
+      value: "global"
       action: upsert
 
   normalizesums:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

We will be using generic_node for all Google examples in the near future. Mysql and Redis will be part of a blog being written right now, so I have updated them earlier than expected.

To use [Google's generic_node](https://cloud.google.com/monitoring/api/resources#tag_generic_node), we need to use hostname as the node_id and set namespace / location. The `resourceattributetransposer` is no longer required as host.name is being preserved as `node_id`.

<img width="1402" alt="Screen Shot 2022-04-14 at 4 01 04 PM" src="https://user-images.githubusercontent.com/23043836/163466717-b1ae3f81-9f92-4c72-b2b9-3ca3c63322a0.png">

<img width="1387" alt="Screen Shot 2022-04-14 at 4 01 38 PM" src="https://user-images.githubusercontent.com/23043836/163466801-9f4cbc6c-8d68-4f41-9318-3b52528c81e7.png">

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed


