### PR TITLE
fix: Config in linux package should be marked "config|noreplace"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,13 +78,13 @@ nfpms:
           mode: 0640
           owner: observiq-otel-collector
           group: observiq-otel-collector
+        type: config|noreplace
       - src: LICENSE
         dst: /opt/observiq-otel-collector/LICENSE
         file_info:
           mode: 0644
           owner: observiq-otel-collector
           group: observiq-otel-collector
-        type: config|noreplace
       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
         file_info:


### PR DESCRIPTION
### Proposed Change
* Move the "config|noreplace" type from LICENSE to config.yaml

This is needed to preserve config files between upgrades.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
