### PR TITLE
Use generic node for Tomcat Google Cloud example

### DIFF
--- a/config/google_cloud_exporter/tomcat/config.yaml
+++ b/config/google_cloud_exporter/tomcat/config.yaml
@@ -18,8 +18,6 @@ processors:
     operations:
       - from: "host.name"
         to: "agent"
-      - from: "source"
-        to: "source"
 
   # Used for Google generic_node mapping.
   resource:

--- a/config/google_cloud_exporter/tomcat/config.yaml
+++ b/config/google_cloud_exporter/tomcat/config.yaml
@@ -5,7 +5,8 @@ receivers:
     target_system: tomcat,jvm
     collection_interval: 60s
     properties:
-      otel.resource.attributes: jmx_source=tomcat,jmx_endpoint=localhost:9000
+      # Attribute 'endpoint' will be used for generic_node's node_id field.
+      otel.resource.attributes: endpoint=localhost:9000
 
 processors:
   resourcedetection:
@@ -17,10 +18,18 @@ processors:
     operations:
       - from: "host.name"
         to: "agent"
-      - from: "jmx_source"
-        to: "jmx_source"
-      - from: "jmx_endpoint"
-        to: "jmx_endpoint"
+      - from: "source"
+        to: "source"
+
+  # Used for Google generic_node mapping.
+  resource:
+    attributes:
+    - key: namespace
+      value: "tomcat"
+      action: upsert
+    - key: location
+      value: "global"
+      action: upsert
 
   normalizesums:
 
@@ -32,6 +41,16 @@ exporters:
       enabled: false
     metric:
       prefix: custom.googleapis.com
+    resource_mappings:
+    - source_type: ""
+      target_type: generic_node
+      label_mappings:
+      - source_key: endpoint
+        target_key: node_id
+      - source_key: location
+        target_key: location
+      - source_key: namespace
+        target_key: namespace
 
 service:
   pipelines:
@@ -41,6 +60,7 @@ service:
       processors:
       - resourcedetection
       - resourceattributetransposer
+      - resource
       - normalizesums
       - batch
       exporters:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This PR updates the tomcat configuration to use Google's `generic_node` monitored resource type. I am leveraging the `properties.otel.resource.attributes` parameter to define a unique field that can be used for `node_id`. This allows a single collector to scrape multiple Tomcat systems. The agent's hostname is preserved on the metric labels as `agent`.

![Screenshot from 2022-04-21 10-24-59](https://user-images.githubusercontent.com/23043836/164479702-5a75775a-bd17-4197-a32f-2205b6a776dc.png)

You will notice that I did not remove the `batch`, `normalizesums` or anything else that [this pr](https://github.com/observIQ/observiq-otel-collector/pull/355) abstracts. I would like to be consistent, and update the configs together when we cut over to the "new way" of doing things with Google.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
