### PR TITLE
Changed codeowners to collector-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @observIQ/ot-pipeline-team
+* @observIQ/collector-team


### PR DESCRIPTION
### Proposed Change
Changed codeowners to sub team [collector-team](https://github.com/orgs/observIQ/teams/collector-team)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
