### PR TITLE
Added GitHub action to trigger homebrew action

### DIFF
--- a/.github/workflows/homebrew-update-current.yml
+++ b/.github/workflows/homebrew-update-current.yml
@@ -1,8 +1,8 @@
 name: update_homebrew_current
 on:
   release:
-    # edited is the event triggered when changing from a pre-release to a release on a published release
-    type: [edited]
+    # released is triggered when a pre-release is changed to a release see documentation https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
+    type: [released]
 
 jobs:
   trigger-hombrew-update:

--- a/.github/workflows/homebrew-update-current.yml
+++ b/.github/workflows/homebrew-update-current.yml
@@ -1,0 +1,25 @@
+name: update_homebrew_current
+on:
+  release:
+    # edited is the event triggered when changing from a pre-release to a release on a published release
+    type: [edited]
+
+jobs:
+  trigger-hombrew-update:
+    # Only trigger this if it's not a prerelease
+    if: "!github.event.release.prerelease"
+    runs-on: "ubuntu-20.04"
+    steps:
+      # Extract version from release and remove leading 'v'
+      - name: Get Release Version
+        id: get_version
+        run: |
+          echo "::set-output name=version::$(echo ${{ github.event.release.tag_name }} | sed 's/v//')"
+      # Trigger Action on homebrew repository
+      - name: Trigger Homebrew Action
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
+          repository: observIQ/homebrew-observiq-otel-collector
+          event-type: upstream_release
+          client-payload: '{ "new_version": "${{ steps.get_version.outputs.version }}" }'


### PR DESCRIPTION
### Proposed Change
Adds a GitHub action that will trigger on an edit to a release. This will occur when we change a pre-release to a release. The action sends a `repository_dispatch` event to the https://github.com/observIQ/homebrew-observiq-otel-collector repo to trigger the action to update the homebrew formulas.

Triggers action detailed in observIQ/homebrew-observiq-otel-collector#1.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
