### PR TITLE
feat: Include plugins with container image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,6 +142,8 @@ dockers:
       - "--label=revision={{.FullCommit}}"
       - "--label=version={{.Version}}"
       - "--platform=linux/amd64"
+    extra_files:
+      - plugins
   - goos: linux
     goarch: arm64
     ids:
@@ -159,6 +161,8 @@ dockers:
       - "--label=revision={{.FullCommit}}"
       - "--label=version={{.Version}}"
       - "--platform=linux/arm64"
+    extra_files:
+      - plugins
 
 docker_manifests:
   - name_template: "observiq/observiq-otel-collector:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ ENV PATH=$PATH:/usr/local/openjdk-8/bin
 
 COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY plugins /etc/otel/plugins
 
 RUN adduser \
     --disabled-password \


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

In order to leverage plugins within a container, we need to bundle them. I decided to place them at `/etc/otel/plugins`, as the config already lives in `/etc/otel/config.yaml`. 

After building the image:
```bash
docker run -it -u root --entrypoint ls observiq/observiq-otel-collector-amd64:latest /etc/otel/plugins

apache_common_logs.yaml  mongodb_logs.yaml     rabbitmq_logs.yaml
couchdb_logs.yaml	 mysql_logs.yaml       redis_logs.yaml
elasticsearch_logs.yaml  nginx_logs.yaml       syslog_logs.yaml
haproxy_logs.yaml	 pgbouncer_logs.yaml
ingress_nginx_logs.yaml  postgresql_logs.yaml
```
```
docker run -it -u root --entrypoint head observiq/observiq-otel-collector-amd64:latest /etc/otel/plugins/haproxy_logs.yaml

version: 0.0.1
title: HAProxy
description: Log parser for HAProxy
parameters:
  - name: file_path
    type: "[]string"
    default:
      - "/var/log/haproxy/haproxy.log"
  - name: start_at
    type: string
```

##### Checklist
- [x] Changes are tested
- [x] CI has passed
