### PR TITLE
feat: Adds the Windows DHCP plugin

### DIFF
--- a/plugins/windows_dhcp.yaml
+++ b/plugins/windows_dhcp.yaml
@@ -1,0 +1,42 @@
+version: 0.0.1
+title: Windows DHCP
+description: Log parser for Windows DHCP
+parameters:
+  - name: file_path
+    type: "[]string"
+    default: 
+      - "C:/Windows/System32/dhcp/DhcpSrvLog-*.log"
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+      {{ range $fp := .file_path }}
+        - '{{ $fp }}'
+      {{ end }}
+      start_at: {{ .start_at }}
+      attributes:
+        log_type: 'microsoft_dhcp'
+      operators: 
+        - id: windows_dhcp_router
+          type: router
+          routes:
+            - output: windows_dhcp_parser
+              expr: body matches '^\\d+,\\d{2}\\/\\d{2}\\/\\d{2},\\d{2}:\\d{2}:\\d{2}'
+        - id: windows_dhcp_parser
+          type: regex_parser
+          regex: '^(?P<id>\d+),(?P<timestamp>\d{2}\/\d{2}\/\d{2},\d{2}:\d{2}:\d{2}),(?P<description>[^,]+),(?P<ip_address>[^,]*),(?P<hostname>[^,]*),(?P<mac_address>[^,]*),(?P<username>[^,]*),(?P<transaction_id>[^,]*),(?P<q_result>[^,]*),(?P<probation_time>[^,]*),(?P<correlation_id>[^,]*),(?P<dhc_id>[^,]*),(?P<vendor_class_hex>[^,]*)(,(?P<vendor_class_ascii>[^,]*),(?P<user_Class_hex>[^,]*),(?P<user_class_ascii>[^,]*),(?P<relay_agent_info>[^,]*),(?P<dns_reg_error>[^,]*))?'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%m/%d/%y,%H:%M:%S'
+    
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - filelog 


### PR DESCRIPTION
This is currently blocked by https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10128. Because all log files have lines 2 & 3 as empty lines, this bug affects every file. Even `start_at` end will have an issue once the log rolls over to the next day's file.

### Proposed Change
Adds the Windows DHCP plugin.

#### Sample config.yaml
```
receivers:
  plugin:
    path: ./plugins/windows_dhcp.yaml
    parameters:
      start_at: beginning
  
exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
```
#### Sample parsed log
```
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2022-06-21 17:14:03.939705 +0000 UTC
Timestamp: 2022-06-18 03:38:47 +0000 UTC
Severity: 
Body: 25,06/17/22,23:38:47,0 leases expired and 0 leases deleted,,,,,0,6,,,,,,,,,0
Attributes:
     -> username: STRING()
     -> id: STRING(25)
     -> timestamp: STRING(06/17/22,23:38:47)
     -> mac_address: STRING()
     -> correlation_id: STRING()
     -> transaction_id: STRING(0)
     -> vendor_class_ascii: STRING()
     -> dns_reg_error: STRING(0)
     -> q_result: STRING(6)
     -> user_Class_hex: STRING()
     -> log.file.name: STRING(DhcpSrvLog-Fri.log)
     -> dhc_id: STRING()
     -> ip_address: STRING()
     -> description: STRING(0 leases expired and 0 leases deleted)
     -> relay_agent_info: STRING()
     -> vendor_class_hex: STRING()
     -> hostname: STRING()
     -> probation_time: STRING()
     -> user_class_ascii: STRING()
     -> log_type: STRING(microsoft_dhcp)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
