### PR TITLE
feat: Hadoop log plugin

### DIFF
--- a/plugins/hadoop_logs.yaml
+++ b/plugins/hadoop_logs.yaml
@@ -1,0 +1,93 @@
+version: 0.0.1
+title: Apache Hadoop
+description: Log parser for Apache Hadoop
+parameters:
+  - name: enable_datanode_logs
+    type: bool
+    default: true
+  - name: datanode_log_path
+    type: "[]string"
+    default:
+      - "/usr/local/hadoop/logs/hadoop-*-datanode-*.log"
+  - name: enable_resourcemgr_logs
+    type: bool
+    default: true
+  - name: resourcemgr_log_path
+    type: "[]string"
+    default:
+      - "/usr/local/hadoop/logs/hadoop-*-resourcemgr-*.log"
+  - name: enable_namenode_logs
+    type: bool
+    default: true
+  - name: namenode_log_path
+    type: "[]string"
+    default:
+      - "/usr/local/hadoop/logs/hadoop-*-namenode-*.log"
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ if .enable_datanode_logs }}
+        {{ range $fp := .datanode_log_path }}
+        - '{{ $fp }}'
+        {{ end }}
+        {{ end }}
+        {{ if .enable_resourcemgr_logs }}
+        {{ range $fp := .resourcemgr_log_path }}
+        - '{{ $fp }}'
+        {{ end }}
+        {{ end }}
+        {{ if .enable_namenode_logs }}
+        {{ range $fp := .namenode_log_path }}
+        - '{{ $fp }}'
+        {{ end }}
+        {{ end }}
+      start_at: {{ .start_at }}
+      multiline:
+        line_start_pattern: '^\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3} [A-Z]+'
+      operators:
+        # Set log_type attribute based on file name
+        - type: router
+          routes:
+            - attributes:
+                log_type: hadoop.datanode
+              expr: attributes["log.file.name"] contains "datanode"
+              output: regex_parser
+            - attributes:
+                log_type: hadoop.resource_manager
+              expr: attributes["log.file.name"] contains "resourcemanager"
+              output: regex_parser
+            - attributes:
+                log_type: hadoop.namenode
+              expr: attributes["log.file.name"] contains "namenode"
+              output: regex_parser  
+            - attributes:
+                log_type: hadoop
+              expr: true
+              output: regex_parser          
+
+        - type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}),\d{3}\s(?P<severity>[A-Z]*)\s(?P<fqcn>[A-Za-z0-9\.\$]+):\s(?P<message>(?s)\S.*\S)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%d %H:%M:%S'
+          severity:
+            parse_from: attributes.severity
+            mapping:
+              info2: notice
+              error2: critical
+              error3: alert
+              fatal2: emergency
+              fatal3: catastrophe
+
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - filelog


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->

Ported Hadoop plugin from Stanza
- Merged all three file inputs into a single file log receiver
  - Multiline pattern and regex parser are the same, no need to define them three times
- Use router to set log type from the file name. The file name seems to be stable enough for this.

Works well against a live system. 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
