### PR TITLE
fix: Fixed the module path for the google exporter

### DIFF
--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,4 +1,4 @@
-module github.com/observiq/googlecloudexporter
+module github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter
 
 go 1.17
 


### PR DESCRIPTION
### Proposed Change
- Fixed the module path for the google exporter. This will allow the collector to be imported by other libraries without creating a module path issue.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
