### PR TITLE
fix: Embed tzdata

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	_ "time/tzdata"
 
 	"github.com/observiq/observiq-otel-collector/collector"
 	"github.com/observiq/observiq-otel-collector/internal/logging"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->

Some systems do not have a timezone database supported by Go.
- Container environments
- Windows

Go supports [embedding tzdata](https://pkg.go.dev/time/tzdata) which will be used as a fallback when the operating system does not provide a database.

We have several build systems (Gorelease, make collector) so I have opted to use the `import` option instead of the build tag.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
