### PR TITLE
feat: Update Windows MSI to allow generation of manager.yaml

### DIFF
--- a/windows/install/generate-manager-yaml.ps1
+++ b/windows/install/generate-manager-yaml.ps1
@@ -1,0 +1,29 @@
+param (
+    [string] $install_dir = $null,
+    [string] $endpoint = $null,
+    [string] $secret_key = $null,
+    [string] $labels = $null
+)
+
+Write-Output $install_dir
+Write-Output $endpoint
+Write-Output $secret_key
+Write-Output $labels
+
+if([string]::IsNullOrEmpty($endpoint)) {
+    # Don't generate yaml if endpoint isn't specified
+    Write-Output "Endpoint not specified; Not writing output yaml"
+    return 0
+}
+
+Write-Output "Writing manager yaml"
+$yaml="endpoint: `"$endpoint`"{0}" -f [environment]::NewLine
+if(![string]::IsNullOrEmpty($secret_key)) {
+    $yaml+="secret_key: `"$secret_key`"{0}" -f [environment]::NewLine
+}
+if(![string]::IsNullOrEmpty($labels)) {
+    $yaml+="labels: `"$labels`"{0}" -f [environment]::NewLine
+}
+$yaml+="agent_id: `"{0}`"" -f [guid]::NewGuid()
+
+Set-Content -Path "${install_dir}manager.yaml" -Value $yaml

--- a/windows/templates/ConfigureManagementDlg.wxs
+++ b/windows/templates/ConfigureManagementDlg.wxs
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI Id="ConfigureManagementUI">
+            <Dialog Id="ConfigureManagementDlg" Width="370" Height="270" Title="!(loc.WelcomeDlg_Title)">
+                <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Optionally setup OpAMP for agent management." />
+                <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}OpAMP Configuration" />
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+                <Control Id="FurtherDescription" Type="Text" X="20" Y="60" Width="335" Height="10" Transparent="yes" NoPrefix="yes" Text="OpAMP functionality may be optionally configured to connect with an OpAMP compatible"/>
+                <Control Id="FurtherDescription2" Type="Text" X="20" Y="70" Width="290" Height="15" Transparent="yes" NoPrefix="yes" Text="server." /> 
+                <Control Id="EnableManagementCheckBox" Type="CheckBox" X="20" Y="95" Width="290" Height="15" Property="ENABLEMANAGEMENT" CheckBoxValue="1" Text="Enable OpAMP management" />
+
+
+                <Control Id="EndpointLabel" Type="Text" X="20" Y="110" Width="290" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Endpoint (Required)" Hidden="yes" >
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control> 
+                <Control Id="Endpoint" Type="Edit" X="20" Y="125" Width="330" Height="15" Property="OPAMPENDPOINT" Hidden="yes">
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control>
+
+                <Control Id="SecretKeyLabel" Type="Text" X="20" Y="145" Width="290" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Secret Key" Hidden="yes" >
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control> 
+                <Control Id="SecretKey" Type="Edit" X="20" Y="160" Width="330" Height="15" Property="OPAMPSECRETKEY" Hidden="yes">
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control>
+
+                <Control Id="LabelsLabel" Type="Text" X="20" Y="180" Width="290" Height="15" Transparent="yes" NoPrefix="yes" Text="{\WixUI_Font_Title}Labels (Comma separated)" Hidden="yes" >
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control> 
+                <Control Id="Labels" Type="Edit" X="20" Y="195" Width="330" Height="15" Property="OPAMPLABELS" Hidden="yes">
+                    <Condition Action="show"><![CDATA[ENABLEMANAGEMENT]]></Condition>
+                    <Condition Action="hide"><![CDATA[NOT (ENABLEMANAGEMENT)]]></Condition>
+                </Control>
+
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" >
+                    <!-- Note: These conditions sort of work, but the user has to change focus for the button to enable/disable-->
+                    <!-- <Condition Action="enable">
+                        <![CDATA[ (NOT ENABLEMANAGEMENT) OR (OPAMPENDPOINT)]]>
+                    </Condition>
+                    <Condition Action="disable">
+                        <![CDATA[ENABLEMANAGEMENT AND (NOT OPAMPENDPOINT)]]>
+                    </Condition> -->
+                </Control>
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/windows/templates/EndpointRequiredDlg.wxs
+++ b/windows/templates/EndpointRequiredDlg.wxs
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI Id="EndpointRequiredUI">
+            <Dialog Id="EndpointRequiredDlg" Width="260" Height="85" Title="!(loc.InvalidDirDlg_Title)">
+                <Control Id="OK" Type="PushButton" X="102" Y="57" Width="56" Height="17" Default="yes" Cancel="yes" Text="!(loc.WixUIOK)">
+                    <Publish Event="EndDialog" Value="Return">1</Publish>
+                </Control>
+
+                <Control Id="Text" Type="Text" X="48" Y="22" Width="194" Height="30" Text="Endpoint is required." />
+                <Control Id="Icon" Type="Icon" X="15" Y="15" Width="24" Height="24" ToolTip="!(loc.InvalidDirDlgIconTooltip)" FixedSize="yes" IconSize="32" Text="!(loc.InvalidDirDlgIcon)" />
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
    <Fragment>
-
       <UI Id="WixUI_HK">
          <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
          <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
@@ -21,6 +20,8 @@
          <DialogRef Id="ResumeDlg" />
          <DialogRef Id="UserExit" />
          <DialogRef Id="CustomExitDialog" />
+         <DialogRef Id="ConfigureManagementDlg" />
+         <DialogRef Id="EndpointRequiredDlg" />
 
          <!--   Make sure to include custom dialogs in the installer database via a DialogRef command,
                especially if they are not included explicitly in the publish chain below -->
@@ -31,8 +32,8 @@
 
          <Publish Dialog="CustomExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
-         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="{{if gt (.License | len) 0}}LicenseAgreementDlg_HK{{else}}InstallDirDlg{{end}}">NOT Installed</Publish>
-         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="{{if gt (.License | len) 0}}LicenseAgreementDlg_HK{{else}}InstallDirDlg{{end}}">NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">(Installed AND PATCH) OR WIX_UPGRADE_DETECTED</Publish>
 
          <Publish Dialog="LicenseAgreementDlg_HK" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
          <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1"</Publish>
@@ -41,13 +42,18 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
 
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
+      
+         <Publish Dialog="ConfigureManagementDlg" Control="Next" Event="SpawnDialog" Value="EndpointRequiredDlg" Order="1">ENABLEMANAGEMENT AND NOT OPAMPENDPOINT</Publish>
+         <Publish Dialog="ConfigureManagementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">NOT ENABLEMANAGEMENT OR OPAMPENDPOINT</Publish>
+         <Publish Dialog="ConfigureManagementDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">1</Publish>
 
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">NOT Installed</Publish>
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">Installed</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">WIX_UPGRADE_DETECTED</Publish>
 
          <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
@@ -64,7 +70,9 @@
          </AdminUISequence>
       </UI>
 
+      <UIRef Id="ConfigureManagementUI" />
       <UIRef Id="WixUI_Common" />
       <UIRef Id="CustomExitDialogUI" />
+      <UIRef Id="EndpointRequiredUI" />
    </Fragment>
 </Wix>

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -48,6 +48,27 @@
       {{range $i, $c := .Conditions}}
       <Condition Message="{{$c.Message}}"><![CDATA[{{$c.Condition}}]]></Condition>
       {{end}}
+      
+
+      <!-- Load previous install directory (if it exists); This will populate the install dir with the current install dir
+           for upgrades. -->
+      <Property Id="INSTALLDIR">
+          <RegistrySearch Id='LOADINSTALLDIR' Type='raw'
+            Root='HKLM' Key='Software\Microsoft\Windows\CurrentVersion\Uninstall\[ProductName]' Name='InstallLocation' />
+      </Property>
+
+      <!-- Load Powershell location -->
+      <Property Id="POWERSHELLEXE">
+          <RegistrySearch Id="POWERSHELLEXE"
+                          Type="raw"
+                          Root="HKLM"
+                          Key="SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell"
+                          Name="Path" />
+      </Property>
+
+      <Condition Message="This application requires Windows PowerShell to be installed.">
+        <![CDATA[POWERSHELLEXE]]>
+      </Condition>
 
       <Directory Id="TARGETDIR" Name="SourceDir">
 
@@ -159,6 +180,21 @@
       <SetProperty Action="SetCustomExec{{$i}}" {{if eq $h.Execute "immediate"}} Id="WixQuietExecCmdLine" {{else}} Id="CustomExec{{$i}}" {{end}} Value="{{$h.CookedCommand}}" Before="CustomExec{{$i}}" Sequence="execute"/>
       <CustomAction Id="CustomExec{{$i}}" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="{{$h.Execute}}" Impersonate="{{$h.Impersonate}}" {{if gt ($h.Return | len) 0}} Return="{{$h.Return}}" {{end}}/>
       {{end}}
+
+      <CustomAction Id="CustomExecCreateManagerYaml_set"
+              Property="CustomExecCreateManagerYaml"
+              Value="&quot;[POWERSHELLEXE]&quot; -ExecutionPolicy Bypass -NoProfile -Command &quot;&amp; '[INSTALLDIR]install\generate-manager-yaml.ps1' -install_dir '[INSTALLDIR]' -endpoint '[OPAMPENDPOINT]' -secret_key '[OPAMPSECRETKEY]' -labels '[OPAMPLABELS]'&quot;"
+              Execute="immediate"/>
+
+      <CustomAction Id="CustomExecCreateManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="yes" Return="check" />
+
+      <CustomAction Id="CustomExecRemoveManagerYaml_set"
+              Property="CustomExecRemoveManagerYaml"
+              Value="&quot;[POWERSHELLEXE]&quot; -ExecutionPolicy Bypass -NoProfile -Command &quot;Remove-Item -Force -ErrorAction Continue -Path '[INSTALLDIR]manager.yaml'&quot;"
+              Execute="immediate"/>
+
+      <CustomAction Id="CustomExecRemoveManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="yes" Return="ignore" />
+
       <InstallExecuteSequence>
          {{range $i, $h := .Hooks}}
          <Custom Action="CustomExec{{$i}}" {{if eq $h.When "install"}} After="InstallFiles" {{else if eq $h.Execute "immediate"}} Before="InstallValidate" {{else}} After="InstallInitialize" {{end}}>
@@ -171,6 +207,22 @@
             {{end}}
          </Custom>
          {{end}}
+
+        <!-- Schedule the action that creates the manager.yaml file on initial install -->
+        <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >
+            <![CDATA[NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+        </Custom>
+        <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
+            <![CDATA[NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+        </Custom>
+        
+        <!-- Schedule the action that removes the manager.yaml file on final uninstall -->
+        <Custom Action="CustomExecRemoveManagerYaml_set" After="InstallInitialize" >
+            <![CDATA[REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+        </Custom>
+        <Custom Action="CustomExecRemoveManagerYaml" Before="RemoveFiles" >
+            <![CDATA[REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+        </Custom>
       </InstallExecuteSequence>
 
       <Feature Id="DefaultFeature" Level="1">

--- a/windows/wix.json
+++ b/windows/wix.json
@@ -35,6 +35,9 @@
     },
     {
       "name": "storage"
+    }, 
+    {
+      "name": "install"
     }
   ],
   "environments": [


### PR DESCRIPTION
### Proposed Change
* Allow user to optionally configure OpAMP parameters through the installer UI:
![Screen Shot 2022-05-10 at 11 05 54 AM](https://user-images.githubusercontent.com/10042942/167660877-d103d2c8-a7ac-484c-ad91-53b87477d17c.png)
![Screen Shot 2022-05-10 at 11 06 14 AM](https://user-images.githubusercontent.com/10042942/167660942-54f6d051-76bd-4fa0-bc47-9c324bcc2f4b.png)
  * Endpoint is required:
![Screen Shot 2022-05-10 at 11 06 54 AM](https://user-images.githubusercontent.com/10042942/167661093-593b6176-9ef4-44db-8945-d8e264436e7a.png)

* If a user is upgrading, skip install directory + opamp config steps
  * This change was made because we do not regenerate the opamp config when updating; So having these steps were confusing. It also led to a problem where the user config would be destroyed if they changed the directory they had installed to. This simplified workflow should mitigate that, while also being more painless for users.

* Installing w/ OpAMP configuration using MSIExec would look like this:
  * `msiexec /i "https://github.com/observIQ/observiq-otel-collector/releases/latest/download/observiq-otel-collector.msi" /quiet ENABLEMANAGEMENT=1 OPAMPENDPOINT=<your_endpoint> OPAMPSECRETKEY=<secret-key> OPAMPLABELS=<comma-separated-labels>`

##### Checklist


- [ ] Changes are tested
- [ ] CI has passed
