### PR TITLE
feat: Update GCP example configs to use latest Google exporter

### DIFF
--- a/config/google_cloud_exporter/bigip/config.yaml
+++ b/config/google_cloud_exporter/bigip/config.yaml
@@ -8,33 +8,16 @@ receivers:
     tls:
       insecure_skip_verify: true
 
-processors:
-  resourceattributetransposer:
-    operations:
-      - from: bigip.virtual_server.name
-        to: virutal_server_name
-      - from: bigip.virtual_server.destination
-        to: virtual_server_destination
-      - from: bigip.pool.name
-        to: pool_name
-      - from: bigip.pool_member.name
-        to: pool_member_name
-      - from: bigip.pool_member.ip_address
-        to: pool_member_address
-      - from: bigip.node.name
-        to: node_name
-      - from: bigip.node.ip_address
-        to: node_address
-
 exporters:
   googlecloud:
+    metric:
+      resource_filters:
+        - prefix: bigip
 
 service:
   pipelines:
     metrics:
       receivers:
         - bigip
-      processors:
-        - resourceattributetransposer
       exporters:
         - googlecloud

--- a/config/google_cloud_exporter/cadvisor/config.yaml
+++ b/config/google_cloud_exporter/cadvisor/config.yaml
@@ -2,44 +2,37 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-      - job_name: 'cadvisor' # A friendly name, will be added as 'service.name' resource label
+      - job_name: 'cadvisor'
         scrape_interval: 60s
         static_configs:
         - targets:
           - cadvisor:8080
 
 processors:
+  # Detect the running containers hostname
+  resourcedetection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+
+  # Copy host.name to cadvisor.collector_hostname and then
+  # remove the origonal. Google will map to "generic_task",
+  # which drops host.name. We need to preserve the collector's
+  # hostname in order to guarantee uniqueness.
   resource:
     attributes:
-    # DOCKER_AGENT_HOSTNAME is set when running `docker run` or docker-compose.
-    - key: agent_host
-      value: "$DOCKER_AGENT_HOSTNAME"
-      action: upsert
-
-  # Metrics require unique metric labels, otherwise the Google
-  # API will reject some metrics as "out of order" / duplicates.
-  # The combination of hostname, instance, and service will make each
-  # metric unique, allowing a single receiver to scrape multiple prometheus
-  # exporter endpoints.
-  resourceattributetransposer:
-    operations:
-    - from: "agent_host"
-      to: "agent"
-    - from: "instance"
-      to: "instance"
-    - from: "service.name"
-      to: "service"
-
-  normalizesums:
-
-  batch:
+    - key: cadvisor.collector_hostname
+      from_attribute: host.name
+      action: insert
+    - key: host.name
+      action: delete
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: custom.googleapis.com
+      prefix: workload.googleapis.com/cadvisor
+      resource_filters:
+        - prefix: cadvisor
 
 service:
   pipelines:
@@ -47,9 +40,7 @@ service:
       receivers:
       - prometheus
       processors:
+      - resourcedetection
       - resource
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/docker/config.yaml
+++ b/config/google_cloud_exporter/docker/config.yaml
@@ -2,55 +2,17 @@ receivers:
   docker_stats:
     collection_interval: 60s
 
-processors:
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resource:
-    attributes:
-    # When running within a docker container, detect the host's hostname
-    # from the environment and overwrite the hostname detected by resource
-    # detection.
-    - key: host.name
-      value: "$DOCKER_AGENT_HOSTNAME"
-      action: upsert
-
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
-      - from: container.hostname
-        to: hostname
-      - from: container.id
-        to: container_id
-      - from: container.image.name
-        to: image
-      - from: container.name
-        to: name
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: custom.googleapis.com
+      prefix: workload.googleapis.com/docker
+      resource_filters:
+        - prefix: container
 
 service:
   pipelines:
     metrics:
       receivers:
       - docker_stats
-      processors:
-      - resourcedetection
-      - resource
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/elasticsearch/config.yaml
+++ b/config/google_cloud_exporter/elasticsearch/config.yaml
@@ -4,59 +4,17 @@ receivers:
     endpoint: http://localhost:9200
     collection_interval: 60s
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resource:
-    attributes:
-    - key: location
-      value: global
-      action: upsert
-
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
-      - from: elasticsearch.cluster.name
-        to: cluster_name
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: workload.googleapis.com
-    resource_mappings:
-      - source_type: ""
-        target_type: generic_node
-        label_mappings:
-          - source_key: elasticsearch.node.name
-            target_key: node_id
-          - source_key: elasticsearch.node.name
-            target_key: namespace
-          - source_key: location
-            target_key: location
+      prefix: workload.googleapis.com/elastic
+      resource_filters:
+        - prefix: elasticsearch
 
 service:
   pipelines:
     metrics:
       receivers:
       - elasticsearch
-      processors:
-      - resourcedetection
-      - resource
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/filelog/README.md
+++ b/config/google_cloud_exporter/filelog/README.md
@@ -10,8 +10,6 @@ The collector must be installed on the target system. The user running the colle
 
 See the [prerequisites](../README.md) doc for Google Cloud prerequisites.
 
-Edit the configuration and replace `project: REPLACE_ME` with the project id you wish to write logs to.
-
 ## Examples
 
 **Raw log file**

--- a/config/google_cloud_exporter/filelog/config.yaml
+++ b/config/google_cloud_exporter/filelog/config.yaml
@@ -6,9 +6,6 @@ receivers:
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    project: REPLACE_ME
 
 service:
   pipelines:

--- a/config/google_cloud_exporter/filelog/config_json.yaml
+++ b/config/google_cloud_exporter/filelog/config_json.yaml
@@ -12,9 +12,6 @@ receivers:
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    project: REPLACE_ME
 
 service:
   pipelines:

--- a/config/google_cloud_exporter/filelog/config_regex.yaml
+++ b/config/google_cloud_exporter/filelog/config_regex.yaml
@@ -21,9 +21,6 @@ receivers:
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    project: REPLACE_ME
 
 service:
   pipelines:

--- a/config/google_cloud_exporter/hadoop/config.yaml
+++ b/config/google_cloud_exporter/hadoop/config.yaml
@@ -1,7 +1,7 @@
 receivers:
   jmx:
     jar_path: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-    endpoint: localhost:8005
+    endpoint: localhost:8004
     target_system: hadoop,jvm
     collection_interval: 60s
     resource_attributes:

--- a/config/google_cloud_exporter/hadoop/config.yaml
+++ b/config/google_cloud_exporter/hadoop/config.yaml
@@ -1,65 +1,22 @@
 receivers:
   jmx:
     jar_path: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-    endpoint: localhost:8004
+    endpoint: localhost:8005
     target_system: hadoop,jvm
     collection_interval: 60s
-    properties:
-      # Attribute 'endpoint' will be used for generic_node's node_id field.
-      otel.resource.attributes: endpoint=localhost:8004
-
-processors:
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resourceattributetransposer:
-    operations:
-      - from: "host.name"
-        to: "agent"
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "hadoop"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
+    resource_attributes:
+      hadoop.endpoint: localhost:8004
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: workload.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: endpoint
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
+      resource_filters:
+        - prefix: hadoop
 
 service:
   pipelines:
     metrics:
       receivers:
       - jmx
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/hostmetrics/README.md
+++ b/config/google_cloud_exporter/hostmetrics/README.md
@@ -20,15 +20,3 @@ Host Metrics does not have setup requirements.
 ## Process metrics
 
 The host metrics receiver supports per process cpu, memory, disk, and network metrics. This feature requires elevetated privileges. On Linux, you must update the service configuration to run the collector as the root user. See the [installation documentation](https://github.com/observIQ/observiq-otel-collector/blob/main/docs/installation-linux.md#configuring-the-collector) for instructions.
-
-## Metrics
-
-Metrics can be found with the `custom.googleapis.com/system` prefix.
-
-Example MQL query for `cpu.time`:
-```
-fetch global
-| metric 'custom.googleapis.com/system.cpu.time'
-| align rate(1m)
-| every 1m
-```

--- a/config/google_cloud_exporter/hostmetrics/config.yaml
+++ b/config/google_cloud_exporter/hostmetrics/config.yaml
@@ -18,20 +18,6 @@ receivers:
       #  mute_process_name_error: true
 
 exporters: 
-  # observIQ collector wraps the upstream Google Cloud exporter
-  # with the following processors:
-  #   - resource detection processor
-  #   - resource attributes transposer processor
-  #   - normalizesums processor
-  #   - batch processor
-  #
-  # In additon to wrapping processors, the following settings are configured:
-  #   - retry_on_failure.enabled: false
-  #   - metric.prefix: workload.googleapis.com
-  #   - resource mapping: default to generic_node monitored resource type.
-  #     - node_id: host.name
-  #     - namespace: host.name
-  #     - location: global
   googlecloud:
 
 service:

--- a/config/google_cloud_exporter/iis/config.yaml
+++ b/config/google_cloud_exporter/iis/config.yaml
@@ -2,8 +2,6 @@ receivers:
   iis:
     collection_interval: 60s
 
-processors:
-
 exporters:
   googlecloud:
 
@@ -12,6 +10,5 @@ service:
     metrics:
       receivers:
       - iis
-      processors:
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/journald_logs/README.md
+++ b/config/google_cloud_exporter/journald_logs/README.md
@@ -9,5 +9,3 @@ The collector must be installed on the Journald system. The system must use Syst
 ## Prerequisites
 
 See the [prerequisites](../README.md) doc for Google Cloud prerequisites.
-
-Edit the configuration and replace `project: REPLACE_ME` with the project id you wish to write logs to.

--- a/config/google_cloud_exporter/journald_logs/config.yaml
+++ b/config/google_cloud_exporter/journald_logs/config.yaml
@@ -8,9 +8,6 @@ receivers:
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    project: REPLACE_ME
 
 service:
   pipelines:

--- a/config/google_cloud_exporter/mongodb/config.yaml
+++ b/config/google_cloud_exporter/mongodb/config.yaml
@@ -2,45 +2,20 @@ receivers:
   mongodb:
     hosts:
       - endpoint: 127.0.0.1:27017
-    collection_interval: 60s
+    collection_interval: 30s
+    username: otelu
+    password: otelp
     # disable TLS
     tls:
       insecure: true
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    metric:
-      prefix: custom.googleapis.com
 
 service:
   pipelines:
     metrics:
       receivers:
       - mongodb
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/mongodb/config.yaml
+++ b/config/google_cloud_exporter/mongodb/config.yaml
@@ -2,9 +2,7 @@ receivers:
   mongodb:
     hosts:
       - endpoint: 127.0.0.1:27017
-    collection_interval: 30s
-    username: otelu
-    password: otelp
+    collection_interval: 60s
     # disable TLS
     tls:
       insecure: true

--- a/config/google_cloud_exporter/mongodb_atlas/config.yaml
+++ b/config/google_cloud_exporter/mongodb_atlas/config.yaml
@@ -2,70 +2,18 @@ receivers:
   mongodbatlas:
     public_key: $MONGODB_ATLAS_PUBLIC_KEY
     private_key: $MONGODB_ATLAS_PRIVATE_KEY
-    collection_interval: 1m
-
-processors:
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  # Copy useful mongodb specific attributes that will otherwise
-  # be dropped by the Google exporter.
-  resourceattributetransposer:
-    operations:
-      - from: host.name
-        to: agent
-      - from: mongodb_atlas.org_name
-        to: org_name
-      - from: mongodb_atlas.project.name
-        to: project
-      - from: mongodb_atlas.db.name
-        to: database
-      - from: mongodb_atlas.process.type_name
-        to: process_type
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "mongodbatlas"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
+    collection_interval: 60s
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: workload.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: mongodb_atlas.host.name
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
+      resource_filters:
+        - prefix: mongodb_atlas
 
 service:
   pipelines:
     metrics:
       receivers:
       - mongodbatlas
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/mysql/config.yaml
+++ b/config/google_cloud_exporter/mysql/config.yaml
@@ -5,55 +5,13 @@ receivers:
     password: $MYSQL_PASSWORD
     collection_interval: 60s
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "mysql"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    metric:
-      prefix: custom.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: host.name
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
 
 service:
   pipelines:
     metrics:
       receivers:
       - mysql
-      processors:
-      - resourcedetection
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/postgresql/config.yaml
+++ b/config/google_cloud_exporter/postgresql/config.yaml
@@ -1,62 +1,20 @@
 receivers:
   postgresql:
     endpoint: localhost:5432
-    username: $POSTGRESQL_USERNAME
-    password: $POSTGRESQL_PASSWORD
+    #username: $POSTGRESQL_USERNAME
+    #password: $POSTGRESQL_PASSWORD
     collection_interval: 60s
     # TLS is enabled by default, this disables it.
     tls:
       insecure: true
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "postgres"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    metric:
-      prefix: custom.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: host.name
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
 
 service:
   pipelines:
     metrics:
       receivers:
       - postgresql
-      processors:
-      - resourcedetection
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/postgresql/config.yaml
+++ b/config/google_cloud_exporter/postgresql/config.yaml
@@ -1,8 +1,8 @@
 receivers:
   postgresql:
     endpoint: localhost:5432
-    #username: $POSTGRESQL_USERNAME
-    #password: $POSTGRESQL_PASSWORD
+    username: $POSTGRESQL_USERNAME
+    password: $POSTGRESQL_PASSWORD
     collection_interval: 60s
     # TLS is enabled by default, this disables it.
     tls:

--- a/config/google_cloud_exporter/prometheus/README.md
+++ b/config/google_cloud_exporter/prometheus/README.md
@@ -26,15 +26,3 @@ If you wish to scrape metrics from external systems, update `config.yaml`'s prom
     - '10.128.1.32:9100'
     - '10.128.1.33:9100'
 ```
-
-## Metrics
-
-Metrics can be found with the `custom.googleapis.com` prefix.
-
-Example MQL query for [node exporter's](https://github.com/prometheus/node_exporter) `node_cpu_seconds_total`:
-```
-fetch global
-| metric 'custom.googleapis.com/node_cpu_seconds_total'
-| align rate(1m)
-| every 1m
-```

--- a/config/google_cloud_exporter/prometheus/config.yaml
+++ b/config/google_cloud_exporter/prometheus/config.yaml
@@ -2,56 +2,21 @@ receivers:
   prometheus:
     config:
       scrape_configs:
-      - job_name: 'nodeexporter' # A friendly name, will be added as 'service.name' resource label
+      - job_name: 'nodeexporter'
         scrape_interval: 60s
         static_configs:
-        # One or many target IP's to scrape.
         - targets:
           - '127.0.0.1:9100'
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  # Metrics require unique metric labels, otherwise the Google
-  # API will reject some metrics as "out of order" / duplicates.
-  # The combination of hostname, instance, and service will make each
-  # metric unique, allowing a single receiver to scrape multiple prometheus
-  # exporter endpoints.
-  resourceattributetransposer:
-    operations:
-    - from: "host.name"
-      to: "agent"
-    - from: "instance"
-      to: "instance"
-    - from: "service.name"
-      to: "service"
-
-  normalizesums:
-
-  batch:
-
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: custom.googleapis.com
+      prefix: workload.googleapis.com/nodeexporter
 
 service:
   pipelines:
     metrics:
       receivers:
       - prometheus
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/rabbitmq/config.yaml
+++ b/config/google_cloud_exporter/rabbitmq/config.yaml
@@ -6,64 +6,16 @@ receivers:
     username: $RABBITMQ_USERNAME
     password: $RABBITMQ_PASSWORD
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resource:
-    attributes:
-    - key: location
-      value: global
-      action: upsert
-
-  resourceattributetransposer:
-    operations:
-      # Rabbitmq metrics require unique metric labels, otherwise the Google
-      # API will reject some metrics as "out of order" / duplicates. This happens
-      # when there are multiple rabbitmq instances or multiple vhosts / queues.
-      - from: host.name
-        to: agent
-      - from: rabbitmq.queue.name
-        to: queue
-      - from: rabbitmq.vhost.name
-        to: vhost
-
-  normalizesums:
-
-  batch:
-
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: workload.googleapis.com
-    resource_mappings:
-      - source_type: ""
-        target_type: generic_node
-        label_mappings:
-          - source_key: rabbitmq.node.name
-            target_key: node_id
-          - source_key: rabbitmq.node.name
-            target_key: namespace
-          - source_key: location
-            target_key: location
+      resource_filters:
+        - prefix: rabbitmq
 
 service:
   pipelines:
     metrics:
       receivers:
       - rabbitmq
-      processors:
-      - resourcedetection
-      - resource
-      - resourceattributetransposer
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/redis/config.yaml
+++ b/config/google_cloud_exporter/redis/config.yaml
@@ -3,55 +3,13 @@ receivers:
     endpoint: "localhost:6379"
     collection_interval: 60s
 
-processors:
-  # Resourcedetection is used to add a unique (host.name)
-  # to the metric resource(s), allowing users to filter
-  # between multiple agent systems.
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "redis"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
-
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    metric:
-      prefix: custom.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: host.name
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
 
 service:
   pipelines:
     metrics:
       receivers:
       - redis
-      processors:
-      - resourcedetection
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud

--- a/config/google_cloud_exporter/syslog/README.md
+++ b/config/google_cloud_exporter/syslog/README.md
@@ -6,8 +6,6 @@ The Syslog receiver can be used to receive Syslog and forward to Google Cloud Lo
 
 See the [prerequisites](../README.md) doc for Google Cloud prerequisites.
 
-Edit the configuration and replace `project: REPLACE_ME` with the project id you wish to write logs to.
-
 ## Examples
 
 **Rsyslog RFC 3164**

--- a/config/google_cloud_exporter/syslog/config.yaml
+++ b/config/google_cloud_exporter/syslog/config.yaml
@@ -10,9 +10,6 @@ receivers:
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
-    project: REPLACE_ME
 
 service:
   pipelines:

--- a/config/google_cloud_exporter/tomcat/config.yaml
+++ b/config/google_cloud_exporter/tomcat/config.yaml
@@ -4,62 +4,19 @@ receivers:
     endpoint: localhost:9000
     target_system: tomcat,jvm
     collection_interval: 60s
-    properties:
-      # Attribute 'endpoint' will be used for generic_node's node_id field.
-      otel.resource.attributes: endpoint=localhost:9000
-
-processors:
-  resourcedetection:
-    detectors: ["system"]
-    system:
-      hostname_sources: ["os"]
-
-  resourceattributetransposer:
-    operations:
-      - from: "host.name"
-        to: "agent"
-
-  # Used for Google generic_node mapping.
-  resource:
-    attributes:
-    - key: namespace
-      value: "tomcat"
-      action: upsert
-    - key: location
-      value: "global"
-      action: upsert
-
-  normalizesums:
-
-  batch:
+    resource_attributes:
+      tomcat.endpoint: localhost:9000
 
 exporters: 
   googlecloud:
-    retry_on_failure:
-      enabled: false
     metric:
-      prefix: custom.googleapis.com
-    resource_mappings:
-    - source_type: ""
-      target_type: generic_node
-      label_mappings:
-      - source_key: endpoint
-        target_key: node_id
-      - source_key: location
-        target_key: location
-      - source_key: namespace
-        target_key: namespace
+      resource_filters:
+        - prefix: tomcat
 
 service:
   pipelines:
     metrics:
       receivers:
       - jmx
-      processors:
-      - resourcedetection
-      - resourceattributetransposer
-      - resource
-      - normalizesums
-      - batch
       exporters:
       - googlecloud


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The latest Google exporter allows us to simplify most of the example configs

**Metrics**

- Removed batch and normalizesums, as these are handled by the exporter now
- Generally removed the need for RAT processor. It is still useful sometimes, but the new exporter allows us to copy resource attributes with the `metric.resource_filters[].prefix` setting.
- Generally removed the need for resource detection, as the exporter handles this. This could change in the future, and it will be trivial to re-add resource detection to these configs.
- Removed all resource mapping configs, this is no longer exposed.
- Use `resource_attributes` option on all jmx receivers.
- Set Google `metric.prefix` when metric names can conflict with other receivers

**Logs**

- Removed `project` requirement, no longer required

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
