### PR TITLE
feat: Updates docs with human readable names for components

### DIFF
--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -2,30 +2,31 @@
 
 Below is a list of supported exports with links to their documentation pages.
 
-- [alibabacloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/alibabacloudlogserviceexporter/README.md)
-- [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awscloudwatchlogsexporter/README.md)
-- [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsemfexporter/README.md)
-- [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awskinesisexporter/README.md)
-- [awsprometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsprometheusremotewriteexporter/README.md)
-- [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsxrayexporter/README.md)
-- [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/azuremonitorexporter/README.md)
-- [carbonexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/carbonexporter/README.md)
-- [componenttest](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/component/componenttest)
-- [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/elasticsearchexporter/README.md)
-- [f5cloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/f5cloudexporter/README.md)
-- [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/fileexporter/README.md)
-- [googlecloudexporter](../exporter/googlecloudexporter/README.md)
-- [googlecloudpubsubexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/googlecloudpubsubexporter/README.md)
-- [influxdbexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/influxdbexporter/README.md)
-- [jaegerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/jaegerexporter/README.md)
-- [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/kafkaexporter/README.md)
-- [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/loadbalancingexporter/README.md)
-- [loggingexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/loggingexporter/README.md)
-- [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/lokiexporter/README.md)
-- [observiqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/observiqexporter/README.md)
-- [opencensusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/opencensusexporter/README.md)
-- [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlpexporter/README.md)
-- [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlphttpexporter/README.md)
-- [prometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusexporter/README.md)
-- [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusremotewriteexporter/README.md)
-- [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/zipkinexporter/README.md)
+| Name                                     | GitHub README |
+| ---------------------------------------- | ------------- |
+| Alibaba Cloud Log Service Exporter       | [alibabacloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/alibabacloudlogserviceexporter/README.md) |
+| AWS CloudWatch Logs Exporter             | [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awscloudwatchlogsexporter/README.md) |
+| AWS CloudWatch EMF Exporter              | [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsemfexporter/README.md) |
+| AWS Kinesis Exporter                     | [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awskinesisexporter/README.md) |
+| AWS Prometheus Remote Write Exporter     | [awsprometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsprometheusremotewriteexporter/README.md) |
+| AWS X-Ray Tracing Exporter               | [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsxrayexporter/README.md) |
+| Azure Monitor Exporter                   | [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/azuremonitorexporter/README.md) |
+| Carbon Exporter                          | [carbonexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/carbonexporter/README.md) |
+| Elasticsearch Exporter                   | [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/elasticsearchexporter/README.md) |
+| F5 Cloud Exporter                        | [f5cloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/f5cloudexporter/README.md) |
+| File Exporter                            | [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/fileexporter/README.md) |
+| Google Cloud Exporter                    | [googlecloudexporter](../exporter/googlecloudexporter/README.md) |
+| Google Cloud Pub/Sub Exporter            | [googlecloudpubsubexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/googlecloudpubsubexporter/README.md) |
+| InfluxDB Exporter                        | [influxdbexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/influxdbexporter/README.md) |
+| Jaeger gRPC Exporter                     | [jaegerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/jaegerexporter/README.md) |
+| Kafka Exporter                           | [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/kafkaexporter/README.md) |
+| Load-Balancing (Trace ID Aware) Exporter | [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/loadbalancingexporter/README.md) |
+| Logging Exporter                         | [loggingexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/loggingexporter/README.md) |
+| Loki Exporter                            | [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/lokiexporter/README.md) |
+| observIQ Exporter                        | [observiqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/observiqexporter/README.md) |
+| OpenCensus gRPC Exporter                 | [opencensusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/opencensusexporter/README.md) |
+| OTLP gRPC Exporter                       | [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlpexporter/README.md) |
+| OTLP HTTP Exporter                       | [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlphttpexporter/README.md) |
+| Prometheus Exporter                      | [prometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusexporter/README.md) |
+| Prometheus Remote Write Exporter         | [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusremotewriteexporter/README.md) |
+| Zipkin Exporter                          | [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/zipkinexporter/README.md) |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -2,11 +2,12 @@
 
 Below is a list of supported extensions with links to their documentation pages.
 
-- [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/ballastextension/README.md)
-- [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/bearertokenauthextension/README.md)
-- [componenttest](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/component/componenttest)
-- [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/storage/filestorage/README.md)
-- [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/healthcheckextension/README.md)
-- [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/oidcauthextension/README.md)
-- [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/pprofextension/README.md)
-- [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/zpagesextension/README.md)
+| Name                             | GitHub README |
+| -------------------------------- | ------------- |
+| Authenticator - Bearer Extension | [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/bearertokenauthextension/README.md) |
+| Authenticator - OIDC Extension   | [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/oidcauthextension/README.md) |
+| File Storage Extension           | [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/storage/filestorage/README.md) |
+| Health Check Extension           | [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/healthcheckextension/README.md) |
+| Memory Ballast Extension         | [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/ballastextension/README.md) |
+| Performance Profiler Extension   | [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/pprofextension/README.md) |
+| zPages Extension                 | [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/zpagesextension/README.md) |

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -2,25 +2,26 @@
 
 Below is a list of supported processors with links to their documentation pages.
 
-- [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/attributesprocessor/README.md)
-- [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/batchprocessor/README.md)
-- [componenttest](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/component/componenttest)
-- [cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/cumulativetodeltaprocessor/README.md)
-- [deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/deltatorateprocessor/README.md)
-- [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/filterprocessor/README.md)
-- [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbyattrsprocessor/README.md)
-- [groupbytraceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbytraceprocessor/README.md)
-- [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/k8sattributesprocessor/README.md)
-- [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/memorylimiterprocessor/README.md)
-- [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricsgenerationprocessor/README.md)
-- [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricstransformprocessor/README.md)
-- [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/normalizesumsprocessor/README.md)
-- [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/probabilisticsamplerprocessor/README.md)
-- [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md)
-- [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourcedetectionprocessor/README.md)
-- [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourceprocessor/README.md)
-- [routingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/routingprocessor/README.md)
-- [spanmetricsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanmetricsprocessor/README.md)
-- [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanprocessor/README.md)
-- [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/tailsamplingprocessor/README.md)
-- [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/transformprocessor/README.md)
+| Name                                    | GitHub README |
+| --------------------------------------- | ------------- |
+| Attributes Processor                    | [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/attributesprocessor/README.md) |
+| Batch Processor                         | [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/batchprocessor/README.md) |
+| Cumulative to Delta Processor           | [cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/cumulativetodeltaprocessor/README.md) |
+| Delta to Rate Processor                 | [deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/deltatorateprocessor/README.md) |
+| Filter Processor                        | [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/filterprocessor/README.md) |
+| Group by Attributes Processor           | [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbyattrsprocessor/README.md) |
+| Group by Trace Processor                | [groupbytraceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbytraceprocessor/README.md) |
+| Kubernetes Attributes Processor         | [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/k8sattributesprocessor/README.md) |
+| Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/memorylimiterprocessor/README.md) |
+| Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricsgenerationprocessor/README.md) |
+| Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricstransformprocessor/README.md) |
+| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/normalizesumsprocessor/README.md) |
+| Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/probabilisticsamplerprocessor/README.md) |
+| Resource Attribute Transposer Processor | [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md) |
+| Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourcedetectionprocessor/README.md) |
+| Resource Processor                      | [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourceprocessor/README.md) |
+| Routing processor                       | [routingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/routingprocessor/README.md) |
+| Span Metrics Processor                  | [spanmetricsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanmetricsprocessor/README.md) |
+| Span Processor                          | [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanprocessor/README.md) |
+| Tail Sampling Processor                 | [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/tailsamplingprocessor/README.md) |
+| Transform Processor                     | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/transformprocessor/README.md) |

--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -2,58 +2,59 @@
 
 Below is a list of supported receivers with links to their documentation pages.
 
-- [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/activedirectorydsreceiver/README.md)
-- [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/apachereceiver/README.md)
-- [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awscontainerinsightreceiver/README.md)
-- [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsecscontainermetricsreceiver/README.md)
-- [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsfirehosereceiver/README.md)
-- [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsxrayreceiver/README.md)
-- [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/carbonreceiver/README.md)
-- [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/cloudfoundryreceiver/README.md)
-- [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/collectdreceiver/README.md)
-- [componenttest](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/component/componenttest)
-- [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/couchdbreceiver/README.md)
-- [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dockerstatsreceiver/README.md)
-- [dotnetdiagnosticsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dotnetdiagnosticsreceiver/README.md)
-- [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/elasticsearchreceiver/README.md)
-- [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/filelogreceiver/README.md)
-- [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/fluentforwardreceiver/README.md)
-- [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudpubsubreceiver/README.md)
-- [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudspannerreceiver/README.md)
-- [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/hostmetricsreceiver/README.md)
-- [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/iisreceiver/README.md)
-- [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/influxdbreceiver/README.md)
-- [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jaegerreceiver/README.md)
-- [jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jmxreceiver/README.md)
-- [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/journaldreceiver/README.md)
-- [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8sclusterreceiver/README.md)
-- [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8seventsreceiver/README.md)
-- [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkametricsreceiver/README.md)
-- [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkareceiver/README.md)
-- [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kubeletstatsreceiver/README.md)
-- [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/memcachedreceiver/README.md)
-- [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbatlasreceiver/README.md)
-- [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbreceiver/README.md)
-- [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mysqlreceiver/README.md)
-- [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/nginxreceiver/README.md)
-- [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/opencensusreceiver/README.md)
-- [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/receiver/otlpreceiver/README.md)
-- [pluginreceiver](../receiver/pluginreceiver/README.md)
-- [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/podmanreceiver/README.md)
-- [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/postgresqlreceiver/README.md)
-- [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/prometheusreceiver/README.md)
-- [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/rabbitmqreceiver/README.md)
-- [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/redisreceiver/README.md)
-- [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/riakreceiver/README.md)
-- [sapmreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sapmreceiver/README.md)
-- [simpleprometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/simpleprometheusreceiver/README.md)
-- [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/statsdreceiver/README.md)
-- [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sqlserverreceiver/README.md)
-- [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/syslogreceiver/README.md)
-- [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/tcplogreceiver/README.md)
-- [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/udplogreceiver/README.md)
-- [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/1ba794f22664266994c03a5c0b0893179f526e34/receiver/varnishreceiver/README.md)
-- [vcenterreceiver](https://github.com/observIQ/opentelemetry-collector-contrib/blob/vcenterreceiver-vsan-support/receiver/vcenterreceiver/README.md)
-- [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/windowsperfcountersreceiver/README.md)
-- [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zipkinreceiver/README.md)
-- [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zookeeperreceiver/README.md)
+| Name                                        | GitHub README |
+| ------------------------------------------- | ------------- |
+| Active Directory Domain Services Receiver   | [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/activedirectorydsreceiver/README.md) |
+| Apache CouchDB Receiver                     | [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/couchdbreceiver/README.md) |
+| Apache Web Server Receiver                  | [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/apachereceiver/README.md) |
+| Apache ZooKeeper Receiver                   | [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zookeeperreceiver/README.md) |
+| AWS CloudWatch Container Insights Receiver  | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awscontainerinsightreceiver/README.md) |
+| AWS ECS Container Metrics Receiver          | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsecscontainermetricsreceiver/README.md) |
+| AWS Kinesis Data Firehose Receiver          | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsfirehosereceiver/README.md) |
+| AWS X-Ray Receiver                          | [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsxrayreceiver/README.md) |
+| Carbon Receiver                             | [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/carbonreceiver/README.md) |
+| Cloud Foundry Receiver                      | [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/cloudfoundryreceiver/README.md) |
+| collectd write_http Plugin JSON Receiver    | [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/collectdreceiver/README.md) |
+| Docker Stats Receiver                       | [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dockerstatsreceiver/README.md) |
+| Elasticsearch Receiver                      | [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/elasticsearchreceiver/README.md) |
+| File Log Receiver                           | [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/filelogreceiver/README.md) |
+| Fluentd Forward Receiver                    | [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/fluentforwardreceiver/README.md) |
+| Google Cloud Pub/Sub Receiver               | [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudpubsubreceiver/README.md) |
+| Google Cloud Spanner Receiver               | [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudspannerreceiver/README.md) |
+| Host Metrics Receiver                       | [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/hostmetricsreceiver/README.md) |
+| InfluxDB Receiver                           | [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/influxdbreceiver/README.md) |
+| Jaeger Receiver                             | [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jaegerreceiver/README.md) |
+| JMX Receiver                                | [jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jmxreceiver/README.md) |
+| journald Receiver                           | [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/journaldreceiver/README.md) |
+| Kubernetes Cluster Receiver                 | [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8sclusterreceiver/README.md) |
+| Kubernetes Events Receiver                  | [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8seventsreceiver/README.md) |
+| Kubernetes kubelet Stats Receiver           | [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kubeletstatsreceiver/README.md) |
+| Kafka Receiver                              | [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkareceiver/README.md) |
+| Kafka Metrics Receiver                      | [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkametricsreceiver/README.md) |
+| Memcached Receiver                          | [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/memcachedreceiver/README.md) |
+| Microsoft .NET Process Diagnostics Receiver | [dotnetdiagnosticsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dotnetdiagnosticsreceiver/README.md) |
+| Microsoft IIS Receiver                      | [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/iisreceiver/README.md) |
+| Microsoft SQL Server Receiver               | [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sqlserverreceiver/README.md) |
+| MongoDB Receiver                            | [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbreceiver/README.md) |
+| MongoDB Atlas Receiver                      | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbatlasreceiver/README.md) |
+| MySQL Receiver                              | [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mysqlreceiver/README.md) |
+| NGINX Receiver                              | [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/nginxreceiver/README.md) |
+| OpenCensus Receiver                         | [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/opencensusreceiver/README.md) |
+| OTLP Receiver                               | [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/receiver/otlpreceiver/README.md) |
+| Plugin Receiver                             | [pluginreceiver](../receiver/pluginreceiver/README.md) |
+| Podman Stats Receiver                       | [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/podmanreceiver/README.md) |
+| PostgreSQL Receiver                         | [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/postgresqlreceiver/README.md) |
+| Prometheus Receiver                         | [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/prometheusreceiver/README.md) |
+| Prometheus (Simple) Receiver                | [simpleprometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/simpleprometheusreceiver/README.md) |
+| RabbitMQ Receiver                           | [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/rabbitmqreceiver/README.md) |
+| Redis Receiver                              | [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/redisreceiver/README.md) |
+| Riak Receiver                               | [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/riakreceiver/README.md) |
+| SAPM Receiver                               | [sapmreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sapmreceiver/README.md) |
+| StatsD Receiver                             | [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/statsdreceiver/README.md) |
+| Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/syslogreceiver/README.md) |
+| TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/tcplogreceiver/README.md) |
+| UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/udplogreceiver/README.md) |
+| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/1ba794f22664266994c03a5c0b0893179f526e34/receiver/varnishreceiver/README.md) |
+| vCenter Receiver                            | [vcenterreceiver](https://github.com/observIQ/opentelemetry-collector-contrib/blob/vcenterreceiver-vsan-support/receiver/vcenterreceiver/README.md) |
+| Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/windowsperfcountersreceiver/README.md) |
+| Zipkin Receiver                             | [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zipkinreceiver/README.md) |


### PR DESCRIPTION
Resolves #419 

### Proposed Change
Updates documentation with two column tables for extensions, receivers, exporters, and processors. The first column has a human readable name and the second has the original otel name along with a link to the github README for that component.

#### Sample
<img width="607" alt="image" src="https://user-images.githubusercontent.com/12396806/170070392-eefe11a9-8e1a-48f3-a025-e910754bd11d.png">


