### PR TITLE
fix(release): Updated path for msi release to use new gorleaser path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy Windows Binary
-        run: cp dist/collector_windows_amd64/observiq-otel-collector.exe windows/observiq-otel-collector.exe
+        run: cp dist/collector_windows_amd64_v1/observiq-otel-collector.exe windows/observiq-otel-collector.exe
       - name: Copy Plugins to MSI Build Directory
         run: cp -r release_deps/plugins windows/
       - name: Copy Example Config


### PR DESCRIPTION
### Proposed Change
In go releaser 1.8.0 a version number was added to the amd64 build directories. This was not taken into account in our msi build.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
