### PR TITLE
fix(pluginreceiver): Turn metrics telemetry off for plugin sub-service

### DIFF
--- a/receiver/pluginreceiver/provider.go
+++ b/receiver/pluginreceiver/provider.go
@@ -219,6 +219,11 @@ func (c *ComponentMap) ToConfigMap() *config.Map {
 		"service": map[string]interface{}{
 			"extensions": c.Service.Extensions,
 			"pipelines":  pipelines,
+			"telemetry": map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"level": "none",
+				},
+			},
 		},
 	}
 

--- a/receiver/pluginreceiver/provider_test.go
+++ b/receiver/pluginreceiver/provider_test.go
@@ -234,6 +234,11 @@ func TestComponentsToConfigMap(t *testing.T) {
 					"exporters":  []string{"exporter"},
 				},
 			},
+			"telemetry": map[string]interface{}{
+				"metrics": map[string]interface{}{
+					"level": "none",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
### Proposed Change
* Set metrics level to none for plugin sub-service

Without this, plugins will set up the internal metrics server without respecting the config that was passed to the collector. This means that it would always attempt to start up the metrics server on port 8888, which can cause conflicts (the collector will not start if something is already bound to 8888).

This PR disables the plugin receiver from spinning up its own internal metrics server, so that only the top-level collector will spin up the internal metrics server.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
