### PR TITLE
fix: Fixes environment variable replacement in configs not working

### DIFF
--- a/collector/settings.go
+++ b/collector/settings.go
@@ -20,6 +20,7 @@ import (
 	"github.com/observiq/observiq-otel-collector/factories"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/mapconverter/expandmapconverter"
 	"go.opentelemetry.io/collector/config/mapprovider/filemapprovider"
 	"go.opentelemetry.io/collector/service"
 	"go.uber.org/zap"
@@ -40,7 +41,7 @@ func NewSettings(configPaths []string, version string, loggingOpts []zap.Option)
 	configProviderSettings := service.ConfigProviderSettings{
 		Locations:     configPaths,
 		MapProviders:  map[string]config.MapProvider{fmp.Scheme(): fmp},
-		MapConverters: make([]config.MapConverterFunc, 0),
+		MapConverters: []config.MapConverterFunc{expandmapconverter.New()},
 		Unmarshaler:   nil,
 	}
 	provider, err := service.NewConfigProvider(configProviderSettings)

--- a/collector/test/valid_with_env_var.yaml
+++ b/collector/test/valid_with_env_var.yaml
@@ -1,0 +1,13 @@
+receivers:
+  filelog:
+    include: 
+      - ${FILE}
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    logs:
+      receivers: [filelog]
+      exporters: [nop]


### PR DESCRIPTION
### Proposed Change
Fixes the environment variable replacement in configs not working that was broken when updating the otel collector to v0.50.0.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

##### New Unit Test Before Fix
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/12396806/169140043-c8cce209-51b7-46f5-b39f-abbd794daca6.png">

##### New Unit Test After Fix
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/12396806/169139812-18fbb754-fceb-4810-b050-c775ba58e945.png">
