### PR TITLE
feat(nginx): Add nginx logging plugin

### DIFF
--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -121,9 +121,9 @@ template: |
       pipelines:
         logs:
           receivers:
-          {{ if .enable_access_log }}
-          - filelog/access_log
-          {{ end }}
-          {{ if .enable_error_log }}
-          - filelog/error_log
-          {{ end }}
+            {{ if .enable_access_log }}
+            - filelog/access_log
+            {{ end }}
+            {{ if .enable_error_log }}
+            - filelog/error_log
+            {{ end }}

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -1,0 +1,129 @@
+version: 0.0.1
+title: NGINX
+description: Log parser for NGINX
+parameters:
+  # The observiq log format is defined as:
+  # log_format observiq '{"remote_addr":"$remote_addr","remote_user":"$remote_user","time_local":"$time_local","request":"$request","status":"$status","body_bytes_sent":"$body_bytes_sent","http_referer":"$http_referer","http_user_agent":"$http_user_agent","request_length":"$request_length","request_time":"$request_time","upstream_addr":"$upstream_addr","upstream_response_length":"$upstream_response_length","upstream_response_time":"$upstream_response_time","upstream_status":"$upstream_status","proxy_add_x_forwarded_for":"$proxy_add_x_forwarded_for","bytes_sent":"$bytes_sent","time_iso8601":"$time_iso8601","upstream_connect_time":"$upstream_connect_time","upstream_header_time":"$upstream_header_time","http_x_forwarded_for":"$http_x_forwarded_for"}';
+  # See https://docs.nginx.com/nginx/admin-guide/monitoring/logging/#setting-up-the-access-log for more information on configuring log format
+  - name: log_format
+    type: string
+    supported:
+      - default
+      - observiq
+    default: default
+  - name: enable_access_log
+    type: bool
+    default: true
+  - name: access_log_paths
+    type: "[]string"
+    default: 
+      - "/var/log/nginx/access.log*"
+  - name: enable_error_log
+    type: bool
+    default: true
+  - name: error_log_paths
+    type: string
+    default: 
+      - "/var/log/nginx/error.log*"
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+  - name: encoding
+    type: enum
+    supported:
+      - nop
+      - utf-8
+      - utf-16le
+      - utf-16be
+      - ascii
+      - big5
+    default: utf-8
+template: |
+    receivers:
+      {{ if .enable_access_log }}
+      filelog/access_log:
+        include:
+          {{ range $fp := .access_log_paths }}
+          - '{{ $fp }}'
+          {{end}}
+        attributes:
+          log_type: 'nginx.access'
+        start_at: {{ .start_at }}
+        encoding: {{ .encoding }}
+        operators:
+          {{ if eq .log_format "default" }}
+          - type: regex_parser
+            regex: '^(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?$'
+            timestamp:
+              parse_from: "$body.time_local"
+              layout: '%d/%b/%Y:%H:%M:%S %z'
+            severity:
+              parse_from: "$body.http_request_status"
+              mapping:
+                info: 2xx
+                info2: 3xx
+                warn: 4xx
+                error: 5xx
+          {{end}} # End default log format parsing
+          
+          {{ if eq .log_format "observiq" }}
+          - id: access_parser
+            type: json_parser
+            timestamp:
+              parse_from: "$body.time_local"
+              layout: '%d/%b/%Y:%H:%M:%S %z'
+            severity:
+              parse_from: "$body.status"
+              preserve_to: "$body.http_request_status"
+              mapping:
+                info: 2xx
+                info2: 3xx
+                warn: 4xx
+                error: 5xx
+          - id: request_parser
+            type: regex_parser
+            parse_from: "$body.request"
+            preserve_to: "$body.request"
+            if: '$body.request != nil and $body.request matches "\\S+ +[^ ]* "'
+            regex: '(?P<method>\S+) +(?P<path>[^ ]*) ((?P<protocol>[^/]*)/(?P<protocol_version>.*)|.*)?'
+          {{end}} # end observiq format parsing
+      {{end}} # end access log receiver
+
+      {{- if .enable_error_log -}}
+      filelog/error_log:
+        include:
+          {{ range $fp := .error_log_paths }}
+          - '{{ $fp }}'
+          {{end}}
+        attributes:
+          log_type: 'nginx.error'
+        start_at: {{ .start_at }}
+        encoding: {{ .encoding }}
+        operators:
+          - type: regex_parser
+            regex: '^(?P<time>\d+[./-]\d+[./-]\d+[- ]\d+:\d+:\d+) \[(?P<log_level>[^\]]*)\] (?P<pid>\d+)#(?P<tid>\d+):(?: \*(?P<connection>\d+))? (?P<message>.*?)(?:, client: (?P<client>[^,]+))?(?:, server: (?P<server>[^,]+))?(?:, request: "(?P<request>[^"]*)")?(?:, subrequest: \"(?P<subrequest>[^\"]*)\")?(?:, upstream: \"(?P<upstream>[^"]*)\")?(?:, host: \"(?P<host>[^\"]*)\")?(?:, referrer: \"(?P<referer>[^"]*)\")?$'
+            timestamp:
+              parse_from: "$body.time"
+              layout: '%Y/%m/%d %T'
+            severity:
+              parse_from: "$body.log_level"
+              mapping:
+                info: 2xx
+                info2: 3xx
+                warn: 4xx
+                error: 5xx
+      {{end}} # end error log receiver
+
+    service:
+      pipelines:
+        logs:
+          receivers:
+          {{ if .enable_access_log }}
+          - filelog/access_log
+          {{ end }}
+          {{ if .enable_error_log }}
+          - filelog/error_log
+          {{ end }}

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -77,12 +77,15 @@ template: |
               layout: '%d/%b/%Y:%H:%M:%S %z'
             severity:
               parse_from: "attributes.status"
-              preserve_to: "attributes.http_request_status"
               mapping:
                 info: 2xx
                 info2: 3xx
                 warn: 4xx
                 error: 5xx
+          - id: move_status
+            type: move
+            from: attributes.status
+            to: attributes.http_request_status
           - id: request_parser
             type: regex_parser
             parse_from: "attributes.request"

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -96,7 +96,7 @@ template: |
           {{end}} # end observiq format parsing
       {{end}} # end access log receiver
 
-      {{- if .enable_error_log -}}
+      {{ if .enable_error_log }}
       filelog/error_log:
         include:
           {{ range $fp := .error_log_paths }}

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -32,7 +32,7 @@ parameters:
       - end
     default: end
   - name: encoding
-    type: enum
+    type: string
     supported:
       - nop
       - utf-8

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -58,10 +58,10 @@ template: |
           - type: regex_parser
             regex: '^(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?$'
             timestamp:
-              parse_from: "$body.time_local"
+              parse_from: "attributes.time_local"
               layout: '%d/%b/%Y:%H:%M:%S %z'
             severity:
-              parse_from: "$body.http_request_status"
+              parse_from: "attributes.http_request_status"
               mapping:
                 info: 2xx
                 info2: 3xx
@@ -73,11 +73,11 @@ template: |
           - id: access_parser
             type: json_parser
             timestamp:
-              parse_from: "$body.time_local"
+              parse_from: "attributes.time_local"
               layout: '%d/%b/%Y:%H:%M:%S %z'
             severity:
-              parse_from: "$body.status"
-              preserve_to: "$body.http_request_status"
+              parse_from: "attributes.status"
+              preserve_to: "attributes.http_request_status"
               mapping:
                 info: 2xx
                 info2: 3xx
@@ -85,9 +85,8 @@ template: |
                 error: 5xx
           - id: request_parser
             type: regex_parser
-            parse_from: "$body.request"
-            preserve_to: "$body.request"
-            if: '$body.request != nil and $body.request matches "\\S+ +[^ ]* "'
+            parse_from: "attributes.request"
+            if: 'attributes.request != nil and attributes.request matches "\\S+ +[^ ]* "'
             regex: '(?P<method>\S+) +(?P<path>[^ ]*) ((?P<protocol>[^/]*)/(?P<protocol_version>.*)|.*)?'
           {{end}} # end observiq format parsing
       {{end}} # end access log receiver
@@ -106,10 +105,10 @@ template: |
           - type: regex_parser
             regex: '^(?P<time>\d+[./-]\d+[./-]\d+[- ]\d+:\d+:\d+) \[(?P<log_level>[^\]]*)\] (?P<pid>\d+)#(?P<tid>\d+):(?: \*(?P<connection>\d+))? (?P<message>.*?)(?:, client: (?P<client>[^,]+))?(?:, server: (?P<server>[^,]+))?(?:, request: "(?P<request>[^"]*)")?(?:, subrequest: \"(?P<subrequest>[^\"]*)\")?(?:, upstream: \"(?P<upstream>[^"]*)\")?(?:, host: \"(?P<host>[^\"]*)\")?(?:, referrer: \"(?P<referer>[^"]*)\")?$'
             timestamp:
-              parse_from: "$body.time"
+              parse_from: "attributes.time"
               layout: '%Y/%m/%d %T'
             severity:
-              parse_from: "$body.log_level"
+              parse_from: "attributes.log_level"
               mapping:
                 info: 2xx
                 info2: 3xx

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -62,6 +62,7 @@ template: |
               layout: '%d/%b/%Y:%H:%M:%S %z'
             severity:
               parse_from: "attributes.http_request_status"
+              preserve_to: "attributes.http_request_status"
               mapping:
                 info: 2xx
                 info2: 3xx
@@ -77,6 +78,7 @@ template: |
               layout: '%d/%b/%Y:%H:%M:%S %z'
             severity:
               parse_from: "attributes.status"
+              preserve_to: "attributes.status"
               mapping:
                 info: 2xx
                 info2: 3xx
@@ -113,10 +115,8 @@ template: |
             severity:
               parse_from: "attributes.log_level"
               mapping:
-                info: 2xx
-                info2: 3xx
-                warn: 4xx
-                error: 5xx
+                error2: crit
+                error3: emerg
       {{end}} # end error log receiver
 
     service:


### PR DESCRIPTION
### Proposed Change
* Add a logging plugin for NGINX access + error logs. (ported from stanza-plugins)

Tested against a running NGINX instance to make sure access + error logs were parsing correctly.

As noted for Mongodb, k8s support has been removed.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
