### PR TITLE
fix: Changes working directory to directory of executable on startup (for Windows)

### DIFF
--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"go.uber.org/zap"
@@ -42,6 +43,17 @@ func RunService(logger *zap.Logger, rSvc RunnableService) error {
 	}
 
 	if isService {
+		// Change working directory to executable directory
+		ex, err := os.Executable()
+		if err != nil {
+			logger.Warn("Failed to retrieve executable directory", zap.Error(err))
+		} else {
+			execDirPath := filepath.Dir(ex)
+			if err := os.Chdir(execDirPath); err != nil {
+				logger.Warn("Failed to modify current working directory", zap.Error(err))
+			}
+		}
+
 		// Service name doesn't need to be specified when directly run by the service manager.
 		return svc.Run("", newWindowsServiceHandler(logger, rSvc))
 	} else {


### PR DESCRIPTION
### Proposed Change
On startup set the working directory to the directory of the executable. This fixes the Windows Service issue where the working directory is not where the executable lives.

```  
plugin:
  path: ./plugins/csv_logs.yaml
  parameters:
    log_paths:
      - ./input.csv
    start_at: beginning
    header: "1,2,3"
```

The above config produces errors related to not being able to find plugins/csv_logs.yaml after a windows install.  It works fine now after the proposed changes.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
