### PR TITLE
fix: Modify goreleaser to have a safe config.yaml that will not be overwritten

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -297,7 +297,9 @@ brews:
       ****************************************************************
     install: |
       bin.install "observiq-otel-collector"
-      prefix.install "LICENSE", "config.yaml", "VERSION.txt", "logging.yaml"
+      prefix.install "LICENSE", "VERSION.txt", "logging.yaml"
+      etc.install "config.yaml" => "observiq_config.yaml"
+      prefix.install_symlink etc/"observiq_config.yaml" => "config.yaml"
       prefix.install Dir["plugins"]
       lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
     service: |

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -65,6 +65,10 @@ brew uninstall observiq/observiq-otel-collector/observiq-otel-collector
 
 # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
 sudo rm -f /opt/opentelemetry-java-contrib-jmx-metrics.jar
+
+# To remove configs
+rm -f $(brew --prefix)/etc/observiq_config.yaml
+rm -f $(brew --prefix)/etc/observiq_config.yaml.default
 ```
 
 ### Uninstall script

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -20,6 +20,7 @@ FORMULA_NAME="observiq/observiq-otel-collector/observiq-otel-collector"
 SERVICE_NAME="com.observiq.collector"
 
 # Script Constants
+BREW_ETC=$(brew --prefix)/etc/
 PREREQS="printf brew sed uname uuidgen tr"
 MANAGEMENT_YML_NAME="manager.yaml"
 SCRIPT_NAME="$0"
@@ -541,6 +542,11 @@ uninstall()
 
   info "Untapping formula..."
   brew untap observiq/homebrew-observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to untap formula"
+  succeeded
+
+  info "Removing config files..."
+  rm -f $BREW_ETC/observiq_config.yaml.default > /dev/null 2>&1
+  rm -f $BREW_ETC/observiq_config.yaml > /dev/null 2>&1 || error_exit "$LINENO" "Failed to remove all config files"
   succeeded
   decrease_indent
 


### PR DESCRIPTION
### Proposed Change
goreleaser now creates a brew formula which puts the config file in the /etc directory of brew. It is given a observiq prefix (as this is a shared directory) and symlinked back to the standard brew install directory.

Also updated the macos install script to remove these configs on uninstall.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
