### PR TITLE
Use workload prefix for Rabbitmq and Elasticsearch Google examples

### DIFF
--- a/config/google_cloud_exporter/elasticsearch/config.yaml
+++ b/config/google_cloud_exporter/elasticsearch/config.yaml
@@ -13,14 +13,18 @@ processors:
     system:
       hostname_sources: ["os"]
 
+  resource:
+    attributes:
+    - key: location
+      value: global
+      action: upsert
+
   resourceattributetransposer:
     operations:
       - from: host.name
         to: agent
       - from: elasticsearch.cluster.name
         to: cluster_name
-      - from: elasticsearch.node.name
-        to: node_name
 
   normalizesums:
 
@@ -31,7 +35,17 @@ exporters:
     retry_on_failure:
       enabled: false
     metric:
-      prefix: custom.googleapis.com
+      prefix: workload.googleapis.com
+    resource_mappings:
+      - source_type: ""
+        target_type: generic_node
+        label_mappings:
+          - source_key: elasticsearch.node.name
+            target_key: node_id
+          - source_key: elasticsearch.node.name
+            target_key: namespace
+          - source_key: location
+            target_key: location
 
 service:
   pipelines:
@@ -40,6 +54,7 @@ service:
       - elasticsearch
       processors:
       - resourcedetection
+      - resource
       - resourceattributetransposer
       - normalizesums
       - batch

--- a/config/google_cloud_exporter/rabbitmq/config.yaml
+++ b/config/google_cloud_exporter/rabbitmq/config.yaml
@@ -15,6 +15,12 @@ processors:
     system:
       hostname_sources: ["os"]
 
+  resource:
+    attributes:
+    - key: location
+      value: global
+      action: upsert
+
   resourceattributetransposer:
     operations:
       # Rabbitmq metrics require unique metric labels, otherwise the Google
@@ -24,8 +30,6 @@ processors:
         to: agent
       - from: rabbitmq.queue.name
         to: queue
-      - from: rabbitmq.node.name
-        to: node
       - from: rabbitmq.vhost.name
         to: vhost
 
@@ -38,7 +42,17 @@ exporters:
     retry_on_failure:
       enabled: false
     metric:
-      prefix: custom.googleapis.com
+      prefix: workload.googleapis.com
+    resource_mappings:
+      - source_type: ""
+        target_type: generic_node
+        label_mappings:
+          - source_key: rabbitmq.node.name
+            target_key: node_id
+          - source_key: rabbitmq.node.name
+            target_key: namespace
+          - source_key: location
+            target_key: location
 
 service:
   pipelines:
@@ -47,6 +61,7 @@ service:
       - rabbitmq
       processors:
       - resourcedetection
+      - resource
       - resourceattributetransposer
       - normalizesums
       - batch


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

- Updated Rabbitmq to use Workload prefix and generic_node (a requirement of workload)
- Updated Elasticsearch to use Workload prefix and generic_node

![Screen Shot 2022-04-25 at 12 39 37 PM](https://user-images.githubusercontent.com/23043836/165134587-2934bfcd-49c1-455a-9f3a-0d7859f95642.png)

![Screen Shot 2022-04-25 at 12 39 19 PM](https://user-images.githubusercontent.com/23043836/165134591-29d891c3-d18f-455a-a655-ce9f54c6d9bc.png)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
