### PR TITLE
fix(file plugin): Wrap multiline pattern in single quotes

### DIFF
--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -55,7 +55,7 @@ template: |
         {{end}}
       start_at: {{ .start_at }}
       multiline:
-        line_start_pattern: {{ .multiline_line_start_pattern }}
+        line_start_pattern: '{{ .multiline_line_start_pattern }}'
       encoding: {{ .encoding }}
       operators:
         {{ if (eq .parse_format "json")}}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The following multinline pattern fails with a marshal error if not wrapped in single quotes:

Error
>```{"level":"fatal","ts":"2022-06-23T09:56:57.578-0400","caller":"collector/main.go:81","msg":"RunService returned error","error":"failed to start service: failed while starting collector: failed to get config: cannot resolve the configuration: yaml: line 3: did not find expected key","stacktrace":"main.main\n\t/home/runner/work/observiq-otel-collector/observiq-otel-collector/cmd/collector/main.go:81\nruntime.main\n\t/opt/hostedtoolcache/go/1.18.3/x64/src/runtime/proc.go:250"}```

Pattern
```
[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{1,3})?\s+(TRACE|DEBUG|INFO|NOTICE|WARN|WARNING|ERROR|SEVERE|FATAL)
```

This fix works with and without multiline pattern being specified. 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
