### PR TITLE
feat: Aerospike log plugin

### DIFF
--- a/plugins/aerospike_logs.yaml
+++ b/plugins/aerospike_logs.yaml
@@ -59,6 +59,12 @@ template: |
               info: detail
               error2: 'failed assertion'
 
+        # Timestamp and severity have been promoted to the entry
+        - type: remove
+          field: attributes.timestamp
+        - type: remove
+          field: attributes.severity
+
         # Aerospike logs the configuration at startup. This is not something we should
         # capture.
         - type: filter

--- a/plugins/aerospike_logs.yaml
+++ b/plugins/aerospike_logs.yaml
@@ -49,7 +49,7 @@ template: |
         # Parse Aerospike's log and update the entry's Timestamp and Severity
         # fields with the values from the Aerospike log.
         - type: regex_parser
-          regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<severity>[A-Z]*( [A-Z]*)?) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?(?P<message>.*)'
+          regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<severity>[A-Z]*( [A-Z]*)?) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?.*'
           timestamp:
             parse_from: attributes.timestamp
             layout: '%b %d %Y %H:%M:%S %Z'

--- a/plugins/aerospike_logs.yaml
+++ b/plugins/aerospike_logs.yaml
@@ -1,0 +1,75 @@
+version: 0.0.1
+title: Aerospike
+description: Log parser for Aerospike
+parameters:
+  # optional
+  - name: journald_directory
+    type: string
+  - name: start_at
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    journald:
+      {{ if .journald_directory }}
+      directory: {{ .journald_directory }}
+      {{ end }}
+      units: [aerospike]
+      start_at: {{ .start_at }}
+      operators:
+        # Capture relevant journald fields before replacing body
+        # with the Aerospike log body
+        - type: move
+          from: body._HOSTNAME
+          to: resource["host.name"]
+        - type: move
+          from: body.__CURSOR
+          to: attributes.journald_cursor
+        - type: move
+          from: body._PID
+          to: attributes.pid
+        - type: move
+          from: body.PRIORITY
+          to: attributes.priority
+        - type: move
+          from: body.SYSLOG_FACILITY
+          to: attributes.facility
+        - type: move
+          from: body._SYSTEMD_UNIT
+          to: attributes.systemd_unit
+
+        # Replce raw journald message with aerospike log body.
+        - type: move
+          from: body.MESSAGE
+          to: body
+
+        # Parse Aerospike's log and update the entry's Timestamp and Severity
+        # fields with the values from the Aerospike log.
+        - type: regex_parser
+          regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<severity>[A-Z]*( [A-Z]*)?) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?(?P<message>.*)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%b %d %Y %H:%M:%S %Z'
+          severity:
+            parse_from: attributes.severity
+            mapping:
+              info: detail
+              error2: 'failed assertion'
+
+        # Aerospike logs the configuration at startup. This is not something we should
+        # capture.
+        - type: filter
+          expr: 'attributes.context == "config"'
+
+        - type: add
+          field: attributes.log_type
+          value: aerospike
+
+  service:
+    pipelines:
+      logs:
+        receivers: [journald]
+


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

### Proposed Change
<!-- Please provide a description of the change here. -->

- Ported Aerospike plugin from stanza
- Replaced file input with journald input
- Preserve hostname (as resource host.name), cursor, pid, priority, facility, and service name from journald entry
- Replace body with Aerospike's log body
- Parse Aerospike's log body and promote timestamp and severity fields (from stanza plugin)
- Filter out 'config' logs (from stanza plugin)
- Add log type (from stanza plugin)

Previously, the Stanza plugin expected to read from a log file. Journald is the default log driver for Aerospike, so we decided to replace the log input in favor of Journald.

Example Input:
```json
{
  "__CURSOR": "s=e2a0ce35f993490e9b57bfc00a93204f;i=6275;b=4c9e0328beb14759afeff1fdd487bde9;m=a815e8a1;t=5e20ac4ece40b;x=d4d03fcd934119c2",
  "__REALTIME_TIMESTAMP": "1655910764962827",
  "__MONOTONIC_TIMESTAMP": "2820008097",
  "_BOOT_ID": "4c9e0328beb14759afeff1fdd487bde9",
  "_MACHINE_ID": "04ec1a5ba1012f0dbb413b265e9d9df7",
  "PRIORITY": "6",
  "SYSLOG_FACILITY": "3",
  "_UID": "0",
  "_GID": "0",
  "_SYSTEMD_SLICE": "system.slice",
  "_TRANSPORT": "stdout",
  "_CAP_EFFECTIVE": "1ffffffffff",
  "_SELINUX_CONTEXT": "system_u:system_r:unconfined_service_t:s0",
  "_HOSTNAME": "dev",
  "_SYSTEMD_CGROUP": "/system.slice/aerospike.service",
  "_SYSTEMD_UNIT": "aerospike.service",
  "SYSLOG_IDENTIFIER": "asd",
  "_COMM": "asd",
  "_EXE": "/usr/bin/asd",
  "_CMDLINE": "/usr/bin/asd --config-file /etc/aerospike/aerospike.conf --fgdaemon",
  "_STREAM_ID": "4d5df377afd64d86a437b2b2dbaa251d",
  "_PID": "57834",
  "_SYSTEMD_INVOCATION_ID": "3b4cb46ad49f424cbec1c63c6cea179a",
  "MESSAGE": "Jun 22 2022 15:12:44 GMT: INFO (info): (ticker.c:499) {bar} memory-usage: total-bytes 0 index-bytes 0 set-index-bytes 0 sindex-bytes 0 data-bytes 0 used-pct 0.00"
}
```

Example Output:
```
Resource SchemaURL: 
Resource labels:
     -> host.name: STRING(dev)
...
LogRecord #13
ObservedTimestamp: 2022-06-22 15:11:15.306016435 +0000 UTC
Timestamp: 2022-06-22 15:11:14 +0000 UTC
Severity: Info
Body: Jun 22 2022 15:11:14 GMT: INFO (info): (ticker.c:499) {bar} memory-usage: total-bytes 0 index-bytes 0 set-index-bytes 0 sindex-bytes 0 data-bytes 0 used-pct 0.00
Attributes:
     -> namespace: STRING(bar)
     -> log_type: STRING(aerospike)
     -> facility: STRING(3)
     -> context: STRING(info)
     -> source_file: STRING(ticker.c)
     -> source_location: STRING(499)
     -> journald_cursor: STRING(s=e2a0ce35f993490e9b57bfc00a93204f;i=61f7;b=4c9e0328beb14759afeff1fdd487bde9;m=a2b8574f;t=5e20abf8f52c6;x=1cdc808bc2bb8feb)
     -> pid: STRING(57834)
     -> priority: STRING(6)
     -> systemd_unit: STRING(aerospike.service)
Trace ID:
```

##### Checklist
- [x] Changes are tested
- [x] CI has passed
