### PR TITLE
fix(deprecation): Removed unsupported preserve_to in plugins

### DIFF
--- a/plugins/elasticsearch_logs.yaml
+++ b/plugins/elasticsearch_logs.yaml
@@ -50,7 +50,6 @@ template: |
             layout: 2006-01-02T15:04:05,999Z07:00
           severity:
             parse_from: attributes.level
-            preserve_to: attributes.level
             preset: none
             mapping:
               trace:

--- a/plugins/nginx_logs.yaml
+++ b/plugins/nginx_logs.yaml
@@ -16,14 +16,14 @@ parameters:
     default: true
   - name: access_log_paths
     type: "[]string"
-    default: 
+    default:
       - "/var/log/nginx/access.log*"
   - name: enable_error_log
     type: bool
     default: true
   - name: error_log_paths
     type: "[]string"
-    default: 
+    default:
       - "/var/log/nginx/error.log*"
   - name: start_at
     type: string
@@ -48,101 +48,99 @@ parameters:
       - low
     default: high
 template: |
-    receivers:
-      {{ if .enable_access_log }}
-      filelog/access_log:
-        include:
-          {{ range $fp := .access_log_paths }}
-          - '{{ $fp }}'
-          {{end}}
-        attributes:
-          log_type: 'nginx.access'
-        start_at: {{ .start_at }}
-        encoding: {{ .encoding }}
-        operators:
-          {{ if eq .log_format "default" }}
-          - type: regex_parser
-            regex: '^(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?$'
-            timestamp:
-              parse_from: "attributes.time_local"
-              layout: '%d/%b/%Y:%H:%M:%S %z'
-            severity:
-              parse_from: "attributes.http_request_status"
-              preserve_to: "attributes.http_request_status"
-              mapping:
-                info: 2xx
-                info2: 3xx
-                warn: 4xx
-                error: 5xx
-          {{end}} # End default log format parsing
-          
-          {{ if eq .log_format "observiq" }}
-          - id: access_parser
-            type: json_parser
-            timestamp:
-              parse_from: "attributes.time_local"
-              layout: '%d/%b/%Y:%H:%M:%S %z'
-            severity:
-              parse_from: "attributes.status"
-              preserve_to: "attributes.status"
-              mapping:
-                info: 2xx
-                info2: 3xx
-                warn: 4xx
-                error: 5xx
-          - id: move_status
-            type: move
-            from: attributes.status
-            to: attributes.http_request_status
-          - id: request_parser
-            type: regex_parser
-            parse_from: "attributes.request"
-            if: 'attributes.request != nil and attributes.request matches "\\S+ +[^ ]* "'
-            regex: '(?P<http_request_requestMethod>\S+) +(?P<http_request_requestUrl>[^ ]*) ((?P<http_request_protocol>[^/]*)/(?P<http_request_protocol_version>.*)|.*)?'
-          {{end}} # end observiq format parsing
-          {{ if eq .data_flow "low" }}
-          - id: filter
-            type: filter
-            expr: 'attributes.http_request_status == nil or not (attributes.http_request_status matches "[45][0-9]{2}")'
-          - id: retain
-            type: retain
-            fields:
-              - attributes.http_request_status
-              - attributes.http_request_requestUrl
-              - attributes.request_time
+  receivers:
+    {{ if .enable_access_log }}
+    filelog/access_log:
+      include:
+        {{ range $fp := .access_log_paths }}
+        - '{{ $fp }}'
+        {{end}}
+      attributes:
+        log_type: 'nginx.access'
+      start_at: {{ .start_at }}
+      encoding: {{ .encoding }}
+      operators:
+        {{ if eq .log_format "default" }}
+        - type: regex_parser
+          regex: '^(?P<http_request_remoteIp>[^ ]*) (?P<host>[^ ]*) (?P<user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<http_request_requestMethod>\S+)(?: +(?P<http_request_requestUrl>[^\"]*?)(?: +(?P<http_request_protocol>\S+))?)?" (?P<http_request_status>[^ ]*) (?P<http_request_responseSize>[^ ]*)(?: "(?P<http_request_referer>[^\"]*)" "(?P<http_request_userAgent>[^\"]*)")?$'
+          timestamp:
+            parse_from: "attributes.time_local"
+            layout: '%d/%b/%Y:%H:%M:%S %z'
+          severity:
+            parse_from: "attributes.http_request_status"
+            mapping:
+              info: 2xx
+              info2: 3xx
+              warn: 4xx
+              error: 5xx
+        {{end}} # End default log format parsing
+        
+        {{ if eq .log_format "observiq" }}
+        - id: access_parser
+          type: json_parser
+          timestamp:
+            parse_from: "attributes.time_local"
+            layout: '%d/%b/%Y:%H:%M:%S %z'
+          severity:
+            parse_from: "attributes.status"
+            mapping:
+              info: 2xx
+              info2: 3xx
+              warn: 4xx
+              error: 5xx
+        - id: move_status
+          type: move
+          from: attributes.status
+          to: attributes.http_request_status
+        - id: request_parser
+          type: regex_parser
+          parse_from: "attributes.request"
+          if: 'attributes.request != nil and attributes.request matches "\\S+ +[^ ]* "'
+          regex: '(?P<http_request_requestMethod>\S+) +(?P<http_request_requestUrl>[^ ]*) ((?P<http_request_protocol>[^/]*)/(?P<http_request_protocol_version>.*)|.*)?'
+        {{end}} # end observiq format parsing
+        {{ if eq .data_flow "low" }}
+        - id: filter
+          type: filter
+          expr: 'attributes.http_request_status == nil or not (attributes.http_request_status matches "[45][0-9]{2}")'
+        - id: retain
+          type: retain
+          fields:
+            - attributes.http_request_status
+            - attributes.http_request_requestUrl
+            - attributes.request_time
+        {{ end }}
+    {{end}} # end access log receiver
+
+    {{ if .enable_error_log }}
+    filelog/error_log:
+      include:
+        {{ range $fp := .error_log_paths }}
+        - '{{ $fp }}'
+        {{end}}
+      attributes:
+        log_type: 'nginx.error'
+      start_at: {{ .start_at }}
+      encoding: {{ .encoding }}
+      operators:
+        - type: regex_parser
+          regex: '^(?P<time>\d+[./-]\d+[./-]\d+[- ]\d+:\d+:\d+) \[(?P<log_level>[^\]]*)\] (?P<pid>\d+)#(?P<tid>\d+):(?: \*(?P<connection>\d+))? (?P<message>.*?)(?:, client: (?P<client>[^,]+))?(?:, server: (?P<server>[^,]+))?(?:, request: "(?P<request>[^"]*)")?(?:, subrequest: \"(?P<subrequest>[^\"]*)\")?(?:, upstream: \"(?P<upstream>[^"]*)\")?(?:, host: \"(?P<host>[^\"]*)\")?(?:, referrer: \"(?P<referer>[^"]*)\")?$'
+          timestamp:
+            parse_from: "attributes.time"
+            layout: '%Y/%m/%d %T'
+          severity:
+            parse_from: "attributes.log_level"
+            mapping:
+              error2: crit
+              error3: emerg
+    {{end}} # end error log receiver
+
+  service:
+    pipelines:
+      logs:
+        receivers:
+          {{ if .enable_access_log }}
+          - filelog/access_log
           {{ end }}
-      {{end}} # end access log receiver
-
-      {{ if .enable_error_log }}
-      filelog/error_log:
-        include:
-          {{ range $fp := .error_log_paths }}
-          - '{{ $fp }}'
-          {{end}}
-        attributes:
-          log_type: 'nginx.error'
-        start_at: {{ .start_at }}
-        encoding: {{ .encoding }}
-        operators:
-          - type: regex_parser
-            regex: '^(?P<time>\d+[./-]\d+[./-]\d+[- ]\d+:\d+:\d+) \[(?P<log_level>[^\]]*)\] (?P<pid>\d+)#(?P<tid>\d+):(?: \*(?P<connection>\d+))? (?P<message>.*?)(?:, client: (?P<client>[^,]+))?(?:, server: (?P<server>[^,]+))?(?:, request: "(?P<request>[^"]*)")?(?:, subrequest: \"(?P<subrequest>[^\"]*)\")?(?:, upstream: \"(?P<upstream>[^"]*)\")?(?:, host: \"(?P<host>[^\"]*)\")?(?:, referrer: \"(?P<referer>[^"]*)\")?$'
-            timestamp:
-              parse_from: "attributes.time"
-              layout: '%Y/%m/%d %T'
-            severity:
-              parse_from: "attributes.log_level"
-              mapping:
-                error2: crit
-                error3: emerg
-      {{end}} # end error log receiver
-
-    service:
-      pipelines:
-        logs:
-          receivers:
-            {{ if .enable_access_log }}
-            - filelog/access_log
-            {{ end }}
-            {{ if .enable_error_log }}
-            - filelog/error_log
-            {{ end }}
+          {{ if .enable_error_log }}
+          - filelog/error_log
+          {{ end }}


### PR DESCRIPTION
### Proposed Change
The `preserve_to` field in log operators is no longer supported in otel. The new default behavior is the `parse_from` field automatically preserves the original field. I removed the few `preserve_to` statements that were just keeping the original field.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
