### PR TITLE
feat(plugin): Added Mongodb log plugin

### DIFF
--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -55,6 +55,8 @@ template: |
                 - D5
           output: add_log_type
 
+        # Example log line:
+        # {"t":{"$date":"2022-04-26T16:15:44.876+00:00"},"s":"I",  "c":"INDEX",    "id":20345,   "ctx":"LogicalSessionCacheRefresh","msg":"Index build: done building","attr":{"buildUUID":null,"namespace":"config.system.sessions","index":"lsidTTLIndex","commitTimestamp":null}}
         - id: 4_4_parser
           type: json_parser
           parse_from: body

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -1,0 +1,128 @@
+version: 0.0.1
+title: MongoDB
+description: Log parser for MongoDB
+parameters:
+  - name: log_paths
+    type: "[]string"
+    default: ["/var/log/mongodb/mongodb.log*"]
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ range $fp := .daemon_log_paths }}
+        - '{{ $fp }}'
+        {{end}}
+      exclude:
+        {{ range $fp := .daemon_log_paths }}
+        - '{{ $fp }}*.gz'
+        {{end}}
+      start_at: {{ .start_at }}
+      operators:
+        - type: router
+          default: legacy_parser
+          routes:
+            - expr: 'body matches "^{.*}$|^{.*}\\n$"'
+              output: 4_4_parser
+
+        - id: legacy_parser
+          type: regex_parser
+          regex: '^(?P<timestamp>\S+)\s+(?P<severity>\w+)\s+(?P<component>[\w-]+)\s+\[(?P<context>\S+)\]\s+(?P<message>.*)$'
+          timestamp:
+            parse_from: attributes:timestamp
+            #2019-02-06T09:22:43.967-0500
+            layout: '%Y-%m-%dT%H:%M:%S.%f%z'
+          severity:
+            parse_from: attributes.severity
+            mapping:
+              fatal: F
+              error: E
+              warn: W
+              info: I
+              debug:
+                - D
+                - D1
+                - D2
+                - D3
+                - D4
+                - D5
+          output: add_plugin_id
+
+        - id: 4_4_parser
+          type: json_parser
+          parse_from: body
+          timestamp:
+            parse_from: attributes.t.date
+            #2020-11-03T14:24:07.436-05:00
+            layout: '%Y-%m-%dT%H:%M:%S.%f%j'
+          severity:
+            parse_from: attributes.s
+            mapping:
+              fatal: F
+              error: E
+              warn: W
+              info: I
+              debug:
+                - D
+                - D1
+                - D2
+                - D3
+                - D4
+                - D5
+          output: remove_t
+
+        - id: remove_t
+          type: remove
+          field: attributes.t
+
+        - id: move_component
+          type: move
+          from: attributes.c
+          to: attributes.component
+
+        - id: move_context
+          type: move
+          from: attributes.ctx
+          to: attributes.context
+
+        - id: move_message
+          type: move
+          from: attributes.msg
+          to: attributes.message
+
+        # When message is 'WiredTiger message', data.attr.message
+        # always exists, and should be promoted to message
+        - id: wiredtiger_router
+          type: router
+          default: add_log_type
+          routes:
+            - expr: 'attributes.message == "WiredTiger message"'
+              output: move_wiredtiger_type
+
+        - id: move_wiredtiger_type
+          type: move
+          from: attributes.message
+          to: attributes.message_type
+          output: move_wiredtiger_msg
+
+        - id: move_wiredtiger_msg
+          type: move
+          from: attributes.attr.message
+          to: attributes.message
+          output: add_log_type
+          
+        - id: add_log_type
+          type: add
+          field: 'attributes.log_type'
+          value: 'mongodb'
+
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - filelog

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -4,7 +4,9 @@ description: Log parser for MongoDB
 parameters:
   - name: log_paths
     type: "[]string"
-    default: ["/var/log/mongodb/mongodb.log*"]
+    default:
+      - "/var/log/mongodb/mongodb.log*"
+      - "/var/log/mongodb/mongod.log*"
   - name: start_at
     type: string
     supported:

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -17,11 +17,11 @@ template: |
   receivers:
     filelog:
       include:
-        {{ range $fp := .daemon_log_paths }}
+        {{ range $fp := .log_paths }}
         - '{{ $fp }}'
         {{end}}
       exclude:
-        {{ range $fp := .daemon_log_paths }}
+        {{ range $fp := .log_paths }}
         - '{{ $fp }}*.gz'
         {{end}}
       start_at: {{ .start_at }}
@@ -36,7 +36,7 @@ template: |
           type: regex_parser
           regex: '^(?P<timestamp>\S+)\s+(?P<severity>\w+)\s+(?P<component>[\w-]+)\s+\[(?P<context>\S+)\]\s+(?P<message>.*)$'
           timestamp:
-            parse_from: attributes:timestamp
+            parse_from: attributes.timestamp
             #2019-02-06T09:22:43.967-0500
             layout: '%Y-%m-%dT%H:%M:%S.%f%z'
           severity:
@@ -53,13 +53,13 @@ template: |
                 - D3
                 - D4
                 - D5
-          output: add_plugin_id
+          output: add_log_type
 
         - id: 4_4_parser
           type: json_parser
           parse_from: body
           timestamp:
-            parse_from: attributes.t.date
+            parse_from: attributes.t.$date
             #2020-11-03T14:24:07.436-05:00
             layout: '%Y-%m-%dT%H:%M:%S.%f%j'
           severity:
@@ -76,11 +76,15 @@ template: |
                 - D3
                 - D4
                 - D5
-          output: remove_t
+          output: move_component
+        # Commented out remove operatore out and output until remove operator is added in.
+        # Tracking in PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9545
+          #output: remove_t
 
-        - id: remove_t
-          type: remove
-          field: attributes.t
+
+        # - id: remove_t
+        #   type: remove
+        #   field: attributes.t
 
         - id: move_component
           type: move


### PR DESCRIPTION
### Proposed Change
Added the Mongodb log plugin MVP as a port from `stanza-plugins`. 

**Note1:** The stanza-plugin included the ability to read from k8s. There is no way I could find in otel to get logs from k8s and add the operator parsing. The [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver) does not support operators. This would be doable if the logs transforms processor is approved open-telemetry/opentelemetry-collector-contrib#9133.

**Note2:** The remove operator is currently not present in the filelog receiver. There is a PR to add it so I commented out that operator until the PR is approved. Tracked in open-telemetry/opentelemetry-collector-contrib#9524

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
