### PR TITLE
feat: Add a plugin for CouchDB logs

### DIFF
--- a/plugins/couchdb_logs.yaml
+++ b/plugins/couchdb_logs.yaml
@@ -1,0 +1,73 @@
+version: 0.0.1
+title: CouchDB
+description: Log parser for CouchDB
+parameters:
+  - name: log_paths
+    type: "[]string"
+    default:
+      - "/var/log/couchdb/couchdb.log"
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ range $fp := .log_paths }}
+        - '{{ $fp }}'
+        {{end}}
+      multiline: 
+        line_start_pattern: '^\[\w+\]'
+      attributes:
+        log_type: couchdb
+      start_at: {{ .start_at }}
+      operators:
+        - id: id_router
+          type: router
+          routes:
+            - output: couchdb_access_parser
+              expr: $ matches '^\\[(\\w*)\\] ([\\d\\-\\.:TZ]+) (\\S+)@([^\\s]+) \\<([^ ]*)\\> [\\w-]+ ([^ ]*) ([^ ]*) (([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([\\d]*))'
+            - output: couchdb_parser
+              expr: $ matches '^\\[(\\w*)\\] ([\\d\\-\\.:TZ]+) (\\S+)@([^\\s]+) ([\\s\\S]*(\\<([^>]+)\\>)[\\s\\S]*)'
+        - id: couchdb_access_parser
+          type: regex_parser
+          regex: '^\[(?P<level>\w*)\] (?P<timestamp>[\d\-\.:TZ]+) (?P<node>\S+)@(?P<host>[^\s]+) \<(?P<pid>[^ ]*)\> [\w-]+ (?P<http_request_serverIp>[^ ]*) (?P<http_request_remoteIp>[^ ]*) (?P<message>(?P<remote_user>[^ ]*) (?P<http_request_requestMethod>[^ ]*) (?P<path>[^ ]*) (?P<http_request_status>[^ ]*) (?P<status_message>[^ ]*) (?P<http_request_responseSize>[\d]*))'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%dT%H:%M:%S.%sZ'
+          severity:
+            parse_from: attributes.level
+            mapping:
+              info: notice
+              warn: warn
+              error: err
+              error2: crit
+              fatal: emerg
+          output: end_filter
+        - id: couchdb_parser
+          type: regex_parser
+          regex: '^\[(?P<level>\w*)\] (?P<timestamp>[\d\-\.:TZ]+) (?P<node>\S+)@(?P<host>[^\s]+) (?P<message>[\s\S]*(\<(?P<pid>[^>]+)\>)[\s\S]*)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%dT%H:%M:%S.%sZ'
+          severity:
+            parse_from: attributes.level
+            mapping:
+              info: notice
+              warn: warn
+              error: err
+              error2: crit
+              fatal: emerg
+          output: end_filter
+        # Noop filter to allow an exit point for other operators
+        - id: end_filter
+          type: filter
+          expr: 'body == ""'
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - filelog


### PR DESCRIPTION
### Proposed Change
* Adds a plugin that receives & parses CouchDB logs

Sample Access record:
```
ObservedTimestamp: 2022-05-13 17:04:29.920619491 +0000 UTC
Timestamp: 2022-05-13 14:57:30.951381 +0000 UTC
Severity: Info
Body: [notice] 2022-05-13T14:57:30.951381Z couchdb@127.0.0.1 <0.1363.0> 4022011fc3 localhost:5984 127.0.0.1 admin PUT /_replicator 412 ok 1
Attributes:
     -> log_type: STRING(couchdb)
     -> log.file.name: STRING(couchdb.log)
     -> node: STRING(couchdb)
     -> http_request_requestMethod: STRING(PUT)
     -> remote_user: STRING(admin)
     -> pid: STRING(0.1363.0)
     -> http_request_remoteIp: STRING(127.0.0.1)
     -> host: STRING(127.0.0.1)
     -> http_request_responseSize: STRING(1)
     -> level: STRING(notice)
     -> status_message: STRING(ok)
     -> path: STRING(/_replicator)
     -> message: STRING(admin PUT /_replicator 412 ok 1)
     -> timestamp: STRING(2022-05-13T14:57:30.951381Z)
     -> http_request_serverIp: STRING(localhost:5984)
     -> http_request_status: STRING(412)
```

Sample internal record:
```
ObservedTimestamp: 2022-05-13 17:04:29.920511008 +0000 UTC
Timestamp: 2022-05-13 14:55:46.429948 +0000 UTC
Severity: Info
Body: [notice] 2022-05-13T14:55:46.429948Z couchdb@127.0.0.1 <0.405.0> -------- Started replicator db changes listener <0.523.0>
Attributes:
     -> timestamp: STRING(2022-05-13T14:55:46.429948Z)
     -> node: STRING(couchdb)
     -> host: STRING(127.0.0.1)
     -> log_type: STRING(couchdb)
     -> log.file.name: STRING(couchdb.log)
     -> message: STRING(<0.405.0> -------- Started replicator db changes listener <0.523.0>)
     -> pid: STRING(0.523.0)
     -> level: STRING(notice)
```

tested against CouchDB v3.2.2

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
