### PR TITLE
fix(installscripts): Return exit code 0 on successful actions

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -206,6 +206,15 @@ force_exit()
   exit 1
 }
 
+# like force_exit, but returns exit code 0
+force_exit_no_error()
+{
+  # Exit regardless of subshell level with no "Terminated" message
+  kill -PIPE $$
+  # Call exit to handle special circumstances (like running script during docker container build)
+  exit 0
+}
+
 error_exit()
 {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
@@ -603,15 +612,15 @@ main()
           version=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
-          force_exit
+          force_exit_no_error
           ;;
         -u|--upgrade)
           upgrade
-          force_exit
+          force_exit_no_error
           ;;
         -h|--help)
           usage
-          force_exit
+          force_exit_no_error
           ;;
         -e|--endpoint)
           opamp_endpoint=$2 ; shift 2 ;;

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -206,15 +206,6 @@ force_exit()
   exit 1
 }
 
-# like force_exit, but returns exit code 0
-force_exit_no_error()
-{
-  # Exit regardless of subshell level with no "Terminated" message
-  kill -PIPE $$
-  # Call exit to handle special circumstances (like running script during docker container build)
-  exit 0
-}
-
 error_exit()
 {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
@@ -612,15 +603,15 @@ main()
           version=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
-          force_exit_no_error
+          exit 0
           ;;
         -u|--upgrade)
           upgrade
-          force_exit_no_error
+          exit 0
           ;;
         -h|--help)
           usage
-          force_exit_no_error
+          exit 0
           ;;
         -e|--endpoint)
           opamp_endpoint=$2 ; shift 2 ;;

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -217,15 +217,6 @@ force_exit()
   exit 1
 }
 
-# like force_exit, but exits with code 0
-force_exit_no_error()
-{
-  # Exit regardless of subshell level with no "Terminated" message
-  kill -PIPE $$
-  # Call exit to handle special circumstances (like running script during docker container build)
-  exit 0
-}
-
 error_exit()
 {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
@@ -704,11 +695,11 @@ main()
           opamp_secret_key=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
-          force_exit_no_error
+          exit 0
           ;;
         -h|--help)
           usage
-          force_exit_no_error
+          exit 0
           ;;
       --)
         shift; break ;;

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -217,6 +217,15 @@ force_exit()
   exit 1
 }
 
+# like force_exit, but exits with code 0
+force_exit_no_error()
+{
+  # Exit regardless of subshell level with no "Terminated" message
+  kill -PIPE $$
+  # Call exit to handle special circumstances (like running script during docker container build)
+  exit 0
+}
+
 error_exit()
 {
   line_num=$(if [ -n "$1" ]; then command printf ":$1"; fi)
@@ -695,11 +704,11 @@ main()
           opamp_secret_key=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
-          force_exit
+          force_exit_no_error
           ;;
         -h|--help)
           usage
-          force_exit
+          force_exit_no_error
           ;;
       --)
         shift; break ;;


### PR DESCRIPTION
### Proposed Change
* When force exiting, return exit code 0 when successful

For some actions, we were using force_exit to exit the script after the action was done (e.g. uninstall). This returns exit code 1, indicating a failure, even if the script ran successfully. Noticed this while trying to automate testing for uninstallation.

Tested on mac and AlmaLinux 8.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
