### PR TITLE
feat: Add UDP plugin

### DIFF
--- a/plugins/udp_logs.yaml
+++ b/plugins/udp_logs.yaml
@@ -1,0 +1,28 @@
+version: 0.0.1
+title: UDP
+description: Log parser for UDP
+parameters:
+  - name: listen_port
+    type: int
+    required: true
+  - name: log_type
+    type: string
+    default: udp
+  - name: listen_ip
+    type: string
+    default: "0.0.0.0"
+  - name: add_attributes
+    type: bool
+    default: true
+template: |
+  receivers:
+    udplog:
+      listen_address: '{{ .listen_ip }}:{{ .listen_port}}'
+      attributes:
+        log_type: {{.log_type}}
+      add_attributes: {{.add_attributes}}
+
+  service:
+    pipelines:
+      logs:
+        receivers: [udplog]


### PR DESCRIPTION
### Test Code:
```
package main

import (
	"log"
	"net"
)

func main() {
	con, err := net.Dial("udp", "127.0.0.1:4444")
	if err != nil {
		log.Fatalf("Failed to dial udp: %v", err)
	}

	defer con.Close()
	con.Write([]byte("Logging over UDP\n"))
}
```
### Test Result:
```
2022-05-26T12:54:30.584-0400    INFO    loggingexporter/logging_exporter.go:71  LogsExporter  {"#logs": 1}
2022-05-26T12:54:30.584-0400    DEBUG   loggingexporter/logging_exporter.go:81  ResourceLog #0
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2022-05-26 16:54:30.55076 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: Logging over UDP
Attributes:
     -> net.peer.ip: STRING(127.0.0.1)
     -> net.peer.port: STRING(63813)
     -> net.peer.name: STRING(localhost)
     -> log_type: STRING(udp)
     -> net.transport: STRING(IP.UDP)
     -> net.host.ip: STRING(::)
     -> net.host.port: STRING(4444)
     -> net.host.name: STRING(::)
Trace ID: 
Span ID: 
Flags: 0
```
### Proposed Change
<!-- Please provide a description of the change here. -->
- Simplified plugin from stanza
- Ran test code in one terminal and kept the udp_logs.yaml running through a config in another terminal

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
