### PR TITLE
fix: Fix manager.yaml not being generated if installing user was not admin

### DIFF
--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -186,14 +186,14 @@
               Value="&quot;[POWERSHELLEXE]&quot; -ExecutionPolicy Bypass -NoProfile -Command &quot;&amp; '[INSTALLDIR]install\generate-manager-yaml.ps1' -install_dir '[INSTALLDIR]' -endpoint '[OPAMPENDPOINT]' -secret_key '[OPAMPSECRETKEY]' -labels '[OPAMPLABELS]'&quot;"
               Execute="immediate"/>
 
-      <CustomAction Id="CustomExecCreateManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="yes" Return="check" />
+      <CustomAction Id="CustomExecCreateManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="check" />
 
       <CustomAction Id="CustomExecRemoveManagerYaml_set"
               Property="CustomExecRemoveManagerYaml"
               Value="&quot;[POWERSHELLEXE]&quot; -ExecutionPolicy Bypass -NoProfile -Command &quot;Remove-Item -Force -ErrorAction Continue -Path '[INSTALLDIR]manager.yaml'&quot;"
               Execute="immediate"/>
 
-      <CustomAction Id="CustomExecRemoveManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="yes" Return="ignore" />
+      <CustomAction Id="CustomExecRemoveManagerYaml" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
 
       <InstallExecuteSequence>
          {{range $i, $h := .Hooks}}


### PR DESCRIPTION
### Proposed Change
* Run the custom actions with elevated privileges to create/delete manager.yaml

If the user who ran the installer was not an admin, but could elevate to admin privileges, manager.yaml would fail to create. This change will let the CustomAction be run as .\LocalSystem, which has the privileges needed to properly create the file.

See the Impersonate option here:
https://wixtoolset.org/documentation/manual/v3/xsd/wix/customaction.html

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
