### PR TITLE
fix: Multi arch (amd64 / arm64) container image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -132,22 +132,6 @@ dockers:
       - "--label=title={{.ProjectName}}"
       - "--label=revision={{.FullCommit}}"
       - "--label=version={{.Version}}"
-  - goos: linux
-    goarch: arm64
-    ids:
-      - collector
-    image_templates:
-      - "observiq/observiq-otel-collector:latest"
-      - "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
-      - "observiq/observiq-otel-collector:{{ .Major }}"
-    dockerfile: ./Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--label=created={{.Date}}"
-      - "--label=title={{.ProjectName}}"
-      - "--label=revision={{.FullCommit}}"
-      - "--label=version={{.Version}}"
 
 # https://goreleaser.com/customization/checksum/
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,92 +27,92 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/observiq/observiq-otel-collector/internal/version.version=v{{ .Version }}
-      - -X github.com/observiq/observiq-otel-collector/internal/version.gitHash={{ .FullCommit }}
-      - -X github.com/observiq/observiq-otel-collector/internal/version.date={{ .Date }}
+      - -X github.com/bmedora/observiq-otel-collector/internal/version.version=v{{ .Version }}
+      - -X github.com/bmedora/observiq-otel-collector/internal/version.gitHash={{ .FullCommit }}
+      - -X github.com/bmedora/observiq-otel-collector/internal/version.date={{ .Date }}
     no_unique_dist_dir: false
 
 # https://goreleaser.com/customization/archive/
-archives:
-  - format: tar.gz
-    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-    files:
-      - LICENSE
-      - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
-        dst: "."
-        strip_parent: true
-      - src: release_deps/config.yaml
-        dst: "."
-        strip_parent: true
-      - src: release_deps/plugins/*
-        dst: plugins
-        strip_parent: true
+# archives:
+#   - format: tar.gz
+#     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+#     files:
+#       - LICENSE
+#       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
+#         dst: "."
+#         strip_parent: true
+#       - src: release_deps/config.yaml
+#         dst: "."
+#         strip_parent: true
+#       - src: release_deps/plugins/*
+#         dst: plugins
+#         strip_parent: true
 
-    format_overrides:
-      - goos: windows
-        format: zip
+#     format_overrides:
+#       - goos: windows
+#         format: zip
 
-nfpms:
-  - id: collector
-    file_name_template: "{{ .PackageName }}_{{ .Os }}_{{ .Arch }}"
-    package_name: observiq-otel-collector
-    vendor: observIQ, Inc
-    maintainer: observIQ <support@observiq.com>
-    description: observIQ's distribution of the OpenTelemetry collector
-    homepage: https://github.com/observIQ/observiq-otel-collector
-    license: Apache 2.0
-    formats:
-      - rpm
-      - deb
-    bindir: /opt/observiq-otel-collector
-    contents:
-      - dst: /opt/observiq-otel-collector
-        type: dir
-        file_info:
-          mode: 0755
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-      - src: release_deps/config.yaml
-        dst: /opt/observiq-otel-collector/config.yaml
-        file_info:
-          mode: 0640
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-        type: config|noreplace
-      - src: LICENSE
-        dst: /opt/observiq-otel-collector/LICENSE
-        file_info:
-          mode: 0644
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-      - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
-        dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-        file_info:
-          mode: 0755
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-      - dst: /opt/observiq-otel-collector/plugins
-        type: dir
-        file_info:
-          mode: 0750 # restrict plugins to owner / group only
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-      # Note: plugins owner/group/mode is set in the post-install script
-      # Attempting to set the permissions here results in the following error:
-      # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
-      - src: release_deps/plugins/*
-        dst: /opt/observiq-otel-collector/plugins
-      # Storage dir is used by stateful receivers, such as filelog receiver. It allows
-      # receivers to track their progress and buffer data.
-      - dst: /opt/observiq-otel-collector/storage
-        type: dir
-        file_info:
-          mode: 0750
-          owner: observiq-otel-collector
-          group: observiq-otel-collector
-    scripts:
-      preinstall: "./scripts/package/preinstall.sh"
-      postinstall: ./scripts/package/postinstall.sh
+# nfpms:
+#   - id: collector
+#     file_name_template: "{{ .PackageName }}_{{ .Os }}_{{ .Arch }}"
+#     package_name: observiq-otel-collector
+#     vendor: observIQ, Inc
+#     maintainer: observIQ <support@observiq.com>
+#     description: observIQ's distribution of the OpenTelemetry collector
+#     homepage: https://github.com/bmedora/observiq-otel-collector
+#     license: Apache 2.0
+#     formats:
+#       - rpm
+#       - deb
+#     bindir: /opt/observiq-otel-collector
+#     contents:
+#       - dst: /opt/observiq-otel-collector
+#         type: dir
+#         file_info:
+#           mode: 0755
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#       - src: release_deps/config.yaml
+#         dst: /opt/observiq-otel-collector/config.yaml
+#         file_info:
+#           mode: 0640
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#         type: config|noreplace
+#       - src: LICENSE
+#         dst: /opt/observiq-otel-collector/LICENSE
+#         file_info:
+#           mode: 0644
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
+#         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
+#         file_info:
+#           mode: 0755
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#       - dst: /opt/observiq-otel-collector/plugins
+#         type: dir
+#         file_info:
+#           mode: 0750 # restrict plugins to owner / group only
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#       # Note: plugins owner/group/mode is set in the post-install script
+#       # Attempting to set the permissions here results in the following error:
+#       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
+#       - src: release_deps/plugins/*
+#         dst: /opt/observiq-otel-collector/plugins
+#       # Storage dir is used by stateful receivers, such as filelog receiver. It allows
+#       # receivers to track their progress and buffer data.
+#       - dst: /opt/observiq-otel-collector/storage
+#         type: dir
+#         file_info:
+#           mode: 0750
+#           owner: observiq-otel-collector
+#           group: observiq-otel-collector
+#     scripts:
+#       preinstall: "./scripts/package/preinstall.sh"
+#       postinstall: ./scripts/package/postinstall.sh
 
 # Build container images with docker buildx (mutli arch builds)
 dockers:
@@ -121,10 +121,10 @@ dockers:
     ids:
       - collector
     image_templates:
-      - "observiq/observiq-otel-collector:latest"
-      - "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
-      - "observiq/observiq-otel-collector:{{ .Major }}"
+      - "bmedora/observiq-otel-collector-amd64:latest"
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}"
     dockerfile: ./Dockerfile
     use: buildx
     build_flag_templates:
@@ -132,127 +132,167 @@ dockers:
       - "--label=title={{.ProjectName}}"
       - "--label=revision={{.FullCommit}}"
       - "--label=version={{.Version}}"
+      - "--platform=linux/amd64"
+  - goos: linux
+    goarch: arm64
+    ids:
+      - collector
+    image_templates:
+      - "bmedora/observiq-otel-collector-arm64:latest"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}"
+    dockerfile: ./Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--label=created={{.Date}}"
+      - "--label=title={{.ProjectName}}"
+      - "--label=revision={{.FullCommit}}"
+      - "--label=version={{.Version}}"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "bmedora/observiq-otel-collector:latest"
+    image_templates:
+      - "bmedora/observiq-otel-collector-amd64:latest"
+      - "bmedora/observiq-otel-collector-arm64:latest"
+    skip_push: false
+  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    skip_push: false
+  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+    skip_push: false
+  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}"
+    image_templates:
+      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}"
+      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}"
+    skip_push: false
 
 # https://goreleaser.com/customization/checksum/
-checksum:
-  name_template: "{{ .ProjectName }}-v{{ .Version }}-SHA256SUMS"
-  algorithm: sha256
+# checksum:
+#   name_template: "{{ .ProjectName }}-v{{ .Version }}-SHA256SUMS"
+#   algorithm: sha256
 
-# https://goreleaser.com/customization/sign/
-signs:
-  - cmd: cosign
-    stdin: "{{ .Env.COSIGN_PWD }}"
-    args:
-      ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
-    artifacts: all
+# # https://goreleaser.com/customization/sign/
+# signs:
+#   - cmd: cosign
+#     stdin: "{{ .Env.COSIGN_PWD }}"
+#     args:
+#       ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+#     artifacts: all
 
 # https://goreleaser.com/customization/release/
-release:
-  draft: false
-  extra_files:
-    - glob: "./observiq-otel-collector*.msi"
-    - glob: "./scripts/install/install_unix.sh"
-    - glob: "./scripts/install/install_macos.sh"
+# release:
+#   draft: false
+#   extra_files:
+#     - glob: "./observiq-otel-collector*.msi"
+#     - glob: "./scripts/install/install_unix.sh"
+#     - glob: "./scripts/install/install_macos.sh"
 
 # https://goreleaser.com/customization/changelog/
-changelog:
-  skip: false
-  use: github
-  sort: asc
-  groups:
-    - title: "New Features"
-      regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 0
-    - title: "Bug Fixes"
-      regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
-    - title: "Dependencies"
-      regexp: "^.*deps[(\\w)]*:+.*$"
-      order: 30
-    - title: Other
-      order: 999
+# changelog:
+#   skip: false
+#   use: github
+#   sort: asc
+#   groups:
+#     - title: "New Features"
+#       regexp: "^.*feat[(\\w)]*:+.*$"
+#       order: 0
+#     - title: "Bug Fixes"
+#       regexp: "^.*fix[(\\w)]*:+.*$"
+#       order: 10
+#     - title: "Dependencies"
+#       regexp: "^.*deps[(\\w)]*:+.*$"
+#       order: 30
+#     - title: Other
+#       order: 999
 
 # https://goreleaser.com/customization/homebrew/
-brews:
-  - name: observiq-otel-collector
-    tap:
-      owner: observIQ
-      name: homebrew-observiq-otel-collector
-      branch: main
-    download_strategy: CurlDownloadStrategy
-    folder: Formula
-    url_template: https://github.com/observIQ/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
-    commit_author:
-      name: observiq
-      email: support@observiq.com
-    homepage: "https://github.com/observIQ/observiq-otel-collector"
-    license: "Apache 2.0"
-    caveats: |
-      ****************************************************************
-      The configuration file that is run by the service is located at #{prefix}/config.yaml.
+# brews:
+#   - name: observiq-otel-collector
+#     tap:
+#       owner: observIQ
+#       name: homebrew-observiq-otel-collector
+#       branch: main
+#     download_strategy: CurlDownloadStrategy
+#     folder: Formula
+#     url_template: https://github.com/bmedora/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
+#     commit_author:
+#       name: observiq
+#       email: support@observiq.com
+#     homepage: "https://github.com/bmedora/observiq-otel-collector"
+#     license: "Apache 2.0"
+#     caveats: |
+#       ****************************************************************
+#       The configuration file that is run by the service is located at #{prefix}/config.yaml.
 
-      If you are configuring a logreceiver the plugin directory is located at #{prefix}/plugins.
-      ****************************************************************
+#       If you are configuring a logreceiver the plugin directory is located at #{prefix}/plugins.
+#       ****************************************************************
 
-      ****************************************************************
-      Below are services commands to run to manage the collector service.
-      If you wish to run the collector at boot prefix these commands with sudo
-      otherwise the service will run at login.
+#       ****************************************************************
+#       Below are services commands to run to manage the collector service.
+#       If you wish to run the collector at boot prefix these commands with sudo
+#       otherwise the service will run at login.
 
-      To start the collector service run:
+#       To start the collector service run:
 
-        brew services start observiq/observiq-otel-collector/observiq-otel-collector
+#         brew services start bmedora/observiq-otel-collector/observiq-otel-collector
 
-      To stop the collector service run:
+#       To stop the collector service run:
 
-        brew services stop observiq/observiq-otel-collector/observiq-otel-collector
+#         brew services stop bmedora/observiq-otel-collector/observiq-otel-collector
 
-      To restart the collector service run:
+#       To restart the collector service run:
 
-        brew services restart observiq/observiq-otel-collector/observiq-otel-collector
-      ****************************************************************
+#         brew services restart bmedora/observiq-otel-collector/observiq-otel-collector
+#       ****************************************************************
 
-      ****************************************************************
-      To uninstall the collector and its dependencies run the following commands:
+#       ****************************************************************
+#       To uninstall the collector and its dependencies run the following commands:
 
-          brew services stop observiq/observiq-otel-collector/observiq-otel-collector
-          brew uninstall observiq/observiq-otel-collector/observiq-otel-collector
-          launchctl remove com.observiq.collector
+#           brew services stop bmedora/observiq-otel-collector/observiq-otel-collector
+#           brew uninstall bmedora/observiq-otel-collector/observiq-otel-collector
+#           launchctl remove com.observiq.collector
 
-          # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
-          sudo rm /opt/opentelemetry-java-contrib-jmx-metrics.jar
+#           # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
+#           sudo rm /opt/opentelemetry-java-contrib-jmx-metrics.jar
 
-      ****************************************************************
-    install: |
-      bin.install "observiq-otel-collector"
-      prefix.install "LICENSE", "config.yaml"
-      prefix.install Dir["plugins"]
-      lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
-    plist: |
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
+#       ****************************************************************
+#     install: |
+#       bin.install "observiq-otel-collector"
+#       prefix.install "LICENSE", "config.yaml"
+#       prefix.install Dir["plugins"]
+#       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
+#     plist: |
+#       <?xml version="1.0" encoding="UTF-8"?>
+#       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+#       <plist version="1.0">
+#         <dict>
 
-          <key>Label</key>
-          <string>com.observiq.collector</string>
+#           <key>Label</key>
+#           <string>com.observiq.collector</string>
 
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{bin}/observiq-otel-collector</string>
-            <string>--config</string>
-            <string>#{prefix}/config.yaml</string>
-          </array>
+#           <key>ProgramArguments</key>
+#           <array>
+#             <string>#{bin}/observiq-otel-collector</string>
+#             <string>--config</string>
+#             <string>#{prefix}/config.yaml</string>
+#           </array>
 
-          <key>RunAtLoad</key>
-          <true/>
+#           <key>RunAtLoad</key>
+#           <true/>
 
-          <key>StandardErrorPath</key>
-          <string>/tmp/observiq-otel-collector.log</string>
+#           <key>StandardErrorPath</key>
+#           <string>/tmp/observiq-otel-collector.log</string>
 
-          <key>StandardOutPath</key>
-          <string>/tmp/observiq-otel-collector.log</string>
-        </dict>
-      </plist>
-    # For local testing
-    # skip_upload: "true"
+#           <key>StandardOutPath</key>
+#           <string>/tmp/observiq-otel-collector.log</string>
+#         </dict>
+#       </plist>
+#     # For local testing
+#     # skip_upload: "true"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,7 +59,7 @@ nfpms:
     vendor: observIQ, Inc
     maintainer: observIQ <support@observiq.com>
     description: observIQ's distribution of the OpenTelemetry collector
-    homepage: https://github.com/observiq/observiq-otel-collector
+    homepage: https://github.com/observIQ/observiq-otel-collector
     license: Apache 2.0
     formats:
       - rpm

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -178,7 +178,7 @@ checksum:
   name_template: "{{ .ProjectName }}-v{{ .Version }}-SHA256SUMS"
   algorithm: sha256
 
-# # https://goreleaser.com/customization/sign/
+# https://goreleaser.com/customization/sign/
 signs:
   - cmd: cosign
     stdin: "{{ .Env.COSIGN_PWD }}"
@@ -221,11 +221,11 @@ brews:
       branch: main
     download_strategy: CurlDownloadStrategy
     folder: Formula
-    url_template: https://github.com/observiq/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
+    url_template: https://github.com/observIQ/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
     commit_author:
       name: observiq
       email: support@observiq.com
-    homepage: "https://github.com/observiq/observiq-otel-collector"
+    homepage: "https://github.com/observIQ/observiq-otel-collector"
     license: "Apache 2.0"
     caveats: |
       ****************************************************************

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,92 +27,92 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/bmedora/observiq-otel-collector/internal/version.version=v{{ .Version }}
-      - -X github.com/bmedora/observiq-otel-collector/internal/version.gitHash={{ .FullCommit }}
-      - -X github.com/bmedora/observiq-otel-collector/internal/version.date={{ .Date }}
+      - -X github.com/observiq/observiq-otel-collector/internal/version.version=v{{ .Version }}
+      - -X github.com/observiq/observiq-otel-collector/internal/version.gitHash={{ .FullCommit }}
+      - -X github.com/observiq/observiq-otel-collector/internal/version.date={{ .Date }}
     no_unique_dist_dir: false
 
 # https://goreleaser.com/customization/archive/
-# archives:
-#   - format: tar.gz
-#     name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
-#     files:
-#       - LICENSE
-#       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
-#         dst: "."
-#         strip_parent: true
-#       - src: release_deps/config.yaml
-#         dst: "."
-#         strip_parent: true
-#       - src: release_deps/plugins/*
-#         dst: plugins
-#         strip_parent: true
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    files:
+      - LICENSE
+      - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
+        dst: "."
+        strip_parent: true
+      - src: release_deps/config.yaml
+        dst: "."
+        strip_parent: true
+      - src: release_deps/plugins/*
+        dst: plugins
+        strip_parent: true
 
-#     format_overrides:
-#       - goos: windows
-#         format: zip
+    format_overrides:
+      - goos: windows
+        format: zip
 
-# nfpms:
-#   - id: collector
-#     file_name_template: "{{ .PackageName }}_{{ .Os }}_{{ .Arch }}"
-#     package_name: observiq-otel-collector
-#     vendor: observIQ, Inc
-#     maintainer: observIQ <support@observiq.com>
-#     description: observIQ's distribution of the OpenTelemetry collector
-#     homepage: https://github.com/bmedora/observiq-otel-collector
-#     license: Apache 2.0
-#     formats:
-#       - rpm
-#       - deb
-#     bindir: /opt/observiq-otel-collector
-#     contents:
-#       - dst: /opt/observiq-otel-collector
-#         type: dir
-#         file_info:
-#           mode: 0755
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#       - src: release_deps/config.yaml
-#         dst: /opt/observiq-otel-collector/config.yaml
-#         file_info:
-#           mode: 0640
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#         type: config|noreplace
-#       - src: LICENSE
-#         dst: /opt/observiq-otel-collector/LICENSE
-#         file_info:
-#           mode: 0644
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#       - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
-#         dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-#         file_info:
-#           mode: 0755
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#       - dst: /opt/observiq-otel-collector/plugins
-#         type: dir
-#         file_info:
-#           mode: 0750 # restrict plugins to owner / group only
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#       # Note: plugins owner/group/mode is set in the post-install script
-#       # Attempting to set the permissions here results in the following error:
-#       # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
-#       - src: release_deps/plugins/*
-#         dst: /opt/observiq-otel-collector/plugins
-#       # Storage dir is used by stateful receivers, such as filelog receiver. It allows
-#       # receivers to track their progress and buffer data.
-#       - dst: /opt/observiq-otel-collector/storage
-#         type: dir
-#         file_info:
-#           mode: 0750
-#           owner: observiq-otel-collector
-#           group: observiq-otel-collector
-#     scripts:
-#       preinstall: "./scripts/package/preinstall.sh"
-#       postinstall: ./scripts/package/postinstall.sh
+nfpms:
+  - id: collector
+    file_name_template: "{{ .PackageName }}_{{ .Os }}_{{ .Arch }}"
+    package_name: observiq-otel-collector
+    vendor: observIQ, Inc
+    maintainer: observIQ <support@observiq.com>
+    description: observIQ's distribution of the OpenTelemetry collector
+    homepage: https://github.com/observiq/observiq-otel-collector
+    license: Apache 2.0
+    formats:
+      - rpm
+      - deb
+    bindir: /opt/observiq-otel-collector
+    contents:
+      - dst: /opt/observiq-otel-collector
+        type: dir
+        file_info:
+          mode: 0755
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+      - src: release_deps/config.yaml
+        dst: /opt/observiq-otel-collector/config.yaml
+        file_info:
+          mode: 0640
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+        type: config|noreplace
+      - src: LICENSE
+        dst: /opt/observiq-otel-collector/LICENSE
+        file_info:
+          mode: 0644
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+      - src: release_deps/opentelemetry-java-contrib-jmx-metrics.jar
+        dst: /opt/opentelemetry-java-contrib-jmx-metrics.jar
+        file_info:
+          mode: 0755
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+      - dst: /opt/observiq-otel-collector/plugins
+        type: dir
+        file_info:
+          mode: 0750 # restrict plugins to owner / group only
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+      # Note: plugins owner/group/mode is set in the post-install script
+      # Attempting to set the permissions here results in the following error:
+      # nfpm failed: cannot write header of release_deps/plugins/amazon_eks.yaml to data.tar.gz: archive/tar: missed writing 1736 bytes
+      - src: release_deps/plugins/*
+        dst: /opt/observiq-otel-collector/plugins
+      # Storage dir is used by stateful receivers, such as filelog receiver. It allows
+      # receivers to track their progress and buffer data.
+      - dst: /opt/observiq-otel-collector/storage
+        type: dir
+        file_info:
+          mode: 0750
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
+    scripts:
+      preinstall: "./scripts/package/preinstall.sh"
+      postinstall: ./scripts/package/postinstall.sh
 
 # Build container images with docker buildx (mutli arch builds)
 dockers:
@@ -121,10 +121,10 @@ dockers:
     ids:
       - collector
     image_templates:
-      - "bmedora/observiq-otel-collector-amd64:latest"
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}"
+      - "observiq/observiq-otel-collector-amd64:latest"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}"
     dockerfile: ./Dockerfile
     use: buildx
     build_flag_templates:
@@ -138,10 +138,10 @@ dockers:
     ids:
       - collector
     image_templates:
-      - "bmedora/observiq-otel-collector-arm64:latest"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}"
+      - "observiq/observiq-otel-collector-arm64:latest"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}"
     dockerfile: ./Dockerfile
     use: buildx
     build_flag_templates:
@@ -152,147 +152,147 @@ dockers:
       - "--platform=linux/arm64"
 
 docker_manifests:
-  - name_template: "bmedora/observiq-otel-collector:latest"
+  - name_template: "observiq/observiq-otel-collector:latest"
     image_templates:
-      - "bmedora/observiq-otel-collector-amd64:latest"
-      - "bmedora/observiq-otel-collector-arm64:latest"
+      - "observiq/observiq-otel-collector-amd64:latest"
+      - "observiq/observiq-otel-collector-arm64:latest"
     skip_push: false
-  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+  - name_template: "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     image_templates:
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
     skip_push: false
-  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
+  - name_template: "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
     image_templates:
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
     skip_push: false
-  - name_template: "bmedora/observiq-otel-collector:{{ .Major }}"
+  - name_template: "observiq/observiq-otel-collector:{{ .Major }}"
     image_templates:
-      - "bmedora/observiq-otel-collector-amd64:{{ .Major }}"
-      - "bmedora/observiq-otel-collector-arm64:{{ .Major }}"
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}"
     skip_push: false
 
 # https://goreleaser.com/customization/checksum/
-# checksum:
-#   name_template: "{{ .ProjectName }}-v{{ .Version }}-SHA256SUMS"
-#   algorithm: sha256
+checksum:
+  name_template: "{{ .ProjectName }}-v{{ .Version }}-SHA256SUMS"
+  algorithm: sha256
 
 # # https://goreleaser.com/customization/sign/
-# signs:
-#   - cmd: cosign
-#     stdin: "{{ .Env.COSIGN_PWD }}"
-#     args:
-#       ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
-#     artifacts: all
+signs:
+  - cmd: cosign
+    stdin: "{{ .Env.COSIGN_PWD }}"
+    args:
+      ["sign-blob", "--key=cosign.key", "--output=${signature}", "${artifact}"]
+    artifacts: all
 
 # https://goreleaser.com/customization/release/
-# release:
-#   draft: false
-#   extra_files:
-#     - glob: "./observiq-otel-collector*.msi"
-#     - glob: "./scripts/install/install_unix.sh"
-#     - glob: "./scripts/install/install_macos.sh"
+release:
+  draft: false
+  extra_files:
+    - glob: "./observiq-otel-collector*.msi"
+    - glob: "./scripts/install/install_unix.sh"
+    - glob: "./scripts/install/install_macos.sh"
 
 # https://goreleaser.com/customization/changelog/
-# changelog:
-#   skip: false
-#   use: github
-#   sort: asc
-#   groups:
-#     - title: "New Features"
-#       regexp: "^.*feat[(\\w)]*:+.*$"
-#       order: 0
-#     - title: "Bug Fixes"
-#       regexp: "^.*fix[(\\w)]*:+.*$"
-#       order: 10
-#     - title: "Dependencies"
-#       regexp: "^.*deps[(\\w)]*:+.*$"
-#       order: 30
-#     - title: Other
-#       order: 999
+changelog:
+  skip: false
+  use: github
+  sort: asc
+  groups:
+    - title: "New Features"
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 10
+    - title: "Dependencies"
+      regexp: "^.*deps[(\\w)]*:+.*$"
+      order: 30
+    - title: Other
+      order: 999
 
 # https://goreleaser.com/customization/homebrew/
-# brews:
-#   - name: observiq-otel-collector
-#     tap:
-#       owner: observIQ
-#       name: homebrew-observiq-otel-collector
-#       branch: main
-#     download_strategy: CurlDownloadStrategy
-#     folder: Formula
-#     url_template: https://github.com/bmedora/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
-#     commit_author:
-#       name: observiq
-#       email: support@observiq.com
-#     homepage: "https://github.com/bmedora/observiq-otel-collector"
-#     license: "Apache 2.0"
-#     caveats: |
-#       ****************************************************************
-#       The configuration file that is run by the service is located at #{prefix}/config.yaml.
+brews:
+  - name: observiq-otel-collector
+    tap:
+      owner: observIQ
+      name: homebrew-observiq-otel-collector
+      branch: main
+    download_strategy: CurlDownloadStrategy
+    folder: Formula
+    url_template: https://github.com/observiq/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
+    commit_author:
+      name: observiq
+      email: support@observiq.com
+    homepage: "https://github.com/observiq/observiq-otel-collector"
+    license: "Apache 2.0"
+    caveats: |
+      ****************************************************************
+      The configuration file that is run by the service is located at #{prefix}/config.yaml.
 
-#       If you are configuring a logreceiver the plugin directory is located at #{prefix}/plugins.
-#       ****************************************************************
+      If you are configuring a logreceiver the plugin directory is located at #{prefix}/plugins.
+      ****************************************************************
 
-#       ****************************************************************
-#       Below are services commands to run to manage the collector service.
-#       If you wish to run the collector at boot prefix these commands with sudo
-#       otherwise the service will run at login.
+      ****************************************************************
+      Below are services commands to run to manage the collector service.
+      If you wish to run the collector at boot prefix these commands with sudo
+      otherwise the service will run at login.
 
-#       To start the collector service run:
+      To start the collector service run:
 
-#         brew services start bmedora/observiq-otel-collector/observiq-otel-collector
+        brew services start observiq/observiq-otel-collector/observiq-otel-collector
 
-#       To stop the collector service run:
+      To stop the collector service run:
 
-#         brew services stop bmedora/observiq-otel-collector/observiq-otel-collector
+        brew services stop observiq/observiq-otel-collector/observiq-otel-collector
 
-#       To restart the collector service run:
+      To restart the collector service run:
 
-#         brew services restart bmedora/observiq-otel-collector/observiq-otel-collector
-#       ****************************************************************
+        brew services restart observiq/observiq-otel-collector/observiq-otel-collector
+      ****************************************************************
 
-#       ****************************************************************
-#       To uninstall the collector and its dependencies run the following commands:
+      ****************************************************************
+      To uninstall the collector and its dependencies run the following commands:
 
-#           brew services stop bmedora/observiq-otel-collector/observiq-otel-collector
-#           brew uninstall bmedora/observiq-otel-collector/observiq-otel-collector
-#           launchctl remove com.observiq.collector
+          brew services stop observiq/observiq-otel-collector/observiq-otel-collector
+          brew uninstall observiq/observiq-otel-collector/observiq-otel-collector
+          launchctl remove com.observiq.collector
 
-#           # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
-#           sudo rm /opt/opentelemetry-java-contrib-jmx-metrics.jar
+          # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
+          sudo rm /opt/opentelemetry-java-contrib-jmx-metrics.jar
 
-#       ****************************************************************
-#     install: |
-#       bin.install "observiq-otel-collector"
-#       prefix.install "LICENSE", "config.yaml"
-#       prefix.install Dir["plugins"]
-#       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
-#     plist: |
-#       <?xml version="1.0" encoding="UTF-8"?>
-#       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-#       <plist version="1.0">
-#         <dict>
+      ****************************************************************
+    install: |
+      bin.install "observiq-otel-collector"
+      prefix.install "LICENSE", "config.yaml"
+      prefix.install Dir["plugins"]
+      lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
+    plist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
 
-#           <key>Label</key>
-#           <string>com.observiq.collector</string>
+          <key>Label</key>
+          <string>com.observiq.collector</string>
 
-#           <key>ProgramArguments</key>
-#           <array>
-#             <string>#{bin}/observiq-otel-collector</string>
-#             <string>--config</string>
-#             <string>#{prefix}/config.yaml</string>
-#           </array>
+          <key>ProgramArguments</key>
+          <array>
+            <string>#{bin}/observiq-otel-collector</string>
+            <string>--config</string>
+            <string>#{prefix}/config.yaml</string>
+          </array>
 
-#           <key>RunAtLoad</key>
-#           <true/>
+          <key>RunAtLoad</key>
+          <true/>
 
-#           <key>StandardErrorPath</key>
-#           <string>/tmp/observiq-otel-collector.log</string>
+          <key>StandardErrorPath</key>
+          <string>/tmp/observiq-otel-collector.log</string>
 
-#           <key>StandardOutPath</key>
-#           <string>/tmp/observiq-otel-collector.log</string>
-#         </dict>
-#       </plist>
-#     # For local testing
-#     # skip_upload: "true"
+          <key>StandardOutPath</key>
+          <string>/tmp/observiq-otel-collector.log</string>
+        </dict>
+      </plist>
+    # For local testing
+    # skip_upload: "true"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Updated the image tags to include their arch, added image manifest using the original image tag. This should result in multi arch images.

I tested using the `bmedora` account, you can see the pushed image (with multi arch) [here](https://hub.docker.com/layers/observiq-otel-collector/bmedora/observiq-otel-collector/latest/images/sha256-280a9cb91b018932084f94800d910e0adbb2092061073e9bd4799e2e02e9d2bb?context=explore). 

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
