### PR TITLE
fix: Plugin validation fails on valid []string parameter

### DIFF
--- a/receiver/pluginreceiver/plugin.go
+++ b/receiver/pluginreceiver/plugin.go
@@ -156,7 +156,7 @@ func (p *Plugin) checkType(values map[string]interface{}) error {
 
 			for _, v := range raw {
 				if _, ok := v.(string); !ok {
-					return fmt.Errorf("parameter %s must be a []string", parameter.Name)
+					return fmt.Errorf("parameter %s: expected string, but got %v", parameter.Name, v)
 				}
 			}
 		case intType:

--- a/receiver/pluginreceiver/plugin.go
+++ b/receiver/pluginreceiver/plugin.go
@@ -149,8 +149,15 @@ func (p *Plugin) checkType(values map[string]interface{}) error {
 				return fmt.Errorf("parameter %s must be a string", parameter.Name)
 			}
 		case stringArrayType:
-			if _, ok := value.([]string); !ok {
+			raw, ok := value.([]interface{})
+			if !ok {
 				return fmt.Errorf("parameter %s must be a []string", parameter.Name)
+			}
+
+			for _, v := range raw {
+				if _, ok := v.(string); !ok {
+					return fmt.Errorf("parameter %s must be a []string", parameter.Name)
+				}
 			}
 		case intType:
 			if _, ok := value.(int); !ok {

--- a/receiver/pluginreceiver/plugin_test.go
+++ b/receiver/pluginreceiver/plugin_test.go
@@ -303,7 +303,7 @@ func TestCheckParameters(t *testing.T) {
 			expectedErr: errors.New("must be a string"),
 		},
 		{
-			name: "invalid []string type",
+			name: "invalid []string type (int)",
 			plugin: &Plugin{
 				Parameters: []Parameter{
 					{
@@ -316,6 +316,23 @@ func TestCheckParameters(t *testing.T) {
 				"param1": 5,
 			},
 			expectedErr: errors.New("must be a []string"),
+		},
+		{
+			name: "invalid []string type (slice with int)",
+			plugin: &Plugin{
+				Parameters: []Parameter{
+					{
+						Name: "param1",
+						Type: stringArrayType,
+					},
+				},
+			},
+			values: map[string]interface{}{
+				"param1": []interface{}{
+					5,
+				},
+			},
+			expectedErr: errors.New("parameter param1: expected string, but got"),
 		},
 		{
 			name: "invalid int type",
@@ -409,7 +426,7 @@ func TestCheckParameters(t *testing.T) {
 			},
 			values: map[string]interface{}{
 				"param1": "value1",
-				"param2": []string{"value2"},
+				"param2": []interface{}{"value2"},
 				"param3": 5,
 				"param4": true,
 			},


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

While using the redis plugin, default values were working fine but when setting `file_path` @algchoo gets the following error.
```
2022/05/02 13:30:51 collector server run finished with error: cannot build receivers: cannot create receiver plugin: invalid plugin parameter: type failure: parameter file_path must be a []string
```

Config example
```
  plugin:
    path: ./plugins/redis_logs.yaml
    parameters:
      file_path: ["/var/log/redis/redis-server.log"]
```

After talking with @jmwilliams89 we assumed that the validation code was incorrectly considering []interface{} to be invalid. 

When using this change, the collector starts fine and reads the file we specified.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
