### PR TITLE
feat: Add logging support to resource attribute transposer

### DIFF
--- a/processor/resourceattributetransposerprocessor/README.md
+++ b/processor/resourceattributetransposerprocessor/README.md
@@ -1,14 +1,16 @@
 # Resource Attribute Transposer Processor
 
-This processor copies a resource level attribute to all individual metric data points associated with the resource.
+Supported pipelines: logs, metrics
+
+This processor copies a resource level attribute to all individual logs or metric data points associated with the resource.
 If they key already exists, no action is taken (the data points' attribute _**IS NOT**_ overwritten)
 
 ## Configuration
 
 The following options may be configured:
-- `operations` (default: []): A list of operations to apply to each resource metric.
+- `operations` (default: []): A list of operations to apply to each metric or log resource.
     - `operations[].from` (default: ""): The attribute to copy off of the resource
-    - `operations[].to` (default: ""): The destination attribute on each individual metric data point
+    - `operations[].to` (default: ""): The destination attribute on each individual metric data point or log
 
 ### Example configuration
 

--- a/processor/resourceattributetransposerprocessor/factory.go
+++ b/processor/resourceattributetransposerprocessor/factory.go
@@ -33,6 +33,7 @@ func NewFactory() component.ProcessorFactory {
 		typeStr,
 		createDefaultConfig,
 		component.WithMetricsProcessor(createMetricsProcessor),
+		component.WithLogsProcessor(createLogsProcessor),
 	)
 }
 
@@ -50,5 +51,14 @@ func createMetricsProcessor(_ context.Context, params component.ProcessorCreateS
 		return nil, fmt.Errorf("config was not of correct type for the processor: %+v", cfg)
 	}
 
-	return newResourceAttributeTransposerProcessor(params.Logger, nextConsumer, processorCfg), nil
+	return newMetricsProcessor(params.Logger, nextConsumer, processorCfg), nil
+}
+
+func createLogsProcessor(_ context.Context, params component.ProcessorCreateSettings, cfg config.Processor, nextConsumer consumer.Logs) (component.LogsProcessor, error) {
+	processorCfg, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("config was not of correct type for the processor: %+v", cfg)
+	}
+
+	return newLogsProcessor(params.Logger, nextConsumer, processorCfg), nil
 }

--- a/processor/resourceattributetransposerprocessor/factory_test.go
+++ b/processor/resourceattributetransposerprocessor/factory_test.go
@@ -35,14 +35,26 @@ func TestCreateDefaultConfig(t *testing.T) {
 	require.NoError(t, configtest.CheckConfigStruct(cfg))
 }
 
-func TestCreateMetricsExporter(t *testing.T) {
+func TestCreateMetricsProcessor(t *testing.T) {
 	cfg := createDefaultConfig()
 	p, err := createMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	require.NotNil(t, p)
 	require.NoError(t, err)
 }
 
-func TestCreateMetricsExporterNilConfig(t *testing.T) {
+func TestCreateMetricsProcessorNilConfig(t *testing.T) {
 	_, err := createMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), nil, consumertest.NewNop())
+	require.Error(t, err)
+}
+
+func TestCreateLogsProcessor(t *testing.T) {
+	cfg := createDefaultConfig()
+	p, err := createLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
+	require.NotNil(t, p)
+	require.NoError(t, err)
+}
+
+func TestCreateLogsProcessorNilConfig(t *testing.T) {
+	_, err := createLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), nil, consumertest.NewNop())
 	require.Error(t, err)
 }

--- a/processor/resourceattributetransposerprocessor/processor_logs.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs.go
@@ -1,0 +1,80 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceattributetransposerprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+)
+
+type logsProcessor struct {
+	consumer consumer.Logs
+	logger   *zap.Logger
+	config   *Config
+}
+
+// newLogsProcessor returns a new logsResourceAttributeTransposerProcessor
+func newLogsProcessor(logger *zap.Logger, consumer consumer.Logs, config *Config) *logsProcessor {
+	return &logsProcessor{
+		consumer: consumer,
+		logger:   logger,
+		config:   config,
+	}
+}
+
+// Start starts the processor. It's a noop.
+func (logsProcessor) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+// Capabilities returns the consumer's capabilities. Indicates that this processor mutates the incoming metrics.
+func (logsProcessor) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+func (p logsProcessor) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+	resLogs := md.ResourceLogs()
+	for i := 0; i < resLogs.Len(); i++ {
+		resLog := resLogs.At(i)
+		resourceAttrs := resLog.Resource().Attributes()
+		for _, op := range p.config.Operations {
+			resourceValue, ok := resourceAttrs.Get(op.From)
+			if !ok {
+				continue
+			}
+
+			scopeLogs := resLog.ScopeLogs()
+			for j := 0; j < scopeLogs.Len(); j++ {
+				scopeLog := scopeLogs.At(j)
+				logs := scopeLog.LogRecords()
+				for k := 0; k < logs.Len(); k++ {
+					log := logs.At(k)
+					log.Attributes().Insert(op.To, resourceValue)
+				}
+			}
+		}
+	}
+
+	return p.consumer.ConsumeLogs(ctx, md)
+}
+
+// Shutdown stops the processor. It's a noop.
+func (logsProcessor) Shutdown(_ context.Context) error {
+	return nil
+}

--- a/processor/resourceattributetransposerprocessor/processor_logs_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs_test.go
@@ -1,3 +1,17 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resourceattributetransposerprocessor
 
 import (

--- a/processor/resourceattributetransposerprocessor/processor_logs_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs_test.go
@@ -1,0 +1,251 @@
+package resourceattributetransposerprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+)
+
+func TestLogsProcessorStart(t *testing.T) {
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumertest.NewNop(),
+		createDefaultConfig().(*Config),
+	)
+
+	err := p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+}
+
+func TestLogsProcessorShutdown(t *testing.T) {
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumertest.NewNop(),
+		createDefaultConfig().(*Config),
+	)
+
+	err := p.Shutdown(context.Background())
+	require.NoError(t, err)
+}
+
+func TestLogsProcessorCapabilities(t *testing.T) {
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumertest.NewNop(),
+		createDefaultConfig().(*Config),
+	)
+	capabilities := p.Capabilities()
+	require.True(t, capabilities.MutatesData)
+}
+
+func TestConsumeLogs(t *testing.T) {
+	ctx := context.Background()
+	logs := createLogs()
+
+	attrs := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes()
+	attrs.Insert("resourceattrib1", pcommon.NewValueString("value"))
+	attrs.Insert("resourceattrib2", pcommon.NewValueBool(false))
+	attrs.Insert("resourceattrib3", pcommon.NewValueBytes([]byte("some bytes")))
+	attrs.Insert("resourceattrib4", pcommon.NewValueDouble(2.0))
+	attrs.Insert("resourceattrib5", pcommon.NewValueInt(100))
+	attrs.Insert("resourceattrib6", pcommon.NewValueEmpty())
+
+	var logsOut pdata.Logs
+
+	consumer := &mockConsumer{}
+	consumer.On("ConsumeLogs", ctx, logs).Run(func(args mock.Arguments) {
+		logsOut = args[1].(pdata.Logs)
+	}).Return(nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Operations = []CopyResourceConfig{
+		{
+			From: "resourceattrib1",
+			To:   "resourceattrib1",
+		},
+		{
+			From: "resourceattrib2",
+			To:   "resourceattrib2",
+		},
+		{
+			From: "resourceattrib3",
+			To:   "resourceattrib3",
+		},
+		{
+			From: "resourceattrib4",
+			To:   "resourceattrib4",
+		},
+		{
+			From: "resourceattrib5",
+			To:   "resourceattrib5",
+		},
+		{
+			From: "resourceattrib6",
+			To:   "resourceattrib6",
+		},
+		{
+			From: "resourceattrib7",
+			To:   "resourceattrib7",
+		},
+	}
+
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumer,
+		cfg,
+	)
+
+	err := p.ConsumeLogs(ctx, logs)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]interface{}{
+		"resourceattrib1": "value",
+		"resourceattrib2": false,
+		"resourceattrib3": []byte("some bytes"),
+		"resourceattrib4": float64(2.0),
+		"resourceattrib5": int64(100),
+		"resourceattrib6": nil,
+	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+}
+
+func TestConsumeLogsMoveToMultipleMetrics(t *testing.T) {
+	ctx := context.Background()
+	logs := createLogs()
+
+	attrs := logs.ResourceLogs().At(0).Resource().Attributes()
+	attrs.Insert("resourceattrib1", pcommon.NewValueString("value"))
+
+	var logsOut pdata.Logs
+
+	consumer := &mockConsumer{}
+	consumer.On("ConsumeLogs", ctx, logs).Run(func(args mock.Arguments) {
+		logsOut = args[1].(pdata.Logs)
+	}).Return(nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Operations = []CopyResourceConfig{
+		{
+			From: "resourceattrib1",
+			To:   "resourceattrib1",
+		},
+	}
+
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumer,
+		cfg,
+	)
+
+	logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().AppendEmpty()
+
+	err := p.ConsumeLogs(ctx, logs)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]interface{}{
+		"resourceattrib1": "value",
+	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+
+	require.Equal(t, map[string]interface{}{
+		"resourceattrib1": "value",
+	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(1).Attributes().AsRaw())
+}
+
+func TestConsumeLogsDoesNotOverwrite(t *testing.T) {
+	// Tests that subsequent operations do not overwrite values written
+	// by previous options (list order is respected)
+	ctx := context.Background()
+	logs := createLogs()
+
+	attrs := logs.ResourceLogs().At(0).Resource().Attributes()
+	attrs.Insert("resourceattrib1", pcommon.NewValueString("value1"))
+	attrs.Insert("resourceattrib2", pcommon.NewValueString("value2"))
+
+	var logsOut pdata.Logs
+
+	consumer := &mockConsumer{}
+	consumer.On("ConsumeLogs", ctx, logs).Run(func(args mock.Arguments) {
+		logsOut = args[1].(pdata.Logs)
+	}).Return(nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Operations = []CopyResourceConfig{
+		{
+			From: "resourceattrib1",
+			To:   "out",
+		},
+		{
+			From: "resourceattrib2",
+			To:   "out",
+		},
+	}
+
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumer,
+		cfg,
+	)
+
+	err := p.ConsumeLogs(ctx, logs)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]interface{}{
+		"out": "value1",
+	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+}
+
+func TestConsumeLogsDoesNotOverwrite2(t *testing.T) {
+	// Tests that operations will not overwrite previously filled in attributes.
+	ctx := context.Background()
+	logs := createLogs()
+
+	attrs := logs.ResourceLogs().At(0).Resource().Attributes()
+	attrs.Insert("resourceattrib1", pcommon.NewValueString("value1"))
+	attrs.Insert("resourceattrib2", pcommon.NewValueString("value2"))
+
+	var logsOut pdata.Logs
+
+	consumer := &mockConsumer{}
+	consumer.On("ConsumeLogs", ctx, logs).Run(func(args mock.Arguments) {
+		logsOut = args[1].(pdata.Logs)
+	}).Return(nil)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.Operations = []CopyResourceConfig{
+		{
+			From: "resourceattrib1",
+			To:   "out",
+		},
+		{
+			From: "resourceattrib2",
+			To:   "out",
+		},
+	}
+
+	p := newLogsProcessor(
+		zap.NewNop(),
+		consumer,
+		cfg,
+	)
+
+	logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().InsertString("out", "originalvalue")
+
+	err := p.ConsumeLogs(ctx, logs)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]interface{}{
+		"out": "originalvalue",
+	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
+}
+
+func createLogs() pdata.Logs {
+	logs := pdata.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	return logs
+}

--- a/processor/resourceattributetransposerprocessor/processor_metrics.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics.go
@@ -24,17 +24,17 @@ import (
 )
 
 type metricsProcessor struct {
-	metricsConsumer consumer.Metrics
-	logger          *zap.Logger
-	config          *Config
+	consumer consumer.Metrics
+	logger   *zap.Logger
+	config   *Config
 }
 
 // newMetricsProcessor returns a new resourceToMetricsAttributesProcessor
 func newMetricsProcessor(logger *zap.Logger, consumer consumer.Metrics, config *Config) *metricsProcessor {
 	return &metricsProcessor{
-		metricsConsumer: consumer,
-		logger:          logger,
-		config:          config,
+		consumer: consumer,
+		logger:   logger,
+		config:   config,
 	}
 }
 
@@ -71,7 +71,7 @@ func (p metricsProcessor) ConsumeMetrics(ctx context.Context, md pdata.Metrics) 
 			}
 		}
 	}
-	return p.metricsConsumer.ConsumeMetrics(ctx, md)
+	return p.consumer.ConsumeMetrics(ctx, md)
 }
 
 // Shutdown stops the processor. It's a noop.

--- a/processor/resourceattributetransposerprocessor/processor_metrics.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics.go
@@ -23,33 +23,33 @@ import (
 	"go.uber.org/zap"
 )
 
-type resourceAttributeTransposerProcessor struct {
-	consumer consumer.Metrics
-	logger   *zap.Logger
-	config   *Config
+type metricsProcessor struct {
+	metricsConsumer consumer.Metrics
+	logger          *zap.Logger
+	config          *Config
 }
 
-// newResourceAttributeTransposerProcessor returns a new resourceToMetricsAttributesProcessor
-func newResourceAttributeTransposerProcessor(logger *zap.Logger, consumer consumer.Metrics, config *Config) *resourceAttributeTransposerProcessor {
-	return &resourceAttributeTransposerProcessor{
-		consumer: consumer,
-		logger:   logger,
-		config:   config,
+// newMetricsProcessor returns a new resourceToMetricsAttributesProcessor
+func newMetricsProcessor(logger *zap.Logger, consumer consumer.Metrics, config *Config) *metricsProcessor {
+	return &metricsProcessor{
+		metricsConsumer: consumer,
+		logger:          logger,
+		config:          config,
 	}
 }
 
 // Start starts the processor. It's a noop.
-func (resourceAttributeTransposerProcessor) Start(_ context.Context, _ component.Host) error {
+func (metricsProcessor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
 // Capabilities returns the consumer's capabilities. Indicates that this processor mutates the incoming metrics.
-func (resourceAttributeTransposerProcessor) Capabilities() consumer.Capabilities {
+func (metricsProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
 
 // ConsumeMetrics processes the incoming pdata.Metrics.
-func (p resourceAttributeTransposerProcessor) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
+func (p metricsProcessor) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 	resMetrics := md.ResourceMetrics()
 	for i := 0; i < resMetrics.Len(); i++ {
 		resMetric := resMetrics.At(i)
@@ -71,11 +71,11 @@ func (p resourceAttributeTransposerProcessor) ConsumeMetrics(ctx context.Context
 			}
 		}
 	}
-	return p.consumer.ConsumeMetrics(ctx, md)
+	return p.metricsConsumer.ConsumeMetrics(ctx, md)
 }
 
 // Shutdown stops the processor. It's a noop.
-func (resourceAttributeTransposerProcessor) Shutdown(_ context.Context) error {
+func (metricsProcessor) Shutdown(_ context.Context) error {
 	return nil
 }
 

--- a/processor/resourceattributetransposerprocessor/processor_metrics_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics_test.go
@@ -72,7 +72,7 @@ func TestConsumeMetricsNoop(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -103,7 +103,7 @@ func TestConsumeMetricsMoveExistingAttribs(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -173,7 +173,7 @@ func TestConsumeMetricsMoveToMultipleMetrics(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -224,7 +224,7 @@ func TestConsumeMetricsMixedExistence(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -265,7 +265,7 @@ func TestConsumeMetricsSum(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -306,7 +306,7 @@ func TestConsumeMetricsHistogram(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -347,7 +347,7 @@ func TestConsumeMetricsSummary(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -388,7 +388,7 @@ func TestConsumeMetricsNone(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -426,7 +426,7 @@ func TestConsumeMetricsDoesNotOverwrite(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -472,7 +472,7 @@ func TestConsumeMetricsDoesNotOverwrite2(t *testing.T) {
 
 	var metricsOut pdata.Metrics
 
-	consumer := &mockConsumer{}
+	consumer := &mockMetricsConsumer{}
 	consumer.On("ConsumeMetrics", ctx, metrics).Run(func(args mock.Arguments) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
@@ -510,31 +510,26 @@ func TestConsumeMetricsDoesNotOverwrite2(t *testing.T) {
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
 
-type mockConsumer struct {
+type mockMetricsConsumer struct {
 	mock.Mock
 }
 
-func (m *mockConsumer) Start(ctx context.Context, host component.Host) error {
+func (m *mockMetricsConsumer) Start(ctx context.Context, host component.Host) error {
 	args := m.Called(ctx, host)
 	return args.Error(0)
 }
 
-func (m *mockConsumer) Capabilities() consumer.Capabilities {
+func (m *mockMetricsConsumer) Capabilities() consumer.Capabilities {
 	args := m.Called()
 	return args.Get(0).(consumer.Capabilities)
 }
 
-func (m *mockConsumer) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+func (m *mockMetricsConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
 	args := m.Called(ctx, md)
 	return args.Error(0)
 }
 
-func (m *mockConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {
-	args := m.Called(ctx, md)
-	return args.Error(0)
-}
-
-func (m *mockConsumer) Shutdown(ctx context.Context) error {
+func (m *mockMetricsConsumer) Shutdown(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
 }

--- a/processor/resourceattributetransposerprocessor/processor_metrics_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics_test.go
@@ -28,8 +28,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestProcessorStart(t *testing.T) {
-	p := newResourceAttributeTransposerProcessor(
+func TestMetricsProcessorStart(t *testing.T) {
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumertest.NewNop(),
 		createDefaultConfig().(*Config),
@@ -39,8 +39,8 @@ func TestProcessorStart(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestProcessorShutdown(t *testing.T) {
-	p := newResourceAttributeTransposerProcessor(
+func TestMetricsProcessorShutdown(t *testing.T) {
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumertest.NewNop(),
 		createDefaultConfig().(*Config),
@@ -50,8 +50,8 @@ func TestProcessorShutdown(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestProcessorCapabilities(t *testing.T) {
-	p := newResourceAttributeTransposerProcessor(
+func TestMetricsProcessorCapabilities(t *testing.T) {
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumertest.NewNop(),
 		createDefaultConfig().(*Config),
@@ -77,7 +77,7 @@ func TestConsumeMetricsNoop(t *testing.T) {
 		metricsOut = args[1].(pdata.Metrics)
 	}).Return(nil)
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		createDefaultConfig().(*Config),
@@ -140,7 +140,7 @@ func TestConsumeMetricsMoveExistingAttribs(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -186,7 +186,7 @@ func TestConsumeMetricsMoveToMultipleMetrics(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -237,7 +237,7 @@ func TestConsumeMetricsMixedExistence(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -278,7 +278,7 @@ func TestConsumeMetricsSum(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -319,7 +319,7 @@ func TestConsumeMetricsHistogram(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -360,7 +360,7 @@ func TestConsumeMetricsSummary(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -401,7 +401,7 @@ func TestConsumeMetricsNone(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -443,7 +443,7 @@ func TestConsumeMetricsDoesNotOverwrite(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -489,7 +489,7 @@ func TestConsumeMetricsDoesNotOverwrite2(t *testing.T) {
 		},
 	}
 
-	p := newResourceAttributeTransposerProcessor(
+	p := newMetricsProcessor(
 		zap.NewNop(),
 		consumer,
 		cfg,
@@ -522,6 +522,11 @@ func (m *mockConsumer) Start(ctx context.Context, host component.Host) error {
 func (m *mockConsumer) Capabilities() consumer.Capabilities {
 	args := m.Called()
 	return args.Get(0).(consumer.Capabilities)
+}
+
+func (m *mockConsumer) ConsumeLogs(ctx context.Context, md pdata.Logs) error {
+	args := m.Called(ctx, md)
+	return args.Error(0)
 }
 
 func (m *mockConsumer) ConsumeMetrics(ctx context.Context, md pdata.Metrics) error {


### PR DESCRIPTION
### Proposed Change
* Adds logs support to the resource attributes transposer

Also did a little refactoring to support this. 

We should consider deprecating this processor once https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor is considered ready for use in distributions.

Sample config:
```
receivers:
  filelog:
    include:
    - /Users/brandon/example.log
    start_at: beginning
    resource:
      log_type: app

processors:
  resourceattributetransposer:
    operations:
      - from: log_type
        to: log_type_2

exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    logs:
      receivers: [filelog]
      processors: [resourceattributetransposer]
      exporters: [logging]
  telemetry:
    metrics:
      level: none
```

Sample output:
```
2022-05-16T13:17:22.246-0400    DEBUG   loggingexporter/logging_exporter.go:81  ResourceLog #0
Resource SchemaURL: 
Resource labels:
     -> log_type: STRING(app)
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2022-05-16 17:17:22.145782 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: test
Attributes:
     -> log.file.name: STRING(example.log)
     -> log_type_2: STRING(app)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
