### PR TITLE
feat: Add Zookeeper Plugin

### DIFF
--- a/plugins/zookeeper_logs.yaml
+++ b/plugins/zookeeper_logs.yaml
@@ -1,0 +1,41 @@
+version: 0.0.1
+title: Apache Zookeeper
+description: Log parser for Apache Zookeeper
+parameters:
+  - name: file_path
+    type: "[]string"
+    default: 
+      - "/home/kafka/kafka/logs/zookeeper.log"
+  - name: start_at
+    type: string
+    valid_values:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ range $fp := .file_path }}
+        - '{{ $fp }}'
+        {{ end }}
+      start_at: {{ .start_at }}
+      operators:
+        - type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3} \[myid:(?P<myid>[^\]]*)\] - (?P<zookeeper_severity>[A-Z]+)\s+\[(?P<source>[^\]]+)\] - (?P<message>.*)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%d %H:%M:%S'
+          severity:
+            parse_from: attributes.zookeeper_severity
+            mapping:
+              info2: notice
+              error2: critical
+              error3: alert
+              fatal2: emergency
+              fatal3: catastrophe
+
+  service:
+    pipelines:
+      logs:
+        receivers: [filelog]

--- a/plugins/zookeeper_logs.yaml
+++ b/plugins/zookeeper_logs.yaml
@@ -8,7 +8,7 @@ parameters:
       - "/home/kafka/kafka/logs/zookeeper.log"
   - name: start_at
     type: string
-    valid_values:
+    supported:
       - beginning
       - end
     default: end
@@ -21,8 +21,16 @@ template: |
         {{ end }}
       start_at: {{ .start_at }}
       operators:
-        - type: regex_parser
-          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d{3} \[myid:(?P<myid>[^\]]*)\] - (?P<zookeeper_severity>[A-Z]+)\s+\[(?P<source>[^\]]+)\] - (?P<message>.*)'
+        - id: regex_router
+          type: router
+          routes: 
+            - expr: 'body matches "^(?P<timestamp>\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:\\d{2}:\\d{2},\\d{3})\\s\\[myid:(?P<myid>\\d+)?\\].*"'
+              output: my_id_regex
+          default: no_id_regex 
+
+        - id: my_id_regex
+          type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})\s\[myid:(?P<myid>\d+)?\]\s-\s(?P<zookeeper_severity>\w+)\s+\[(?P<thread>.+):(?P<source>.+)@(?P<line>\d+)\]\s+-\s*(?P<message>[^\n]*)'
           timestamp:
             parse_from: attributes.timestamp
             layout: '%Y-%m-%d %H:%M:%S'
@@ -34,6 +42,27 @@ template: |
               error3: alert
               fatal2: emergency
               fatal3: catastrophe
+          output: add_type
+
+        - id: no_id_regex
+          type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3})\s-\s(?P<zookeeper_severity>\w+)\s+\[(?P<thread>.+):(?P<source>.+)@(?P<line>\d+)\]\s+-\s*(?P<message>[^\n]+)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%d %H:%M:%S'
+          severity:
+            parse_from: attributes.zookeeper_severity
+            mapping:
+              info2: notice
+              error2: critical
+              error3: alert
+              fatal2: emergency
+              fatal3: catastrophe
+
+        - id: add_type
+          type: add
+          field: attributes.log_type
+          value: 'zookeeper'
 
   service:
     pipelines:


### PR DESCRIPTION
### Proposed Change
- Added a logging plugin for apache zookeeper
- Tested using the file located here: [https://github.com/observIQ/log-library/blob/master/library/hbase/zookeeper.log](url)
- Example Log:
```
LogRecord #32
ObservedTimestamp: 2022-06-16 19:53:47.538867 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: 2020-12-09 20:38:42,979 INFO  [main] server.ZooKeeperServer: Server environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib/x86_64-linux-gnu/jni:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/jni:/lib:/usr/lib
Attributes:
     -> log.file.name: STRING(zookeeper.txt)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
