### PR TITLE
deps: Update opamp library with new protobuf message format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor v0.5.0
 	github.com/observiq/observiq-otel-collector/receiver/pluginreceiver v0.5.0
 	github.com/observiq/opentelemetry-collector-contrib/receiver/vcenterreceiver v0.0.0-20220504180047-0f9b0ab55655
-	github.com/open-telemetry/opamp-go v0.0.0-20220513220231-888d3adc29d8
+	github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.50.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.50.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -1367,8 +1367,8 @@ github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/open-telemetry/opamp-go v0.0.0-20220513220231-888d3adc29d8 h1:DOIfPeQbsf9NaKwlE15QTVO6/YhbapkIzY9jLrR5398=
-github.com/open-telemetry/opamp-go v0.0.0-20220513220231-888d3adc29d8/go.mod h1:IMdeuHGVc5CjKSu5/oNV0o+UmiXuahoHvoZ4GOmAI9M=
+github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870 h1:BhAV0W1i8rqOC99bIQJq0jJiEvszE6oOl5hS8Pw2pKM=
+github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870/go.mod h1:IMdeuHGVc5CjKSu5/oNV0o+UmiXuahoHvoZ4GOmAI9M=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.50.0 h1:BAKtE64RCE8IsXnmcuOD+qunAmkt/SFSXgTWuHPdnTI=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.50.0/go.mod h1:X285UAxq30cZA020O94CHFeQgDhOIDZ70TNd6kDPn3s=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.50.0 h1:8IQDK4vNQ1QpSDWsV/PScSKof/vHE1ku1sO2RwAzeIY=

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -19,9 +19,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/observiq/observiq-otel-collector/collector"
+	"github.com/observiq/observiq-otel-collector/internal/version"
 	"github.com/observiq/observiq-otel-collector/opamp"
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/client/types"
@@ -127,10 +129,13 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 
 	settings := types.StartSettings{
-		OpAMPServerURL:      c.currentConfig.Endpoint,
-		AuthorizationHeader: fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey()),
-		TLSConfig:           nil, // TODO add support for TLS
-		InstanceUid:         c.ident.agentID,
+		OpAMPServerURL: c.currentConfig.Endpoint,
+		Header: http.Header{
+			"Authorization": []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
+			"User-Agent":    []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+		},
+		TLSConfig:   nil, // TODO add support for TLS
+		InstanceUid: c.ident.agentID,
 		Callbacks: types.CallbacksStruct{
 			OnConnectFunc:          c.onConnectHandler,
 			OnConnectFailedFunc:    c.onConnectFailedHandler,

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	colmocks "github.com/observiq/observiq-otel-collector/collector/mocks"
@@ -257,7 +256,7 @@ func TestClientConnect(t *testing.T) {
 				mockOpAmpClient.On("Start", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 					settings := args.Get(1).(types.StartSettings)
 					assert.Equal(t, expectedSettings.OpAMPServerURL, settings.OpAMPServerURL)
-					assert.True(t, reflect.DeepEqual(expectedSettings.Header, settings.Header), "Header elements should match")
+					assert.Equal(t, expectedSettings.Header, settings.Header)
 					assert.Equal(t, expectedSettings.TLSConfig, settings.TLSConfig)
 					assert.Equal(t, expectedSettings.InstanceUid, settings.InstanceUid)
 					// assert is unable to compare function pointers

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	colmocks "github.com/observiq/observiq-otel-collector/collector/mocks"
+	"github.com/observiq/observiq-otel-collector/internal/version"
 	"github.com/observiq/observiq-otel-collector/opamp"
 	"github.com/observiq/observiq-otel-collector/opamp/mocks"
 	"github.com/open-telemetry/opamp-go/client/types"
@@ -236,10 +239,13 @@ func TestClientConnect(t *testing.T) {
 				}
 
 				expectedSettings := types.StartSettings{
-					OpAMPServerURL:      c.currentConfig.Endpoint,
-					AuthorizationHeader: fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey()),
-					TLSConfig:           nil,
-					InstanceUid:         c.ident.agentID,
+					OpAMPServerURL: c.currentConfig.Endpoint,
+					Header: http.Header{
+						"Authorization": []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
+						"User-Agent":    []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+					},
+					TLSConfig:   nil,
+					InstanceUid: c.ident.agentID,
 					Callbacks: types.CallbacksStruct{
 						OnConnectFunc:          c.onConnectHandler,
 						OnConnectFailedFunc:    c.onConnectFailedHandler,
@@ -251,7 +257,7 @@ func TestClientConnect(t *testing.T) {
 				mockOpAmpClient.On("Start", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 					settings := args.Get(1).(types.StartSettings)
 					assert.Equal(t, expectedSettings.OpAMPServerURL, settings.OpAMPServerURL)
-					assert.Equal(t, expectedSettings.AuthorizationHeader, settings.AuthorizationHeader)
+					assert.True(t, reflect.DeepEqual(expectedSettings.Header, settings.Header), "Header elements should match")
 					assert.Equal(t, expectedSettings.TLSConfig, settings.TLSConfig)
 					assert.Equal(t, expectedSettings.InstanceUid, settings.InstanceUid)
 					// assert is unable to compare function pointers


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
Most of the changes are handled directly in the library implementation. There was also a change to remove the AuthorizationHeader and replace it with a general Header field to allow additional headers to be passed. This adds the User-Agent header setting it to `observiq-otel-collector/version`

##### Checklist
- [x] Changes are tested
- [x] CI has passed
