### PR TITLE
Update container base image to v1.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM openjdk:8u312-slim-buster as openjdk
 
 # Final Stage
 #
-FROM gcr.io/observiq-container-images/stanza-base:v1.2.0
+FROM gcr.io/observiq-container-images/stanza-base:v1.2.2
 WORKDIR /
 
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

[Stanza Base Image](https://github.com/observIQ/stanza-base-image/releases/tag/v1.2.2) was updated today to fix an issue where the released image did not include the required packages (systemd, ca-certificates, tzdata). This PR updates the observiq-otel-collector's Dockerfile to use the latest base image.

The purpose of the base image is to ensure the required packages are pinned to recent / latest versions. In the past, we have observed the repo's giving us old versions of a package. It also cuts down on this repo's Dockerfile complexity.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
