### PR TITLE
feat: Add Couchbase metrics plugin

### DIFF
--- a/plugins/couchbase_metrics.yaml
+++ b/plugins/couchbase_metrics.yaml
@@ -1,0 +1,158 @@
+version: 0.0.1
+title: Couchbase Metrics
+description: Metrics receiver for Couchbase
+parameters:
+  - name: endpoint
+    type: string
+    default: localhost:8091
+  - name: username
+    type: string
+    required: true
+  - name: password
+    type: string
+    required: true
+  - name: scrape_interval
+    type: string
+    default: 60s
+template: |
+  receivers:
+    prometheus/couchbase:
+      config:
+        scrape_configs:
+          - job_name: 'couchbase'
+            scrape_interval: '{{ .scrape_interval }}'
+            static_configs:
+              - targets: ['{{ .endpoint }}']
+            basic_auth:
+              username: '{{ .username }}'
+              password: '{{ .password }}'
+            metric_relabel_configs:
+              # Include only a few key metrics
+              - source_labels: [ __name__ ]
+                regex: "(kv_ops)|\
+                  (kv_vb_curr_items)|\
+                  (kv_num_vbuckets)|\
+                  (kv_ep_cursor_memory_freed_bytes)|\
+                  (kv_total_memory_used_bytes)|\
+                  (kv_ep_num_value_ejects)|\
+                  (kv_ep_mem_high_wat)|\
+                  (kv_ep_mem_low_wat)|\
+                  (kv_ep_tmp_oom_errors)|\
+                  (kv_ep_oom_errors)"
+                action: keep
+
+  processors:
+    filter/couchbase:
+      # Filter out prometheus scraping meta-metrics.
+      metrics:
+        exclude:
+          match_type: strict
+          metric_names:
+            - scrape_samples_post_metric_relabeling
+            - scrape_series_added
+            - scrape_duration_seconds
+            - scrape_samples_scraped
+            - up
+
+    metricstransform/couchbase:
+      transforms:
+        # Rename from prometheus metric name to OTel metric name.
+        # We cannot do this with metric_relabel_configs, as the prometheus receiver does not
+        # allow metric renames at this time.
+        - include: kv_ops
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.operation.count"
+        - include: kv_vb_curr_items
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.item.count"
+        - include: kv_num_vbuckets
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.vbucket.count"
+        - include: kv_ep_cursor_memory_freed_bytes
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.memory.usage.free"
+        - include: kv_total_memory_used_bytes
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.memory.usage.used"
+        - include: kv_ep_num_value_ejects
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.item.ejection.count"
+        - include: kv_ep_mem_high_wat
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.memory.high_water_mark.limit"
+        - include: kv_ep_mem_low_wat
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.memory.low_water_mark.limit"
+        - include: kv_ep_tmp_oom_errors
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.error.oom.count.recoverable"
+        - include: kv_ep_oom_errors
+          match_type: strict
+          action: update
+          new_name: "couchbase.bucket.error.oom.count.unrecoverable"
+        # Combine couchbase.bucket.error.oom.count.x and couchbase.bucket.memory.usage.x
+        # metrics.
+        - include: '^couchbase\.bucket\.error\.oom\.count\.(?P<error_type>unrecoverable|recoverable)$$'
+          match_type: regexp
+          action: combine
+          new_name: "couchbase.bucket.error.oom.count"
+        - include: '^couchbase\.bucket\.memory\.usage\.(?P<state>free|used)$$'
+          match_type: regexp
+          action: combine
+          new_name: "couchbase.bucket.memory.usage"
+        # Aggregate "result" label on operation count to keep label sets consistent across the metric datapoints
+        - include: 'couchbase.bucket.operation.count'
+          match_type: strict
+          action: update
+          operations:
+            - action: aggregate_labels
+              label_set: ["bucket", "op"]
+              aggregation_type: sum
+
+    transform/couchbase:
+      metrics:
+        queries:
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.operation.count"
+          - set(metric.description, "Number of operations on the bucket.") where metric.name == "couchbase.bucket.operation.count"
+          - set(metric.unit, "{operations}") where metric.name == "couchbase.bucket.operation.count"
+
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.item.count"
+          - set(metric.description, "Number of items that belong to the bucket.") where metric.name == "couchbase.bucket.item.count"
+          - set(metric.unit, "{items}") where metric.name == "couchbase.bucket.item.count"
+
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.vbucket.count"
+          - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "couchbase.bucket.vbucket.count"
+          - set(metric.unit, "{vbuckets}") where metric.name == "couchbase.bucket.vbucket.count"
+
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.memory.usage"
+          - set(metric.description, "Usage of total memory available to the bucket.") where metric.name == "couchbase.bucket.memory.usage"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.usage"
+
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.item.ejection.count"
+          - set(metric.description, "Number of item value ejections from memory to disk.") where metric.name == "couchbase.bucket.item.ejection.count"
+          - set(metric.unit, "{ejections}") where metric.name == "couchbase.bucket.item.ejection.count"
+
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.error.oom.count"
+          - set(metric.description, "Number of out of memory errors.") where metric.name == "couchbase.bucket.error.oom.count"
+          - set(metric.unit, "{errors}") where metric.name == "couchbase.bucket.error.oom.count"
+
+          - set(metric.description, "The memory usage at which items will be ejected.") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
+
+          - set(metric.description, "The memory usage at which ejections will stop that were previously triggered by a high water mark breach.") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
+
+  service:
+    pipelines:
+      metrics/couchbase:
+        receivers: [prometheus/couchbase]
+        processors: [filter/couchbase, metricstransform/couchbase, transform/couchbase]


### PR DESCRIPTION
### Proposed Change
* Add a metric plugin for Couchbase

Tested against a dockerized Couchbase instance with the following config.

<details> 
    <summary>Sample config</summary>

  ```yaml
    receivers:
      plugin:
        path: './plugins/couchbase_metrics.yaml'
        parameters:
          username: 'otelu'
          password: 'otelpassword'
          scrape_interval: '5s'
    
    exporters:
      logging:
        loglevel: debug
    
    service:
      pipelines:
        metrics:
          receivers: [plugin]
          exporters: [logging]
      telemetry:
        metrics:
          level: none
  ```
</details> 

<details> 
  <summary>Sample metric datapoint</summary>

  ```
  2022-06-13T14:19:46.541-0400    DEBUG   loggingexporter/logging_exporter.go:67  ResourceMetrics #0
  Resource SchemaURL: 
  Resource labels:
       -> service.name: STRING(couchbase)
       -> service.instance.id: STRING(localhost:8091)
       -> net.host.port: STRING(8091)
       -> http.scheme: STRING(http)
  ScopeMetrics #0
  ScopeMetrics SchemaURL: 
  InstrumentationScope  
  Metric #0
  Descriptor:
       -> Name: couchbase.bucket.item.count
       -> Description: Number of items that belong to the bucket.
       -> Unit: {items}
       -> DataType: Sum
       -> IsMonotonic: false
       -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
  NumberDataPoints #0
  Data point attributes:
       -> bucket: STRING(otelb)
       -> state: STRING(active)
  StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
  Timestamp: 2022-06-13 18:19:46.015 +0000 UTC
  Value: 0.000000
  NumberDataPoints #1
  Data point attributes:
       -> bucket: STRING(otelb)
       -> state: STRING(replica)
  StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
  Timestamp: 2022-06-13 18:19:46.015 +0000 UTC
  Value: 0.000000
  01 00:00:00 +0000 UTC
  Timestamp: 2022-06-13 18:19:46.015 +0000 UTC
  Value: 0.000000
  ...
  ```
</details>

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
