### PR TITLE
feat:(install): Linux Install Script url flag works as intended

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -340,12 +340,15 @@ set_download_urls()
 
   if [ -z "$url" ] ; then
     url=$DOWNLOAD_BASE
-  fi
 
-  if [ -z "$version" ] ; then
-    collector_download_url="$url/latest/download/${PACKAGE_NAME}_${os_arch}.${package_type}"
+    # Only if we're using the base download url apply version formatting
+    if [ -z "$version" ] ; then
+      collector_download_url="$url/latest/download/${PACKAGE_NAME}_${os_arch}.${package_type}"
+    else
+      collector_download_url="$url/download/v$version/${PACKAGE_NAME}_${os_arch}.${package_type}"
+    fi
   else
-    collector_download_url="$url/download/v$version/${PACKAGE_NAME}_${os_arch}.${package_type}"
+    collector_download_url="$url"
   fi
 }
 


### PR DESCRIPTION
### Proposed Change
Changed the `url` flag on the `install_unix.sh` script to not apply version suffix if specified. This matches what the help message said before.

Tested with the following case:
- `url` set
- `url` not set `version` not set
- `url` not set `version` set

All cases produced the expected URL for download.

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
