### PR TITLE
feat(example config): New Relic Elasticsearch and Redis

### DIFF
--- a/config/new_relic_otlp/elasticsearch/README.md
+++ b/config/new_relic_otlp/elasticsearch/README.md
@@ -1,0 +1,7 @@
+# Elasticsearch Metrics with New Relic
+
+The Elasticsearch Receiver can be used to send Elasticsearch metrics to New Relic.
+
+## Prerequisites
+
+You must update this example config with the endpoint and license key (api key) for your account. See the [doc](../README.md) for New Relic prerequisites.

--- a/config/new_relic_otlp/elasticsearch/config.yaml
+++ b/config/new_relic_otlp/elasticsearch/config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  elasticsearch:
+    nodes: ["_local"]
+    endpoint: http://localhost:9200
+    collection_interval: 60s
+
+processors:
+  batch:
+
+exporters:
+  otlp:
+    endpoint: https://otlp.nr-data.net:443
+    headers:
+      api-key: 00000-00000-00000
+    tls:
+      insecure: false
+
+service:
+  pipelines:
+    metrics:
+      receivers:
+      - elasticsearch
+      processors:
+      - batch
+      exporters:
+      - otlp

--- a/config/new_relic_otlp/redis/README.md
+++ b/config/new_relic_otlp/redis/README.md
@@ -1,0 +1,7 @@
+# Redis Metrics with New Relic
+
+The Redis Receiver can be used to send Redis metrics to New Relic.
+
+## Prerequisites
+
+You must update this example config with the endpoint and license key (api key) for your account. See the [doc](../README.md) for New Relic prerequisites.

--- a/config/new_relic_otlp/redis/config.yaml
+++ b/config/new_relic_otlp/redis/config.yaml
@@ -1,11 +1,7 @@
 receivers:
-  jmx:
-    jar_path: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-    endpoint: localhost:7199
-    target_system: cassandra,jvm
+  redis:
+    endpoint: "localhost:6379"
     collection_interval: 60s
-    resource_attributes:
-      cassandra.endpoint: localhost:7199
 
 processors:
   resourcedetection:
@@ -27,7 +23,7 @@ service:
   pipelines:
     metrics:
       receivers:
-      - jmx
+      - redis
       processors:
       - resourcedetection
       - batch


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->

- Added Elasticsearch metrics for New Relic
- Added Redis metrics for New Relic
- Fixed Cassandra for New Relic (properties.otel.resource.attributes was replaced by resource_attributes)
  - Updated the attribute name to `cassandra.endpoint` to follow the pattern used in other jmx based configs

Redis includes the resource detection processor as it does not include identifiable attributes out of the box. Elasticsearch has node name and cluster name attributes that can be used for identification.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
