### PR TITLE
feat: Add windows service definition to archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,9 @@ archives:
       - src: release_deps/VERSION.txt
         dst: "."
         strip_parent: true
-
+      - src: release_deps/windows_service.json
+        dst: install
+        strip_parent: true
     format_overrides:
       - goos: windows
         format: zip

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ release-prep:
 	@cp -r ./plugins release_deps/
 	@cp config/example.yaml release_deps/config.yaml
 	@cp config/logging.yaml release_deps/logging.yaml
+	@jq ".files[] | select(.service != null)" windows/wix.json >> release_deps/windows_service.json
 
 # Build, sign, and release
 .PHONY: release


### PR DESCRIPTION
### Proposed Change
* Add the definition of the Windows service (pulled from the wix.json file) to the archive

Ideally, I'd be able to do this just for the Windows zip, but goreleaser doesn't seem to have an option to include files only for specific GOOS + GOARCH combinations, so it's being included in all of them at the moment.

The file ends up looking like this:
```json
{
  "path": "observiq-otel-collector.exe",
  "service": {
    "name": "observiq-otel-collector",
    "start": "delayed",
    "display-name": "observIQ OpenTelemetry Collector",
    "description": "observIQ's distribution of the OpenTelemetry collector.",
    "arguments": "--config &quot;[INSTALLDIR]config.yaml&quot; --logging &quot;[INSTALLDIR]logging.yaml&quot; --manager &quot;[INSTALLDIR]manager.yaml&quot;"
  }
}
```

I keep the "name" top-level field, since it's important in constructing the service.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
