### PR TITLE
feat: pgbouncer plugin

### DIFF
--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -19,17 +19,18 @@ template: |
         - '{{ $fp }}'
         {{end}}
       start_at: {{ .start_at }}
+      output: pgbouncer_parser
       operators:
-        - type: regex_parser
+        - id: pgbouncer_parser
+          type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}(\s*[^\d\s]{3})?)\s*(\[)?(?P<pid>\d+)(\])? (?P<severity>\w+) (?P<message>.*)'
           severity:
             parse_from: attributes.severity
             mapping:
-              critical: fatal
-              info: log
+              info2: log
               notice: stats
               debug: noise
-          output: add_type
+          output: time_parser_router
 
         - id: time_parser_router
           type: router

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -1,0 +1,79 @@
+version: 0.0.1
+title: PgBouncer
+description: Log parser for PgBouncer
+parameters:
+  - name: file_path
+    type: "[]string"
+    default: "/var/log/pgbouncer/pgbouncer.log"
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ range $fp := .file_path }}
+        - '{{ $fp }}'
+        {{end}}
+      start_at: beginning
+      operators:
+        - type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}(\s*[^\d\s]{3})?)\s*(\[)?(?P<pid>\d+)(\])? (?P<severity>\w+) (?P<message>.*)'
+          severity:
+            parse_from: attributes.severity
+            mapping:
+              critical: fatal
+              info: log
+              notice: stats
+              debug: noise
+          output: add_type
+
+        - id: time_parser_router
+          type: router
+          default: message_router
+          routes:
+            - output: time_parser_with_timezone
+              expr: 'attributes.timestamp != nil and attributes.timestamp matches "^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}.\\d{3}\\s[^\\d\\s]{3}"'
+            - output: time_parser_without_timezone
+              expr: 'attributes.timestamp != nil and attributes.timestamp matches "^\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2}.\\d{3}"'
+
+        - id: time_parser_with_timezone
+          type: time_parser
+          parse_from: attributes.timestamp
+          layout: '%d %b %Y %H:%M:%S.%s'
+          output: message_router
+
+        - id: time_parser_without_timezone
+          type: time_parser
+          parse_from: attributes.timestamp
+          layout: '%Y-%m-%d %H:%M:%S.%L'
+          output: message_router
+
+        - id: message_router
+          type: router
+          default: add_type
+          routes:
+          - expr: 'attributes.message matches "^[Ss]tats: "'
+            output: stats_parser
+          - expr: 'attributes.message matches "^[CS]-\\w*"'
+            output: request_parser
+
+        - id: stats_parser
+          type: regex_parser
+          parse_from: attributes.message
+          regex: '^[Ss]tats: (?P<xacts_per_second>\d+)[^,]*,\s(?P<queries_per_second>\d+)[^,]*,\sin\s(?P<in_bytes_per_second>\d+)[^,]*,\sout\s(?P<out_bytes_per_second>\d+)[^,]*,\sxact\s(?P<xact_microsecond>\d+)[^,]*,\squery\s(?P<query_microsecond>\d+)\sus(,)?\swait(\stime)?\s(?P<wait_time_microsecond>\d+).*'
+          output: add_type
+
+        - id: request_parser
+          type: regex_parser
+          parse_from: attributes.message
+          regex: '^[CS]-\w*:\s(\()?(?P<db_name>\w*)(\))?\/(\()?(?P<user_name>\w*)(\))?@(?P<host>[^:]*):(?P<port>\d*)\s*(?P<message>[^\(]*)(\s*\(age=(?P<age>\d*)s\))?'
+          output: add_type
+
+        - id: add_type
+          type: add
+          field: attributes.log_type
+          value: 'pgbouncer'

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -20,7 +20,6 @@ template: |
         - '{{ $fp }}'
         {{end}}
       start_at: {{ .start_at }}
-      output: pgbouncer_parser
       operators:
         - id: pgbouncer_parser
           type: regex_parser
@@ -28,11 +27,12 @@ template: |
           severity:
             parse_from: attributes.severity
             mapping:
-              info2: log
-              notice: stats
+              info: log
+              info2: stats
               debug: noise
           output: time_parser_router
 
+        # Handle different timestamps
         - id: time_parser_router
           type: router
           default: message_router
@@ -45,7 +45,7 @@ template: |
         - id: time_parser_with_timezone
           type: time_parser
           parse_from: attributes.timestamp
-          layout: '%d %b %Y %H:%M:%S.%s'
+          layout: '%Y-%m-%d %H:%M:%S.%L %Z'
           output: message_router
 
         - id: time_parser_without_timezone
@@ -58,10 +58,10 @@ template: |
           type: router
           default: add_type
           routes:
-          - expr: 'attributes.message matches "^[Ss]tats: "'
-            output: stats_parser
-          - expr: 'attributes.message matches "^[CS]-\\w*"'
-            output: request_parser
+            - expr: 'attributes.message matches "^[Ss]tats: "'
+              output: stats_parser
+            - expr: 'attributes.message matches "^[CS]-\\w*"'
+              output: request_parser
 
         - id: stats_parser
           type: regex_parser
@@ -72,7 +72,7 @@ template: |
         - id: request_parser
           type: regex_parser
           parse_from: attributes.message
-          regex: '^[CS]-\w*:\s(\()?(?P<db_name>\w*)(\))?\/(\()?(?P<user_name>\w*)(\))?@(?P<host>[^:]*):(?P<port>\d*)\s*(?P<message>[^\(]*)(\s*\(age=(?P<age>\d*)s\))?'
+          regex: '^[CS]-\w*:\s\(?(?P<db_name>\w*)\)?\/\(?(?P<user_name>[^@]*)\)?@(?P<host>[^:]*):(?P<port>\d*)\s*'
           output: add_type
 
         - id: add_type

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -4,7 +4,8 @@ description: Log parser for PgBouncer
 parameters:
   - name: file_path
     type: "[]string"
-    default: "/var/log/pgbouncer/pgbouncer.log"
+    default: 
+      - "/var/log/pgbouncer/pgbouncer.log"
   - name: start_at
     type: string
     supported:

--- a/plugins/pgbouncer_logs.yaml
+++ b/plugins/pgbouncer_logs.yaml
@@ -18,7 +18,7 @@ template: |
         {{ range $fp := .file_path }}
         - '{{ $fp }}'
         {{end}}
-      start_at: beginning
+      start_at: {{ .start_at }}
       operators:
         - type: regex_parser
           regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.\d{3}(\s*[^\d\s]{3})?)\s*(\[)?(?P<pid>\d+)(\])? (?P<severity>\w+) (?P<message>.*)'
@@ -77,3 +77,8 @@ template: |
           type: add
           field: attributes.log_type
           value: 'pgbouncer'
+        
+  service:
+    pipelines:
+      logs:
+        receivers: [filelog]


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Ported PGBouncer plugin

configuration used:
```
receivers:
  plugin:
    path: ./plugins/pgbouncer_logs.yaml
    parameters:
      file_path:
        - /Users/austingeorgiades/projects/observiq-otel-collector/in
      start_at: beginning

exporters:
  logging:
    logLevel: debug

service:
  pipelines:
    logs:
      receivers:
      - plugin
      exporters:
      - logging
```

input/test data:
```
2021-05-17 16:16:40.613 1354 LOG Stats: 0 xacts/s, 0 queries/s, in 0 B/s, out 0 B/s, xact 0 us, query 0 us wait time 0 us
2021-05-18 13:12:05.011 UTC [1] LOG stats: 927 xacts/s, 935 queries/s, in 420598 B/s, out 687149 B/s, xact 893 us, query 816 us, wait 1 us
2021-05-18 13:12:05.191 UTC [1] LOG C-0x55a12ff32ad0: collectors/bindplane@10.1.0.70:56614 closing because: client close request (age=82s)
2021-05-18 12:30:05.591 12788 WARNING C-0x564043c80e20: (nodb)/(nouser)@10.33.104.53:37688 Pooler Error: No such database: bob
```

sample output:
```
LogRecord #7
ObservedTimestamp: 2022-05-16 15:39:03.880806 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: Warn
Body: 2021-05-18 12:30:05.591 12788 WARNING C-0x564043c80e20: (nodb)/(nouser)@10.33.104.53:37688 Pooler Error: No such database: bob
Attributes:
     -> log.file.name: STRING(in)
     -> pid: STRING(12788)
     -> severity: STRING(WARNING)
     -> message: STRING(C-0x564043c80e20: (nodb)/(nouser)@10.33.104.53:37688 Pooler Error: No such database: bob)
     -> timestamp: STRING(2021-05-18 12:30:05.591)
     -> log_type: STRING(pgbouncer)
Trace ID:
Span ID:
Flags: 0
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
