### PR TITLE
feat(release): Added prerelease tag to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -212,6 +212,9 @@ signs:
 # https://goreleaser.com/customization/release/
 release:
   draft: false
+
+  # publish to a prerelease first
+  prerelease: "true"
   extra_files:
     - glob: "./observiq-otel-collector*.msi"
     - glob: "./scripts/install/install_unix.sh"


### PR DESCRIPTION
### Proposed Change
Per the goreleaser [docs](https://goreleaser.com/customization/release/)

```yaml
  # If set to auto, will mark the release as not ready for production
  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
  # If set to true, will mark the release as not ready for production.
  # Default is false.
  prerelease: auto
```

I added the `prerelease` key set to `"true"`. This is to better facilitate the release process and post release testing before we fully publish a release.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
