### PR TITLE
Run as root by default on Linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -129,6 +129,12 @@ nfpms:
           mode: 0750
           owner: observiq-otel-collector
           group: observiq-otel-collector
+      - dst: /opt/observiq-otel-collector/log
+        type: dir
+        file_info:
+          mode: 0750
+          owner: observiq-otel-collector
+          group: observiq-otel-collector
     scripts:
       preinstall: "./scripts/package/preinstall.sh"
       postinstall: ./scripts/package/postinstall.sh

--- a/docs/installation-linux.md
+++ b/docs/installation-linux.md
@@ -33,20 +33,28 @@ sudo systemctl enable --now observiq-otel-collector
 ## Configuring the Collector
 After installing, systems with systemd installed will have the `observiq-otel-collector` service up and running!
 
-Logs from the collector will appear in journald. You may run `sudo tail -F /opt/observiq-otel-collector/log/collector.log` to view them.
+**Logging**
+
+Logs from the collector will appear in `/opt/observiq-otel-collector/log`. You may run `sudo tail -F /opt/observiq-otel-collector/log/collector.log` to view them.
+
+**Configuration**
 
 The config file for the collector can be found at `/opt/observiq-otel-collector/config.yaml`. When changing the configuration,the collector service must be restarted in order for config changes to take effect.
 
 For more information on configuring the collector, see the [OpenTelemetry docs](https://opentelemetry.io/docs/collector/configuration/).
 
-By default, the `observiq-otel-collector` service runs as the "observiq-otel-collector" user. Some OpenTelemetry components may require root permissions.
-To run the collector as root, you may create a systemd override.
+**Permissions**
+
+By default, the `observiq-otel-collector` service runs as the "root" user. Some OpenTelemetry components require root permissions in order to read log files owned by other users.
+
+It may be desirable to run the collector as an unprivileged user. For example, a metrics only collector does not require root access.
+
+To run the collector as the `observiq-otel-collector` user, you may create a systemd override.
 
 Run `sudo systemctl edit observiq-otel-collector` and paste the following config:
 ```
 [Service]
-User=root
-Group=root
+User=observiq-otel-collector
 ```
 
 Restart the collector for these changes to take effect.

--- a/scripts/package/postinstall.sh
+++ b/scripts/package/postinstall.sh
@@ -40,7 +40,7 @@ StartLimitIntervalSec=120
 StartLimitBurst=5
 [Service]
 Type=simple
-User=observiq-otel-collector
+User=root
 Group=observiq-otel-collector
 Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OIQ_OTEL_COLLECTOR_HOME=/opt/observiq-otel-collector
@@ -119,6 +119,13 @@ finish_permissions() {
     # We also change the owner of the binary to observiq-otel-collector
     chown -R observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/observiq-otel-collector /opt/observiq-otel-collector/plugins/*
     chmod 0640 /opt/observiq-otel-collector/plugins/*
+
+  # Initialize the log file to ensure it is owned by observiq-otel-collector.
+  # This prevents the service (running as root) from assigning ownership to
+  # the root user. By doing so, we allow the user to switch to observiq-otel-collector
+  # user for 'non root' installs.
+  touch /opt/observiq-otel-collector/log/collector.log
+  chown observiq-otel-collector:observiq-otel-collector /opt/observiq-otel-collector/log/collector.log
 }
 
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

In order to support reading log files out of the box, we need the collector to run as the root user on Linux. The `observiq-otel-collector` does not have permission to read arbitrary log files. For example: Elasticsearch, Mongodb, Mysql, Nginx, Postgres, Rabbitmq, and redis are all owned by different users.

Changes
- Updated systemd unit file to use `root` user
- Updated post install script to configure the log file permissions
  - The logger will not modify permissions. If the file does not exist, the log file will be owned by root. We want to pre configure the permissions in order to allow users to switch to the `observiq-otel-collector` user.
- Updated linux doc to reflect these changes, and documented the process to switching to the unprivileged user.

I have tested the following
- Fresh install Runs as root
- Upgrades from v1.0.0 switch from oiq user to root user
- Documented systemd override procedure works (switching to unprivileged user)
- Log file rotates and maintains it's permissions (owned by observiq-otel-collector user)
- Manager config maintains its permissions (owned by observiq-otel-collector user) after being re-written by opamp.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
