### PR TITLE
feat(w3c): Add w3c logging plugin

### DIFF
--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,0 +1,149 @@
+version: 0.0.1
+title: W3C
+description: File Input W3C Parser
+min_stanza_version: 1.2.0
+parameters:
+  - name: file_log_path
+    type: strings
+    required: true
+  - name: exclude_file_log_path
+    type: strings
+    default: []
+  - name: encoding
+    type: enum
+    valid_values:
+      - utf-8
+      - utf-16le
+      - utf-16be
+      - ascii
+      - big5
+    default: utf-8
+  - name: log_type
+    type: string
+    default: w3c
+  - name: start_at
+    type: enum
+    valid_values:
+      - beginning
+      - end
+    default: end
+  - name: delete_after_read
+    type: bool
+    default: false
+  - name: max_concurrent_files
+    type: int
+    default: 512
+    advanced_config: true
+  - name: include_file_name
+    type: bool
+    default: true
+  - name: include_file_path
+    type: bool
+    default: false
+  - name: include_file_name_resolved
+    type: bool
+    default: false
+  - name: include_file_path_resolved
+    type: bool
+    default: false
+  - name: fields_header
+    type: string
+    default: Fields
+  - name: delimiter
+    type: string
+    default: "\t"
+  - name: header_delimiter
+    type: string
+    default: "\t"
+# Set Defaults
+# {{$encoding := default "utf-8" .encoding}}
+# {{$log_type := default "w3c" .log_type}}
+# {{$start_at := default "end" .start_at}}
+# {{$delete_after_read := default false .delete_after_read}}
+# {{$max_concurrent_files := default 512 .max_concurrent_files}}
+# {{$include_file_name := default true .include_file_name}}
+# {{$include_file_path := default false .include_file_path}}
+# {{$include_file_name_resolved := default false .include_file_name_resolved}}
+# {{$include_file_path_resolved := default false .include_file_path_resolved}}
+# {{$fields_header := default "Fields" .fields_header}}
+# {{$delimiter := default "\t" .delimiter}}
+# {{$header_delimiter := default "\t" .header_delimiter}}
+
+template: |
+  
+
+
+# Pipeline Template
+pipeline:
+  - type: file_input
+    start_at: '{{ $start_at }}'
+    delete_after_read: {{ $delete_after_read }}
+    max_concurrent_files: {{ $max_concurrent_files }}
+    label_regex: '^#(?P<key>.*?): (?P<value>.*)'
+    include_file_name: {{ $include_file_name }}
+    include_file_path: {{ $include_file_path }}
+    include_file_name_resolved: {{ $include_file_name_resolved }}
+    include_file_path_resolved: {{ $include_file_path_resolved }}
+    include:
+# {{ range $i, $fp := .file_log_path  }}
+      - '{{ $fp }}'
+# {{ end }}
+# {{ if .exclude_file_log_path }}
+    exclude:
+  # {{ range $i, $efp := .exclude_file_log_path  }}
+      - '{{ $efp }}'
+  # {{ end }}
+# {{ end }}
+# {{ if $encoding }}
+    encoding: '{{ $encoding }}'
+# {{ end }}
+    attributes:
+      plugin_id: {{ .id }}
+      log_type: '{{ $log_type }}'
+
+  # Ignore header lines that may exists in the file periodically
+  # or at the end. File input has already read the headers at the top
+  # of the file, and attached them as attributes to each entry.
+  # For example, some w3c logs may have these two fields at th end of a file:
+  #
+  # #End-Date: 2021-07-21 14:40:00
+  # #X-Records: 41373
+  #
+  - type: filter
+    expr: '$body matches "^#"'
+
+  - type: router
+    default: csv_parser
+    routes:
+      - output: quote_handler_parser
+        expr: $body matches '.*".*".*' and not ($body matches "^#")
+
+  # Some example log entries have quotes. This will cause an error.
+  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
+  # All examples from logs seen at time of this comment have only contained one set of quotes.
+  # Example:
+  # #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
+  # 2021-06-14 18:36:47 0.0.0.0 OutboundConnectionResponse SMTPSVC1 TSIC-PHOENIX - 25 - - 354+3.0.0+continue.++finished+with+"\r\n.\r\n" 0 0 46 0 531 SMTP - - - -
+  - id: quote_handler_parser
+    type: regex_parser
+    parse_from: $body
+    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
+    output: quote_handler_restructurer
+
+  # This will remove the first set of parsed quotes.
+  - id: quote_handler_restructurer
+    type: add
+    field: $body
+    value: 'EXPR($body.message1 + $body.message2 + $body.message3)'
+    output: csv_parser
+
+  # Leverage CSV parser's dynamic field name detection by specifying
+  # delimiter, header_delimiter, and header_label
+  - type: csv_parser
+    delimiter: '{{ $delimiter }}'
+    header_delimiter: '{{ $header_delimiter }}'
+    header_label: '{{ $fields_header }}'
+
+  - type: remove
+    field: '$attributes.{{ $fields_header }}'
+    output: {{ .output }}

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,7 +1,6 @@
 version: 0.0.1
 title: W3C
 description: File Input W3C Parser
-min_stanza_version: 1.2.0
 parameters:
   - name: file_log_path
     type: strings
@@ -11,7 +10,7 @@ parameters:
     default: []
   - name: encoding
     type: enum
-    valid_values:
+    supported:
       - utf-8
       - utf-16le
       - utf-16be
@@ -23,17 +22,13 @@ parameters:
     default: w3c
   - name: start_at
     type: enum
-    valid_values:
+    supported:
       - beginning
       - end
     default: end
-  - name: delete_after_read
-    type: bool
-    default: false
   - name: max_concurrent_files
     type: int
     default: 512
-    advanced_config: true
   - name: include_file_name
     type: bool
     default: true
@@ -55,95 +50,78 @@ parameters:
   - name: header_delimiter
     type: string
     default: "\t"
-# Set Defaults
-# {{$encoding := default "utf-8" .encoding}}
-# {{$log_type := default "w3c" .log_type}}
-# {{$start_at := default "end" .start_at}}
-# {{$delete_after_read := default false .delete_after_read}}
-# {{$max_concurrent_files := default 512 .max_concurrent_files}}
-# {{$include_file_name := default true .include_file_name}}
-# {{$include_file_path := default false .include_file_path}}
-# {{$include_file_name_resolved := default false .include_file_name_resolved}}
-# {{$include_file_path_resolved := default false .include_file_path_resolved}}
-# {{$fields_header := default "Fields" .fields_header}}
-# {{$delimiter := default "\t" .delimiter}}
-# {{$header_delimiter := default "\t" .header_delimiter}}
 
 template: |
-  
-
-
-# Pipeline Template
-pipeline:
-  - type: file_input
-    start_at: '{{ $start_at }}'
-    delete_after_read: {{ $delete_after_read }}
-    max_concurrent_files: {{ $max_concurrent_files }}
-    label_regex: '^#(?P<key>.*?): (?P<value>.*)'
-    include_file_name: {{ $include_file_name }}
-    include_file_path: {{ $include_file_path }}
-    include_file_name_resolved: {{ $include_file_name_resolved }}
-    include_file_path_resolved: {{ $include_file_path_resolved }}
+  filelog:
+    start_at: '{{ .start_at }}'
+    max_concurrent_files: {{ .max_concurrent_files }}
+    include_file_name: {{ .include_file_name }}
+    include_file_path: {{ .include_file_path }}
+    include_file_name_resolved: {{ .include_file_name_resolved }}
+    include_file_path_resolved: {{ .include_file_path_resolved }}
     include:
-# {{ range $i, $fp := .file_log_path  }}
+  {{ range $i, $fp := .file_log_path  }}
       - '{{ $fp }}'
-# {{ end }}
-# {{ if .exclude_file_log_path }}
+  {{ end }}
+  {{ if .exclude_file_log_path }}
     exclude:
-  # {{ range $i, $efp := .exclude_file_log_path  }}
+    {{ range $i, $efp := .exclude_file_log_path  }}
       - '{{ $efp }}'
-  # {{ end }}
-# {{ end }}
-# {{ if $encoding }}
-    encoding: '{{ $encoding }}'
-# {{ end }}
+    {{ end }}
+  {{ end }}
+  {{ if .encoding }}
+    encoding: '{{ .encoding }}'
+  {{ end }}
     attributes:
-      plugin_id: {{ .id }}
-      log_type: '{{ $log_type }}'
+      log_type: '{{ .log_type }}'
+    operators:
+      # Ignore header lines that may exists in the file periodically
+      # or at the end. File input has already read the headers at the top
+      # of the file, and attached them as attributes to each entry.
+      # For example, some w3c logs may have these two fields at th end of a file:
+      #
+      # #End-Date: 2021-07-21 14:40:00
+      # #X-Records: 41373
+      #
+      - type: filter
+        expr: 'body matches "^#"'
 
-  # Ignore header lines that may exists in the file periodically
-  # or at the end. File input has already read the headers at the top
-  # of the file, and attached them as attributes to each entry.
-  # For example, some w3c logs may have these two fields at th end of a file:
-  #
-  # #End-Date: 2021-07-21 14:40:00
-  # #X-Records: 41373
-  #
-  - type: filter
-    expr: '$body matches "^#"'
+      - type: router
+        default: csv_parser
+        routes:
+          - output: quote_handler_parser
+            expr: body matches '.*".*".*' and not (body matches "^#")
 
-  - type: router
-    default: csv_parser
-    routes:
-      - output: quote_handler_parser
-        expr: $body matches '.*".*".*' and not ($body matches "^#")
+      # Some example log entries have quotes. This will cause an error.
+      # This parses first set of quotes. If more than one set of quotes exist then it will still error.
+      # All examples from logs seen at time of this comment have only contained one set of quotes.
+      # Example:
+      # #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
+      # 2021-06-14 18:36:47 0.0.0.0 OutboundConnectionResponse SMTPSVC1 TSIC-PHOENIX - 25 - - 354+3.0.0+continue.++finished+with+"\r\n.\r\n" 0 0 46 0 531 SMTP - - - -
+      - id: quote_handler_parser
+        type: regex_parser
+        parse_from: body
+        regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
 
-  # Some example log entries have quotes. This will cause an error.
-  # This parses first set of quotes. If more than one set of quotes exist then it will still error.
-  # All examples from logs seen at time of this comment have only contained one set of quotes.
-  # Example:
-  # #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
-  # 2021-06-14 18:36:47 0.0.0.0 OutboundConnectionResponse SMTPSVC1 TSIC-PHOENIX - 25 - - 354+3.0.0+continue.++finished+with+"\r\n.\r\n" 0 0 46 0 531 SMTP - - - -
-  - id: quote_handler_parser
-    type: regex_parser
-    parse_from: $body
-    regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
-    output: quote_handler_restructurer
+      # This will remove the first set of parsed quotes.
+      - id: quote_handler_restructurer
+        type: add
+        field: attributes
+        value: 'EXPR(attributes.message1 + attributes.message2 + attributes.message3)'
+        output: csv_parser
 
-  # This will remove the first set of parsed quotes.
-  - id: quote_handler_restructurer
-    type: add
-    field: $body
-    value: 'EXPR($body.message1 + $body.message2 + $body.message3)'
-    output: csv_parser
+      # Leverage CSV parser's dynamic field name detection by specifying
+      # delimiter, header_delimiter, and header_label
+      - type: csv_parser
+        delimiter: '{{ .delimiter }}'
+        header_delimiter: '{{ .header_delimiter }}'
+        header_label: '{{ .fields_header }}'
 
-  # Leverage CSV parser's dynamic field name detection by specifying
-  # delimiter, header_delimiter, and header_label
-  - type: csv_parser
-    delimiter: '{{ $delimiter }}'
-    header_delimiter: '{{ $header_delimiter }}'
-    header_label: '{{ $fields_header }}'
-
-  - type: remove
-    field: '$attributes.{{ $fields_header }}'
-    output: {{ .output }}
+      - type: remove
+        field: 'attributes.{{ .fields_header }}'
+        output: {{ .output }}
+        
+  service:
+    pipelines:
+      logs:
+        receivers: [filelog]

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -58,18 +58,18 @@ template: |
       include_file_name_resolved: {{ .include_file_name_resolved }}
       include_file_path_resolved: {{ .include_file_path_resolved }}
       include:
-    # {{ range $i, $fp := .file_log_path  }}
+      {{ range $i, $fp := .file_log_path  }}
         - '{{ $fp }}'
-    # {{ end }}
-    # {{ if .exclude_file_log_path }}
+      {{ end }}
+      {{ if .exclude_file_log_path }}
       exclude:
       {{ range $i, $efp := .exclude_file_log_path  }}
         - '{{ $efp }}'
       {{ end }}
-    # {{ end }}
-    # {{ if .encoding }}
+      {{ end }}
+      {{ if .encoding }}
       encoding: '{{ .encoding }}'
-    # {{ end }}
+      {{ end }}
       attributes:
         log_type: {{ .log_type }}
       operators:
@@ -90,7 +90,7 @@ template: |
         - id: quote_handler_restructurer
           type: add
           field: body
-          value: 'EXPR(body.message1 + body.message2 + body.message3)'
+          value: 'EXPR(attributes.message1 + attributes.message2 + attributes.message3)'
           output: csv_parser
 
         - type: csv_parser

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,16 +1,13 @@
 version: 0.0.1
 title: W3C
-description: File Input W3C Parser
+description: Log Parser for W3C
 parameters:
   - name: file_log_path
     type: "[]string"
     required: true
-    default: 
-      - "/var/log/zookeeper/zookeeper.log"
   - name: exclude_file_log_path
     type: "[]string"
-    default: 
-      - ""
+    default: []
   - name: encoding
     type: string
     supported:
@@ -50,9 +47,6 @@ parameters:
   - name: delimiter
     type: string
     default: "\t"
-  - name: header_delimiter
-    type: string
-    default: "\t"
 
 template: |
   receivers:
@@ -77,7 +71,7 @@ template: |
       encoding: '{{ .encoding }}'
     # {{ end }}
       attributes:
-        log_type: w3c
+        log_type: {{ .log_type }}
       operators:
         - type: filter
           expr: 'body matches "^#"'

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -3,13 +3,16 @@ title: W3C
 description: File Input W3C Parser
 parameters:
   - name: file_log_path
-    type: strings
+    type: "[]string"
     required: true
+    default: 
+      - "/var/log/zookeeper/zookeeper.log"
   - name: exclude_file_log_path
-    type: strings
-    default: []
+    type: "[]string"
+    default: 
+      - ""
   - name: encoding
-    type: enum
+    type: string
     supported:
       - utf-8
       - utf-16le
@@ -21,7 +24,7 @@ parameters:
     type: string
     default: w3c
   - name: start_at
-    type: enum
+    type: string
     supported:
       - beginning
       - end
@@ -41,9 +44,9 @@ parameters:
   - name: include_file_path_resolved
     type: bool
     default: false
-  - name: fields_header
-    type: string
-    default: Fields
+  - name: header
+    type: "string"
+    required: true 
   - name: delimiter
     type: string
     default: "\t"
@@ -52,75 +55,54 @@ parameters:
     default: "\t"
 
 template: |
-  filelog:
-    start_at: '{{ .start_at }}'
-    max_concurrent_files: {{ .max_concurrent_files }}
-    include_file_name: {{ .include_file_name }}
-    include_file_path: {{ .include_file_path }}
-    include_file_name_resolved: {{ .include_file_name_resolved }}
-    include_file_path_resolved: {{ .include_file_path_resolved }}
-    include:
-  {{ range $i, $fp := .file_log_path  }}
-      - '{{ $fp }}'
-  {{ end }}
-  {{ if .exclude_file_log_path }}
-    exclude:
-    {{ range $i, $efp := .exclude_file_log_path  }}
-      - '{{ $efp }}'
-    {{ end }}
-  {{ end }}
-  {{ if .encoding }}
-    encoding: '{{ .encoding }}'
-  {{ end }}
-    attributes:
-      log_type: '{{ .log_type }}'
-    operators:
-      # Ignore header lines that may exists in the file periodically
-      # or at the end. File input has already read the headers at the top
-      # of the file, and attached them as attributes to each entry.
-      # For example, some w3c logs may have these two fields at th end of a file:
-      #
-      # #End-Date: 2021-07-21 14:40:00
-      # #X-Records: 41373
-      #
-      - type: filter
-        expr: 'body matches "^#"'
+  receivers:
+    filelog:
+      start_at: '{{ .start_at }}'
+      max_concurrent_files: {{ .max_concurrent_files }}
+      include_file_name: {{ .include_file_name }}
+      include_file_path: {{ .include_file_path }}
+      include_file_name_resolved: {{ .include_file_name_resolved }}
+      include_file_path_resolved: {{ .include_file_path_resolved }}
+      include:
+    # {{ range $i, $fp := .file_log_path  }}
+        - '{{ $fp }}'
+    # {{ end }}
+    # {{ if .exclude_file_log_path }}
+      exclude:
+      {{ range $i, $efp := .exclude_file_log_path  }}
+        - '{{ $efp }}'
+      {{ end }}
+    # {{ end }}
+    # {{ if .encoding }}
+      encoding: '{{ .encoding }}'
+    # {{ end }}
+      attributes:
+        log_type: w3c
+      operators:
+        - type: filter
+          expr: 'body matches "^#"'
 
-      - type: router
-        default: csv_parser
-        routes:
-          - output: quote_handler_parser
-            expr: body matches '.*".*".*' and not (body matches "^#")
+        - type: router
+          default: csv_parser
+          routes:
+            - output: quote_handler_parser
+              expr: body matches '.*".*".*' and not (body matches "^#")
 
-      # Some example log entries have quotes. This will cause an error.
-      # This parses first set of quotes. If more than one set of quotes exist then it will still error.
-      # All examples from logs seen at time of this comment have only contained one set of quotes.
-      # Example:
-      # #Fields: date time c-ip cs-username s-sitename s-computername s-ip s-port cs-method cs-uri-stem cs-uri-query sc-status sc-win32-status sc-bytes cs-bytes time-taken cs-version cs-host cs(User-Agent) cs(Cookie) cs(Referer)
-      # 2021-06-14 18:36:47 0.0.0.0 OutboundConnectionResponse SMTPSVC1 TSIC-PHOENIX - 25 - - 354+3.0.0+continue.++finished+with+"\r\n.\r\n" 0 0 46 0 531 SMTP - - - -
-      - id: quote_handler_parser
-        type: regex_parser
-        parse_from: body
-        regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
+        - id: quote_handler_parser
+          type: regex_parser
+          parse_from: body
+          regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
 
-      # This will remove the first set of parsed quotes.
-      - id: quote_handler_restructurer
-        type: add
-        field: attributes
-        value: 'EXPR(attributes.message1 + attributes.message2 + attributes.message3)'
-        output: csv_parser
+        - id: quote_handler_restructurer
+          type: add
+          field: body
+          value: 'EXPR(body.message1 + body.message2 + body.message3)'
+          output: csv_parser
 
-      # Leverage CSV parser's dynamic field name detection by specifying
-      # delimiter, header_delimiter, and header_label
-      - type: csv_parser
-        delimiter: '{{ .delimiter }}'
-        header_delimiter: '{{ .header_delimiter }}'
-        header_label: '{{ .fields_header }}'
-
-      - type: remove
-        field: 'attributes.{{ .fields_header }}'
-        output: {{ .output }}
-        
+        - type: csv_parser
+          delimiter: '{{ .delimiter }}'
+          header: '{{ .header }}'
+          
   service:
     pipelines:
       logs:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Add a logging plugin for w3c logs .
Tested running collector locally and testing logs from [iis](https://github.com/observIQ/log-library/blob/master/library/msiis/iis.log)

##### Checklist
- [x] Changes are tested
- [ ] CI has passed

## Disclaimer
In the original stanza plugin, a timestamp was not parsed out and in order to maintain the original functionality while porting we did likewise, which is why it appears the timestamp does not parse out

Example Log:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/48131175/174872090-2674e2f2-5d52-4190-a374-925b19b46978.png">