### PR TITLE
feat(installscript): Restart the service so changes take effect on upgrade

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -472,9 +472,18 @@ install_package()
   unpack_package || error_exit "$LINENO" "Failed to extract package"
   succeeded
 
-  info "Enabling service..."
-  systemctl enable --now observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
-  succeeded
+  if [ "$(systemctl is-enabled observiq-otel-collector)" = "enabled" ]; then
+    # The unit is already enabled; It may be running, too, if this was an upgrade.
+    # We'll want to restart, which will start it if it wasn't running already,
+    # and restart in the case that this was an upgrade on a running collector.
+    info "Restarting service..."
+    systemctl restart observiq-otel-collector
+    succeeded
+  else
+    info "Enabling service..."
+    systemctl enable --now observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
+    succeeded
+  fi
 
   success "observIQ OpenTelemetry Collector installation complete!"
   decrease_indent


### PR DESCRIPTION
### Proposed Change
Our linux installation script currently does not restart the service after an upgrade.
Because of this, the previous version of the collector will still be running until a restart is triggered outside of the install script.

We should automatically restart the service if it's already enabled, so that the new collector binary runs automatically.

Tested on AlmaLinux 8.5 + debian 10
##### Checklist
- [x] Changes are tested
- [ ] CI has passed
