### PR TITLE
feat: Adds BIG-IP Receiver

### DIFF
--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -4,29 +4,29 @@ Below is a list of supported exports with links to their documentation pages.
 
 | Name                                     | GitHub README |
 | ---------------------------------------- | ------------- |
-| Alibaba Cloud Log Service Exporter       | [alibabacloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/alibabacloudlogserviceexporter/README.md) |
-| AWS CloudWatch Logs Exporter             | [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awscloudwatchlogsexporter/README.md) |
-| AWS CloudWatch EMF Exporter              | [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsemfexporter/README.md) |
-| AWS Kinesis Exporter                     | [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awskinesisexporter/README.md) |
-| AWS Prometheus Remote Write Exporter     | [awsprometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsprometheusremotewriteexporter/README.md) |
-| AWS X-Ray Tracing Exporter               | [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/awsxrayexporter/README.md) |
-| Azure Monitor Exporter                   | [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/azuremonitorexporter/README.md) |
-| Carbon Exporter                          | [carbonexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/carbonexporter/README.md) |
-| Elasticsearch Exporter                   | [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/elasticsearchexporter/README.md) |
-| F5 Cloud Exporter                        | [f5cloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/f5cloudexporter/README.md) |
-| File Exporter                            | [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/fileexporter/README.md) |
+| Alibaba Cloud Log Service Exporter       | [alibabacloudlogserviceexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/alibabacloudlogserviceexporter/README.md) |
+| AWS CloudWatch Logs Exporter             | [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/awscloudwatchlogsexporter/README.md) |
+| AWS CloudWatch EMF Exporter              | [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/awsemfexporter/README.md) |
+| AWS Kinesis Exporter                     | [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/awskinesisexporter/README.md) |
+| AWS Prometheus Remote Write Exporter     | [awsprometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/awsprometheusremotewriteexporter/README.md) |
+| AWS X-Ray Tracing Exporter               | [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/awsxrayexporter/README.md) |
+| Azure Monitor Exporter                   | [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/azuremonitorexporter/README.md) |
+| Carbon Exporter                          | [carbonexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/carbonexporter/README.md) |
+| Elasticsearch Exporter                   | [elasticsearchexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/elasticsearchexporter/README.md) |
+| F5 Cloud Exporter                        | [f5cloudexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/f5cloudexporter/README.md) |
+| File Exporter                            | [fileexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/fileexporter/README.md) |
 | Google Cloud Exporter                    | [googlecloudexporter](../exporter/googlecloudexporter/README.md) |
-| Google Cloud Pub/Sub Exporter            | [googlecloudpubsubexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/googlecloudpubsubexporter/README.md) |
-| InfluxDB Exporter                        | [influxdbexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/influxdbexporter/README.md) |
-| Jaeger gRPC Exporter                     | [jaegerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/jaegerexporter/README.md) |
-| Kafka Exporter                           | [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/kafkaexporter/README.md) |
-| Load-Balancing (Trace ID Aware) Exporter | [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/loadbalancingexporter/README.md) |
-| Logging Exporter                         | [loggingexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/loggingexporter/README.md) |
-| Loki Exporter                            | [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/lokiexporter/README.md) |
-| observIQ Exporter                        | [observiqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/observiqexporter/README.md) |
-| OpenCensus gRPC Exporter                 | [opencensusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/opencensusexporter/README.md) |
-| OTLP gRPC Exporter                       | [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlpexporter/README.md) |
-| OTLP HTTP Exporter                       | [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/exporter/otlphttpexporter/README.md) |
-| Prometheus Exporter                      | [prometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusexporter/README.md) |
-| Prometheus Remote Write Exporter         | [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/prometheusremotewriteexporter/README.md) |
-| Zipkin Exporter                          | [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/exporter/zipkinexporter/README.md) |
+| Google Cloud Pub/Sub Exporter            | [googlecloudpubsubexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/googlecloudpubsubexporter/README.md) |
+| InfluxDB Exporter                        | [influxdbexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/influxdbexporter/README.md) |
+| Jaeger gRPC Exporter                     | [jaegerexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/jaegerexporter/README.md) |
+| Kafka Exporter                           | [kafkaexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/kafkaexporter/README.md) |
+| Load-Balancing (Trace ID Aware) Exporter | [loadbalancingexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/loadbalancingexporter/README.md) |
+| Logging Exporter                         | [loggingexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/exporter/loggingexporter/README.md) |
+| Loki Exporter                            | [lokiexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/lokiexporter/README.md) |
+| observIQ Exporter                        | [observiqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/observiqexporter/README.md) |
+| OpenCensus gRPC Exporter                 | [opencensusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/opencensusexporter/README.md) |
+| OTLP gRPC Exporter                       | [otlpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/exporter/otlpexporter/README.md) |
+| OTLP HTTP Exporter                       | [otlphttpexporter](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/exporter/otlphttpexporter/README.md) |
+| Prometheus Exporter                      | [prometheusexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/prometheusexporter/README.md) |
+| Prometheus Remote Write Exporter         | [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/prometheusremotewriteexporter/README.md) |
+| Zipkin Exporter                          | [zipkinexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/exporter/zipkinexporter/README.md) |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -4,10 +4,10 @@ Below is a list of supported extensions with links to their documentation pages.
 
 | Name                             | GitHub README |
 | -------------------------------- | ------------- |
-| Authenticator - Bearer Extension | [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/bearertokenauthextension/README.md) |
-| Authenticator - OIDC Extension   | [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/oidcauthextension/README.md) |
-| File Storage Extension           | [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/storage/filestorage/README.md) |
-| Health Check Extension           | [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/healthcheckextension/README.md) |
-| Memory Ballast Extension         | [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/ballastextension/README.md) |
-| Performance Profiler Extension   | [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/extension/pprofextension/README.md) |
-| zPages Extension                 | [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/extension/zpagesextension/README.md) |
+| Authenticator - Bearer Extension | [bearertokenauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/extension/bearertokenauthextension/README.md) |
+| Authenticator - OIDC Extension   | [oidcauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/extension/oidcauthextension/README.md) |
+| File Storage Extension           | [filestorage](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/extension/storage/filestorage/README.md) |
+| Health Check Extension           | [healthcheckextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/extension/healthcheckextension/README.md) |
+| Memory Ballast Extension         | [ballastextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/extension/ballastextension/README.md) |
+| Performance Profiler Extension   | [pprofextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/extension/pprofextension/README.md) |
+| zPages Extension                 | [zpagesextension](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/extension/zpagesextension/README.md) |

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -26,7 +26,7 @@ sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/release
 
 ### Additional Install Steps
 
-If you plan on collecting metrics via the [JMX Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jmxreceiver/README.md) you can copy the `opentelemetry-java-contrib-jmx-metrics.jar` to the default location to make configuration easier.
+If you plan on collecting metrics via the [JMX Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/jmxreceiver/README.md) you can copy the `opentelemetry-java-contrib-jmx-metrics.jar` to the default location to make configuration easier.
 
 ```sh
 sudo cp $(brew --prefix observiq/observiq-otel-collector/observiq-otel-collector)/lib/opentelemetry-java-contrib-jmx-metrics.jar /opt

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -4,24 +4,24 @@ Below is a list of supported processors with links to their documentation pages.
 
 | Name                                    | GitHub README |
 | --------------------------------------- | ------------- |
-| Attributes Processor                    | [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/attributesprocessor/README.md) |
-| Batch Processor                         | [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/batchprocessor/README.md) |
-| Cumulative to Delta Processor           | [cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/cumulativetodeltaprocessor/README.md) |
-| Delta to Rate Processor                 | [deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/deltatorateprocessor/README.md) |
-| Filter Processor                        | [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/filterprocessor/README.md) |
-| Group by Attributes Processor           | [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbyattrsprocessor/README.md) |
-| Group by Trace Processor                | [groupbytraceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/groupbytraceprocessor/README.md) |
-| Kubernetes Attributes Processor         | [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/k8sattributesprocessor/README.md) |
-| Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/memorylimiterprocessor/README.md) |
-| Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricsgenerationprocessor/README.md) |
-| Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/metricstransformprocessor/README.md) |
+| Attributes Processor                    | [attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/attributesprocessor/README.md) |
+| Batch Processor                         | [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/processor/batchprocessor/README.md) |
+| Cumulative to Delta Processor           | [cumulativetodeltaprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/cumulativetodeltaprocessor/README.md) |
+| Delta to Rate Processor                 | [deltatorateprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/deltatorateprocessor/README.md) |
+| Filter Processor                        | [filterprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/filterprocessor/README.md) |
+| Group by Attributes Processor           | [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/groupbyattrsprocessor/README.md) |
+| Group by Trace Processor                | [groupbytraceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/groupbytraceprocessor/README.md) |
+| Kubernetes Attributes Processor         | [k8sattributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/k8sattributesprocessor/README.md) |
+| Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/processor/memorylimiterprocessor/README.md) |
+| Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/metricsgenerationprocessor/README.md) |
+| Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/metricstransformprocessor/README.md) |
 | Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/master/processor/normalizesumsprocessor/README.md) |
-| Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/probabilisticsamplerprocessor/README.md) |
+| Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/probabilisticsamplerprocessor/README.md) |
 | Resource Attribute Transposer Processor | [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md) |
-| Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourcedetectionprocessor/README.md) |
-| Resource Processor                      | [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/resourceprocessor/README.md) |
-| Routing processor                       | [routingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/routingprocessor/README.md) |
-| Span Metrics Processor                  | [spanmetricsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanmetricsprocessor/README.md) |
-| Span Processor                          | [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/spanprocessor/README.md) |
-| Tail Sampling Processor                 | [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/tailsamplingprocessor/README.md) |
-| Transform Processor                     | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/processor/transformprocessor/README.md) |
+| Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/resourcedetectionprocessor/README.md) |
+| Resource Processor                      | [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/resourceprocessor/README.md) |
+| Routing processor                       | [routingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/routingprocessor/README.md) |
+| Span Metrics Processor                  | [spanmetricsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/spanmetricsprocessor/README.md) |
+| Span Processor                          | [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/spanprocessor/README.md) |
+| Tail Sampling Processor                 | [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/tailsamplingprocessor/README.md) |
+| Transform Processor                     | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/processor/transformprocessor/README.md) |

--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -4,57 +4,58 @@ Below is a list of supported receivers with links to their documentation pages.
 
 | Name                                        | GitHub README |
 | ------------------------------------------- | ------------- |
-| Active Directory Domain Services Receiver   | [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/activedirectorydsreceiver/README.md) |
-| Apache CouchDB Receiver                     | [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/couchdbreceiver/README.md) |
-| Apache Web Server Receiver                  | [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/apachereceiver/README.md) |
-| Apache ZooKeeper Receiver                   | [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zookeeperreceiver/README.md) |
-| AWS CloudWatch Container Insights Receiver  | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awscontainerinsightreceiver/README.md) |
-| AWS ECS Container Metrics Receiver          | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsecscontainermetricsreceiver/README.md) |
-| AWS Kinesis Data Firehose Receiver          | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsfirehosereceiver/README.md) |
-| AWS X-Ray Receiver                          | [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/awsxrayreceiver/README.md) |
-| Carbon Receiver                             | [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/carbonreceiver/README.md) |
-| Cloud Foundry Receiver                      | [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/cloudfoundryreceiver/README.md) |
-| collectd write_http Plugin JSON Receiver    | [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/collectdreceiver/README.md) |
-| Docker Stats Receiver                       | [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dockerstatsreceiver/README.md) |
-| Elasticsearch Receiver                      | [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/elasticsearchreceiver/README.md) |
-| File Log Receiver                           | [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/filelogreceiver/README.md) |
-| Fluentd Forward Receiver                    | [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/fluentforwardreceiver/README.md) |
-| Google Cloud Pub/Sub Receiver               | [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudpubsubreceiver/README.md) |
-| Google Cloud Spanner Receiver               | [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/googlecloudspannerreceiver/README.md) |
-| Host Metrics Receiver                       | [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/hostmetricsreceiver/README.md) |
-| InfluxDB Receiver                           | [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/influxdbreceiver/README.md) |
-| Jaeger Receiver                             | [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jaegerreceiver/README.md) |
-| JMX Receiver                                | [jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/jmxreceiver/README.md) |
-| journald Receiver                           | [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/journaldreceiver/README.md) |
-| Kubernetes Cluster Receiver                 | [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8sclusterreceiver/README.md) |
-| Kubernetes Events Receiver                  | [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/k8seventsreceiver/README.md) |
-| Kubernetes kubelet Stats Receiver           | [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kubeletstatsreceiver/README.md) |
-| Kafka Receiver                              | [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkareceiver/README.md) |
-| Kafka Metrics Receiver                      | [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/kafkametricsreceiver/README.md) |
-| Memcached Receiver                          | [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/memcachedreceiver/README.md) |
-| Microsoft .NET Process Diagnostics Receiver | [dotnetdiagnosticsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/dotnetdiagnosticsreceiver/README.md) |
-| Microsoft IIS Receiver                      | [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/iisreceiver/README.md) |
-| Microsoft SQL Server Receiver               | [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sqlserverreceiver/README.md) |
-| MongoDB Receiver                            | [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbreceiver/README.md) |
-| MongoDB Atlas Receiver                      | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mongodbatlasreceiver/README.md) |
-| MySQL Receiver                              | [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/mysqlreceiver/README.md) |
-| NGINX Receiver                              | [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/nginxreceiver/README.md) |
-| OpenCensus Receiver                         | [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/opencensusreceiver/README.md) |
-| OTLP Receiver                               | [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/receiver/otlpreceiver/README.md) |
+| Active Directory Domain Services Receiver   | [activedirectorydsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/activedirectorydsreceiver/README.md) |
+| Apache CouchDB Receiver                     | [couchdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/couchdbreceiver/README.md) |
+| Apache Web Server Receiver                  | [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/apachereceiver/README.md) |
+| Apache ZooKeeper Receiver                   | [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/zookeeperreceiver/README.md) |
+| AWS CloudWatch Container Insights Receiver  | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/awscontainerinsightreceiver/README.md) |
+| AWS ECS Container Metrics Receiver          | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/awsecscontainermetricsreceiver/README.md) |
+| AWS Kinesis Data Firehose Receiver          | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/awsfirehosereceiver/README.md) |
+| AWS X-Ray Receiver                          | [awsxrayreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/awsxrayreceiver/README.md) |
+| Carbon Receiver                             | [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/carbonreceiver/README.md) |
+| Cloud Foundry Receiver                      | [cloudfoundryreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/cloudfoundryreceiver/README.md) |
+| collectd write_http Plugin JSON Receiver    | [collectdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/collectdreceiver/README.md) |
+| Docker Stats Receiver                       | [dockerstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/dockerstatsreceiver/README.md) |
+| Elasticsearch Receiver                      | [elasticsearchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/elasticsearchreceiver/README.md) |
+| F5 BIG-IP Receiver                          | [bigipreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/bigipreceiver/README.md) |
+| File Log Receiver                           | [filelogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/filelogreceiver/README.md) |
+| Fluentd Forward Receiver                    | [fluentforwardreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/fluentforwardreceiver/README.md) |
+| Google Cloud Pub/Sub Receiver               | [googlecloudpubsubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/googlecloudpubsubreceiver/README.md) |
+| Google Cloud Spanner Receiver               | [googlecloudspannerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/googlecloudspannerreceiver/README.md) |
+| Host Metrics Receiver                       | [hostmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/hostmetricsreceiver/README.md) |
+| InfluxDB Receiver                           | [influxdbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/influxdbreceiver/README.md) |
+| Jaeger Receiver                             | [jaegerreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/jaegerreceiver/README.md) |
+| JMX Receiver                                | [jmxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/jmxreceiver/README.md) |
+| journald Receiver                           | [journaldreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/journaldreceiver/README.md) |
+| Kubernetes Cluster Receiver                 | [k8sclusterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/k8sclusterreceiver/README.md) |
+| Kubernetes Events Receiver                  | [k8seventsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/k8seventsreceiver/README.md) |
+| Kubernetes kubelet Stats Receiver           | [kubeletstatsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/kubeletstatsreceiver/README.md) |
+| Kafka Receiver                              | [kafkareceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/kafkareceiver/README.md) |
+| Kafka Metrics Receiver                      | [kafkametricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/kafkametricsreceiver/README.md) |
+| Memcached Receiver                          | [memcachedreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/memcachedreceiver/README.md) |
+| Microsoft .NET Process Diagnostics Receiver | [dotnetdiagnosticsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/dotnetdiagnosticsreceiver/README.md) |
+| Microsoft IIS Receiver                      | [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/iisreceiver/README.md) |
+| Microsoft SQL Server Receiver               | [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/sqlserverreceiver/README.md) |
+| MongoDB Receiver                            | [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/mongodbreceiver/README.md) |
+| MongoDB Atlas Receiver                      | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/mongodbatlasreceiver/README.md) |
+| MySQL Receiver                              | [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/mysqlreceiver/README.md) |
+| NGINX Receiver                              | [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/nginxreceiver/README.md) |
+| OpenCensus Receiver                         | [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/opencensusreceiver/README.md) |
+| OTLP Receiver                               | [otlpreceiver](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/receiver/otlpreceiver/README.md) |
 | Plugin Receiver                             | [pluginreceiver](../receiver/pluginreceiver/README.md) |
-| Podman Stats Receiver                       | [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/podmanreceiver/README.md) |
-| PostgreSQL Receiver                         | [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/postgresqlreceiver/README.md) |
-| Prometheus Receiver                         | [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/prometheusreceiver/README.md) |
-| Prometheus (Simple) Receiver                | [simpleprometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/simpleprometheusreceiver/README.md) |
-| RabbitMQ Receiver                           | [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/rabbitmqreceiver/README.md) |
-| Redis Receiver                              | [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/redisreceiver/README.md) |
-| Riak Receiver                               | [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/riakreceiver/README.md) |
-| SAPM Receiver                               | [sapmreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/sapmreceiver/README.md) |
-| StatsD Receiver                             | [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/statsdreceiver/README.md) |
-| Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/syslogreceiver/README.md) |
-| TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/tcplogreceiver/README.md) |
-| UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/udplogreceiver/README.md) |
+| Podman Stats Receiver                       | [podmanreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/podmanreceiver/README.md) |
+| PostgreSQL Receiver                         | [postgresqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/postgresqlreceiver/README.md) |
+| Prometheus Receiver                         | [prometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/prometheusreceiver/README.md) |
+| Prometheus (Simple) Receiver                | [simpleprometheusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/simpleprometheusreceiver/README.md) |
+| RabbitMQ Receiver                           | [rabbitmqreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/rabbitmqreceiver/README.md) |
+| Redis Receiver                              | [redisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/redisreceiver/README.md) |
+| Riak Receiver                               | [riakreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/riakreceiver/README.md) |
+| SAPM Receiver                               | [sapmreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/sapmreceiver/README.md) |
+| StatsD Receiver                             | [statsdreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/statsdreceiver/README.md) |
+| Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/syslogreceiver/README.md) |
+| TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/tcplogreceiver/README.md) |
+| UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/udplogreceiver/README.md) |
 | Varnish Cache Receiver                      | [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/1ba794f22664266994c03a5c0b0893179f526e34/receiver/varnishreceiver/README.md) |
 | vCenter Receiver                            | [vcenterreceiver](https://github.com/observIQ/opentelemetry-collector-contrib/blob/vcenterreceiver-vsan-support/receiver/vcenterreceiver/README.md) |
-| Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/windowsperfcountersreceiver/README.md) |
-| Zipkin Receiver                             | [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.50.0/receiver/zipkinreceiver/README.md) |
+| Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/windowsperfcountersreceiver/README.md) |
+| Zipkin Receiver                             | [zipkinreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.52.0/receiver/zipkinreceiver/README.md) |

--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -17,10 +17,10 @@ This exporter can be used to send metrics, traces, and logs to Google Cloud Moni
 | `resource_mappings` | [See below](#resource-mapping-default)         | `false`  | Defines a mapping of resources from source to target. |
 | `retry_on_failure`  |                       | `false`  | Handle retries when sending data to Google Cloud fails. |
 | `sending_queue`     |                       | `false`  | Determines how telemetry data is buffered before exporting. |
-| `batch`             |                       | `false`  | The config of the exporter's [batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.50.0/processor/batchprocessor). |
+| `batch`             |                       | `false`  | The config of the exporter's [batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.52.0/processor/batchprocessor). |
 | `normalize`         |                       | `false`  | The config of the exporter's [normalize sums processor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/master/processor/normalizesumsprocessor). |
-| `detector`          |                       | `false`  | The config of the exporter's [reseource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.50.0/processor/resourcedetectionprocessor). |
-| `attributer`        |                       | `false`  | The config of the exporter's [resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.50.0/processor/resourceprocessor). |
+| `detector`          |                       | `false`  | The config of the exporter's [reseource detection processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/processor/resourcedetectionprocessor). |
+| `attributer`        |                       | `false`  | The config of the exporter's [resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.52.0/processor/resourceprocessor). |
 | `transposer`        |                       | `false`  | The config of the exporter's [resource transposer processor](https://github.com/observIQ/observiq-otel-collector/tree/main/processor/resourceattributetransposerprocessor). |
 
 ### Resource Mapping Default

--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver"
@@ -80,6 +81,7 @@ var defaultReceivers = []component.ReceiverFactory{
 	awsecscontainermetricsreceiver.NewFactory(),
 	awsfirehosereceiver.NewFactory(),
 	awsxrayreceiver.NewFactory(),
+	bigipreceiver.NewFactory(),
 	carbonreceiver.NewFactory(),
 	cloudfoundryreceiver.NewFactory(),
 	collectdreceiver.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.52.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -1548,6 +1548,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosere
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.52.0/go.mod h1:jATn5ZsMNsKdOHy4sqZqe66spS1VsR535NGObBtMIkg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.52.0 h1:Ke6N1+nohOXiTAK+sYKPWBZOM9GFZ9/N4Q+5duCOobU=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.52.0/go.mod h1:L60YFlkddAFxSUlXuUWezWH48P4ZMHX51hg77E9Gdrw=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver v0.52.0 h1:1S63DguKXFnQL03eqTL4P98WDvG1PXTDPOL7fpf1fhc=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver v0.52.0/go.mod h1:k14RPRChTsjXKL5jso1kTI6rnGRFr9n70wKoNmd3Ac4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.52.0 h1:X+0EMgxTCRs0NzDtfQQxErNmyubixpR/1sJUkibayfs=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.52.0/go.mod h1:EqO3C3ybUPWqsOIPTmJ90oh4iZ99TD4bieasHzBG5dw=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver v0.52.0 h1:sOU+HLDq7BKK+eAOFmms6qsNLvkC7HVOBFIR/moxseA=


### PR DESCRIPTION
### Proposed Change
Now that OTEL Collector dependencies have been updated to 0.52.0, we can bring in the new F5 BIG-IP Receiver into this collector.
Also edited docs with 0.52.0 dependencies

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
