### PR TITLE
fix: Wrapped google exporter metric prefix

### DIFF
--- a/config/google_cloud_exporter/hostmetrics/config.yaml
+++ b/config/google_cloud_exporter/hostmetrics/config.yaml
@@ -17,47 +17,27 @@ receivers:
       #process:
       #  mute_process_name_error: true
 
-
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resourceattributetransposer:
-    operations:
-      # Process metrics require unique metric labels, otherwise the Google
-      # API will reject some metrics as "out of order" / duplicates.
-      - from: "host.name"
-        to: "agent"
-      - from: "process.pid"
-        to: "pid"
-      - from: "process.executable.name"
-        to: "binary"
-
-  normalizesums:
-
-  batch:
-
 exporters: 
+  # observIQ collector wraps the upstream Google Cloud exporter
+  # with the following processors:
+  #   - resource detection processor
+  #   - resource attributes transposer processor
+  #   - normalizesums processor
+  #   - batch processor
+  #
+  # In additon to wrapping processors, the following settings are configured:
+  #   - retry_on_failure.enabled: false
+  #   - metric.prefix: workload.googleapis.com
+  #   - resource mapping: default to generic_node monitored resource type.
+  #     - node_id: host.name
+  #     - namespace: host.name
+  #     - location: global
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    metric:
-      prefix: custom.googleapis.com
 
 service:
   pipelines:
     metrics:
       receivers:
       - hostmetrics
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -15,8 +15,6 @@
 package googlecloudexporter
 
 import (
-	"os"
-
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/processor/normalizesumsprocessor"
 	"github.com/mitchellh/mapstructure"
 	"github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor"
@@ -29,7 +27,7 @@ import (
 )
 
 const (
-	defaultMetricPrefix = "workloads.googleapis.com"
+	defaultMetricPrefix = "workload.googleapis.com"
 	defaultUserAgent    = "observIQ-otel-collector"
 	defaultLocation     = "global"
 	genericNodeResource = "generic_node"
@@ -62,11 +60,9 @@ func (c *Config) Validate() error {
 
 // createDefaultConfig creates the default config for the exporter
 func createDefaultConfig() config.Exporter {
-	defaultNamespace, _ := os.Hostname()
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 		Location:         defaultLocation,
-		Namespace:        defaultNamespace,
 		GCPConfig:        createDefaultGCPConfig(),
 		BatchConfig:      createDefaultBatchConfig(),
 		NormalizeConfig:  createDefaultNormalizerConfig(),
@@ -96,7 +92,7 @@ func createDefaultGCPConfig() *gcp.Config {
 					TargetKey: "location",
 				},
 				{
-					SourceKey: "namespace",
+					SourceKey: "host.name",
 					TargetKey: "namespace",
 				},
 			},

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -15,6 +15,8 @@
 package googlecloudexporter
 
 import (
+	"os"
+
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/processor/normalizesumsprocessor"
 	"github.com/mitchellh/mapstructure"
 	"github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor"
@@ -60,9 +62,11 @@ func (c *Config) Validate() error {
 
 // createDefaultConfig creates the default config for the exporter
 func createDefaultConfig() config.Exporter {
+	defaultNamespace, _ := os.Hostname()
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
 		Location:         defaultLocation,
+		Namespace:        defaultNamespace,
 		GCPConfig:        createDefaultGCPConfig(),
 		BatchConfig:      createDefaultBatchConfig(),
 		NormalizeConfig:  createDefaultNormalizerConfig(),
@@ -92,7 +96,7 @@ func createDefaultGCPConfig() *gcp.Config {
 					TargetKey: "location",
 				},
 				{
-					SourceKey: "host.name",
+					SourceKey: "namespace",
 					TargetKey: "namespace",
 				},
 			},


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

- `workloads.googleapis.com` needs to be `workload.googleapis.com`. 
- Update hostmetrics config to leverage wrapped Google exporter

![Screenshot from 2022-04-21 14-27-19](https://user-images.githubusercontent.com/23043836/164528467-e4fccbb7-ce60-4a56-b400-bcd60000c4cf.png)

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
