### PR TITLE
feat: Add Active Directory log plugin

### DIFF
--- a/plugins/active_directory_logs.yaml
+++ b/plugins/active_directory_logs.yaml
@@ -1,0 +1,84 @@
+version: 0.0.1
+title: Active Directory
+description: Log parser for Active Directory
+parameters:
+  - name: enable_dns_server
+    type: bool
+    default: true
+  - name: enable_dfs_replication
+    type: bool
+    default: true
+  - name: enable_file_replication
+    type: bool
+    default: false
+  - name: poll_interval
+    type: string
+    default: 1s
+  - name: max_reads
+    type: int
+    default: 1000
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    windowseventlog/general:
+      channel: "Directory Service"
+      max_reads: {{ .max_reads }}
+      poll_interval: '{{ .poll_interval }}'
+      start_at: '{{ .start_at }}'
+      attributes:
+        log_type: "active_directory.general"
+    windowseventlog/web_services:
+      channel: "Active Directory Web Services"
+      max_reads: {{ .max_reads }}
+      poll_interval: '{{ .poll_interval }}'
+      start_at: '{{ .start_at }}'
+      attributes:
+        log_type: "active_directory.web_services"
+    # {{ if .enable_dns_server }}
+    windowseventlog/dns:
+      channel: "DNS Server"
+      max_reads: {{ .max_reads }}
+      poll_interval: '{{ .poll_interval }}'
+      start_at: '{{ .start_at }}'
+      attributes:
+        log_type: "active_directory.dns"
+    # {{ end }}
+    # {{ if .enable_dfs_replication }}
+    windowseventlog/dfs:
+      channel: "DFS Replication"
+      max_reads: {{ .max_reads }}
+      poll_interval: '{{ .poll_interval }}'
+      start_at: '{{ .start_at }}'
+      attributes:
+        log_type: "active_directory.dfs"
+    # {{ end }}
+    # {{ if .enable_file_replication }}
+    windowseventlog/frs:
+      channel: "File Replication Service"
+      max_reads: {{ .max_reads }}
+      poll_interval: '{{ .poll_interval }}'
+      start_at: '{{ .start_at }}'
+      attributes:
+        log_type: "active_directory.frs"
+    # {{ end }}
+
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - windowseventlog/general
+          - windowseventlog/web_services
+          # {{ if .enable_dns_server }}
+          - windowseventlog/dns
+          # {{ end }}
+          # {{ if .enable_dfs_replication }}
+          - windowseventlog/dfs
+          # {{ end }}
+          # {{ if .enable_file_replication }}
+          - windowseventlog/frs
+          # {{ end }}

--- a/plugins/active_directory_logs.yaml
+++ b/plugins/active_directory_logs.yaml
@@ -1,5 +1,5 @@
 version: 0.0.1
-title: Active Directory
+title: Active Directory Logs
 description: Log parser for Active Directory
 parameters:
   - name: enable_dns_server

--- a/plugins/active_directory_logs.yaml
+++ b/plugins/active_directory_logs.yaml
@@ -39,7 +39,7 @@ template: |
       start_at: '{{ .start_at }}'
       attributes:
         log_type: "active_directory.web_services"
-    # {{ if .enable_dns_server }}
+    {{ if .enable_dns_server }}
     windowseventlog/dns:
       channel: "DNS Server"
       max_reads: {{ .max_reads }}
@@ -47,8 +47,8 @@ template: |
       start_at: '{{ .start_at }}'
       attributes:
         log_type: "active_directory.dns"
-    # {{ end }}
-    # {{ if .enable_dfs_replication }}
+    {{ end }}
+    {{ if .enable_dfs_replication }}
     windowseventlog/dfs:
       channel: "DFS Replication"
       max_reads: {{ .max_reads }}
@@ -56,8 +56,8 @@ template: |
       start_at: '{{ .start_at }}'
       attributes:
         log_type: "active_directory.dfs"
-    # {{ end }}
-    # {{ if .enable_file_replication }}
+    {{ end }}
+    {{ if .enable_file_replication }}
     windowseventlog/frs:
       channel: "File Replication Service"
       max_reads: {{ .max_reads }}
@@ -65,7 +65,7 @@ template: |
       start_at: '{{ .start_at }}'
       attributes:
         log_type: "active_directory.frs"
-    # {{ end }}
+    {{ end }}
 
   service:
     pipelines:
@@ -73,12 +73,12 @@ template: |
         receivers:
           - windowseventlog/general
           - windowseventlog/web_services
-          # {{ if .enable_dns_server }}
+          {{ if .enable_dns_server }}
           - windowseventlog/dns
-          # {{ end }}
-          # {{ if .enable_dfs_replication }}
+          {{ end }}
+          {{ if .enable_dfs_replication }}
           - windowseventlog/dfs
-          # {{ end }}
-          # {{ if .enable_file_replication }}
+          {{ end }}
+          {{ if .enable_file_replication }}
           - windowseventlog/frs
-          # {{ end }}
+          {{ end }}


### PR DESCRIPTION
### Proposed Change
* Port the stanza active directory log plugin to an OTEL plugin

Sample plugin on a system with active directory installed:
```
ObservedTimestamp: 2022-06-20 19:32:24.6656296 +0000 UTC
Timestamp: 2022-06-20 18:42:19.7294182 +0000 UTC
Severity: Info
Body: {
     -> channel: STRING(Directory Service)
     -> computer: STRING(brandon-win-build.test.example.com)
     -> event_data: SLICE(["NTDS","696,D,0","NTDSA: ","C:\\Windows\\NTDS\\ntds.dit","0","6/20/2022","0","1","1","43"])
     -> event_id: MAP({"id":701,"qualifiers":0})
     -> keywords: SLICE(["Classic"])
     -> level: STRING(Information)
     -> message: STRING(NTDS (696,D,0) NTDSA: Online defragmentation has completed a full pass on database 'C:\Windows\NTDS\ntds.dit', freeing 0 pages. This pass started on 6/20/2022 and ran for a total of 0 seconds, requiring 1 invocations over 1 days. Since the database was created it has been fully defragmented 43 times.)
     -> opcode: STRING(Info)
     -> provider: MAP({"event_source":"","guid":"","name":"NTDS ISAM"})
     -> record_id: INT(310)
     -> system_time: STRING(2022-06-20T18:42:19.729418200Z)
     -> task: STRING(Performance)
}
Attributes:
     -> log_type: STRING(active_directory.general)
Trace ID:
Span ID:
Flags: 0
```

Also tested to make sure this shows up correctly when being sent to GCP.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
