### PR TITLE
fix: Removes double forward slash in manager.yaml symlink

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -20,7 +20,7 @@ FORMULA_NAME="observiq/observiq-otel-collector/observiq-otel-collector"
 SERVICE_NAME="com.observiq.collector"
 
 # Script Constants
-BREW_ETC=$(brew --prefix)/etc/
+BREW_ETC=$(brew --prefix)/etc
 PREREQS="printf brew sed uname uuidgen tr"
 CONFIG_PREFIX="observiq_"
 CONFIG_YML_NAME="config.yaml"


### PR DESCRIPTION
### Proposed Change
Removes the double forward slash for the manager.yaml symlink in homebrew
<img width="780" alt="image" src="https://user-images.githubusercontent.com/12396806/174315422-2360de22-32df-4a74-9c09-153b19164387.png">


##### Checklist
- [x] Changes are tested
- [ ] CI has passed
