### PR TITLE
feat: Rework macOS script to install from tarball

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,6 +53,9 @@ archives:
       - src: release_deps/VERSION.txt
         dst: "."
         strip_parent: true
+      - src: release_deps/com.observiq.collector.plist
+        dst: "install"
+        strip_parent: true
 
     format_overrides:
       - goos: windows
@@ -243,68 +246,3 @@ changelog:
       order: 30
     - title: Other
       order: 999
-
-# https://goreleaser.com/customization/homebrew/
-brews:
-  - name: observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-    description: "observIQ's distribution of the OpenTelemetry Collector"
-    tap:
-      owner: observIQ
-      name: homebrew-observiq-otel-collector
-      branch: main
-    download_strategy: CurlDownloadStrategy
-    folder: Formula
-    url_template: https://github.com/observIQ/observiq-otel-collector/releases/download/{{ .Tag }}/{{ .ArtifactName }}
-    commit_author:
-      name: observiq
-      email: support@observiq.com
-    homepage: "https://github.com/observIQ/observiq-otel-collector"
-    license: "Apache 2.0"
-    caveats: |
-      ****************************************************************
-      The configuration file that is run by the service is located at #{prefix}/config.yaml.
-
-      If you are configuring a logreceiver the plugin directory is located at #{prefix}/plugins.
-      ****************************************************************
-
-      ****************************************************************
-      Below are services commands to run to manage the collector service.
-      If you wish to run the collector at boot prefix these commands with sudo
-      otherwise the service will run at login.
-
-      To start the collector service run:
-
-        brew services start observiq/observiq-otel-collector/observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-
-      To stop the collector service run:
-
-        brew services stop observiq/observiq-otel-collector/observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-
-      To restart the collector service run:
-
-        brew services restart observiq/observiq-otel-collector/observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-      ****************************************************************
-
-      ****************************************************************
-      To uninstall the collector and its dependencies run the following commands:
-
-          brew services stop observiq/observiq-otel-collector/observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-          brew uninstall observiq/observiq-otel-collector/observiq-otel-collector@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
-
-          # If you moved the opentelemetry-java-contrib-jmx-metrics.jar
-          sudo rm /opt/opentelemetry-java-contrib-jmx-metrics.jar
-
-      ****************************************************************
-    install: |
-      bin.install "observiq-otel-collector"
-      prefix.install "LICENSE", "VERSION.txt", "logging.yaml"
-      etc.install "config.yaml" => "observiq_config.yaml"
-      prefix.install_symlink etc/"observiq_config.yaml" => "config.yaml"
-      prefix.install Dir["plugins"]
-      lib.install "opentelemetry-java-contrib-jmx-metrics.jar"
-    service: |
-      run [opt_bin/"observiq-otel-collector", "--config", opt_prefix/"config.yaml", "--logging", opt_prefix/"logging.yaml", "--manager", opt_prefix/"manager.yaml"]
-      environment_variables OIQ_OTEL_COLLECTOR_HOME: opt_prefix
-      keep_alive true
-    # For local testing
-    # skip_upload: "true"

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ release-prep:
 	@cp -r ./plugins release_deps/
 	@cp config/example.yaml release_deps/config.yaml
 	@cp config/logging.yaml release_deps/logging.yaml
+	@cp service/com.observiq.collector.plist release_deps/com.observiq.collector.plist
 
 # Build, sign, and release
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Now that the collector is installed it is collecting basic metrics about the hos
 | :--- | :---- |
 | Linux | /opt/observiq-otel-collector/config.yaml |
 | Windows | C:\Program Files\observIQ OpenTelemetry Collector\config.yaml |
-| macOS | $(brew --prefix observiq/observiq-otel-collector/observiq-otel-collector)/config.yaml |
+| macOS | /opt/observiq-otel-collector/config.yaml |
 
 For more information on configuration see the [Configuration section](#configuration).
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For more installation information see [installing on Windows](/docs/installation
 To install using the installation script, you may run:
 
 ```sh
-sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh
+sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh
 ```
 
 For more installation information see [installing on macOS](/docs/installation-mac.md).

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -26,10 +26,10 @@ The collector uses `launchctl` to control the collector lifecycle using the foll
 
 ```sh
 # Start the collector
-launchctl start com.observiq.collector
+sudo launchctl start com.observiq.collector
 
 # Stop the collector
-launchctl stop com.observiq.collector
+sudo launchctl stop com.observiq.collector
 ```
 
 ## Uninstalling

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -1,79 +1,40 @@
 # macOS Installation
 
-## Installing
-
-The installation for macOS is supported via [Homebrew](https://brew.sh/).
-
-```sh
-brew tap observiq/homebrew-observiq-otel-collector
-brew update
-brew install observiq/observiq-otel-collector/observiq-otel-collector
-```
-
-You can then run `brew services start observiq/observiq-otel-collector/observiq-otel-collector` to start the collector with the supplied configuration.
-
-To verify the collector is working you can check the output at `$(brew --prefix observiq/observiq-otel-collector/observiq-otel-collector)/log/collector.log`.
-
-### Install/Update script
-The collector may be installed through a shell script which will wrap brew commands.
+### Installing
+The collector may be installed through a shell script.
 
 This script may also be used to update an existing installation.
 
 To install using the installation script, you may run:
 ```sh
-sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh
+sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh
 ```
 
-### Additional Install Steps
-
-If you plan on collecting metrics via the [JMX Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.54.0/receiver/jmxreceiver/README.md) you can copy the `opentelemetry-java-contrib-jmx-metrics.jar` to the default location to make configuration easier.
-
-```sh
-sudo cp $(brew --prefix observiq/observiq-otel-collector/observiq-otel-collector)/lib/opentelemetry-java-contrib-jmx-metrics.jar /opt
-```
 ## Configuring the Collector
 
 After installing, the `observiq-otel-collector` you can change the configuration file printed out at the end of the brew installation.
 
-The default configuration file can be found at `$(brew --prefix observiq/observiq-otel-collector/observiq-otel-collector)/config.yaml`.
+The default configuration file can be found at `/opt/observiq-otel-collector/config.yaml`.
 
-After changing the configuration file run `brew services restart observiq/observiq-otel-collector/observiq-otel-collector` for the changes to take effect.
+After changing the configuration file run `sudo launchctl stop com.observiq.collector; sudo launchctl start com.observiq.collector` for the changes to take effect.
 
 For more information on configuring the collector, see the [OpenTelemetry docs](https://opentelemetry.io/docs/collector/configuration/).
 
 ## Collector Services Commands
 
-The collector uses `brew services` the following commands control the collector lifecycle.
+The collector uses `launchctl` to control the collector lifecycle using the following commands.
 
 ```sh
 # Start the collector
-brew services start com.observiq.collector
+launchctl start com.observiq.collector
 
 # Stop the collector
-brew services stop com.observiq.collector
+launchctl stop com.observiq.collector
 ```
 
 ## Uninstalling
 
-### Uninstall brew
-
-To uninstall the collector run the following commands:
-
-```sh
-brew services stop observiq/observiq-otel-collector/observiq-otel-collector
-brew uninstall observiq/observiq-otel-collector/observiq-otel-collector
-
-# If you moved the opentelemetry-java-contrib-jmx-metrics.jar
-sudo rm -f /opt/opentelemetry-java-contrib-jmx-metrics.jar
-
-# To remove configs
-rm -f $(brew --prefix)/etc/observiq_config.yaml
-rm -f $(brew --prefix)/etc/observiq_config.yaml.default
-```
-
-### Uninstall script
-
 To uninstall an installation made with the install script, run:
 ```sh
-sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh -r
+sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh -r
 ```

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -12,7 +12,7 @@ sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/re
 
 ## Configuring the Collector
 
-After installing, the `observiq-otel-collector` you can change the configuration file printed out at the end of the brew installation.
+After installing the `observiq-otel-collector` you can change the configuration file printed out at the end of the installation.
 
 The default configuration file can be found at `/opt/observiq-otel-collector/config.yaml`.
 

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -496,6 +496,7 @@ install_package()
     info "Uninstalling existing service file..."
     launchctl stop "$SERVICE_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service $SERVICE_NAME"
     launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+    succeeded
   fi
 
   # Install service file

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -561,6 +561,15 @@ uninstall()
   banner "Uninstalling observIQ OpenTelemetry Collector"
   increase_indent
 
+  if [ ! -f "$INSTALL_DIR/observiq-otel-collector" ]; then
+    # If the collector binary is not present, we assume that the collector is not installed
+    # In this case, do nothing.
+    info "No install detected, skipping..."
+    decrease_indent
+    banner "$(fg_green Uninstallation Complete!)"
+    return 0
+  fi
+
   info "Uninstalling service file..."
   launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
   rm -f "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to remove service file /Library/LaunchDaemons/$SERVICE_NAME.plist"

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -16,17 +16,14 @@
 set -e
 
 # Collector Constants
-FORMULA_NAME="observiq/observiq-otel-collector/observiq-otel-collector"
 SERVICE_NAME="com.observiq.collector"
+DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases"
 
 # Script Constants
-BREW_ETC=$(brew --prefix)/etc
-PREREQS="printf brew sed uname uuidgen tr"
-CONFIG_PREFIX="observiq_"
-CONFIG_YML_NAME="config.yaml"
-MANAGEMENT_YML_NAME="manager.yaml"
-ETC_CONFIG_YML_NAME=$CONFIG_PREFIX$CONFIG_YML_NAME
-ETC_MANAGEMENT_YML_NAME=$CONFIG_PREFIX$MANAGEMENT_YML_NAME
+PREREQS="printf sed uname uuidgen tr find grep"
+TMP_DIR="${TMPDIR:-"/tmp/"}observiq-otel-collector" # Allow this to be overriden by cannonical TMPDIR env var
+INSTALL_DIR="/opt/observiq-otel-collector"
+MANAGEMENT_YML_PATH="$INSTALL_DIR/manager.yaml"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
@@ -167,13 +164,15 @@ Usage:
       If not provided, this will default to the latest version.
       Alternatively the COLLECTOR_VERSION environment variable can be
       set to configure the collector version.
-      Example: '-v 1.2.12' will download 1.2.12. 
+      Example: '-v 1.2.12' will download 1.2.12.
 
   $(fg_yellow '-r, --uninstall')
-      Stops the collector services and uninstalls the collector via brew.
+      Stops the collector services and uninstalls the collector.
 
-  $(fg_yellow '-u, --upgrade')
-      Stops the collector services and upgrades the collector via brew.
+  $(fg_yellow '-l, --url')
+      Defines the URL that the components will be downloaded from.
+      If not provided, this will default to observIQ OpenTelemetry Collector\'s GitHub releases.
+      Example: '-l http://my.domain.org/observiq-otel-collector' will download from there.
    
   $(fg_yellow '-e, --endpoint')
       Defines the endpoint of an OpAMP compatible management server for this collector install.
@@ -284,6 +283,17 @@ os_check()
   esac
 }
 
+# This checks to see if the user who is running the script has root permissions.
+root_check()
+{
+  system_user_name=$(id -un)
+  if [ "${system_user_name}" != 'root' ]
+  then
+    failed
+    error_exit "$LINENO" "Script needs to be run as root or with sudo"
+  fi
+}
+
 # This will check if the current environment has
 # all required shell dependencies to run the installation.
 dependencies_check()
@@ -316,13 +326,57 @@ setup_installation()
   banner "Configuring Installation Variables"
   increase_indent
 
+  set_os_arch
+  set_download_urls
   set_opamp_endpoint
   set_opamp_labels
   set_opamp_secret_key
-  set_formula_name
 
   success "Configuration complete!"
   decrease_indent
+}
+
+set_os_arch()
+{
+  os_arch=$(uname -m)
+  case "$os_arch" in 
+    # arm64 strings. These are from https://stackoverflow.com/questions/45125516/possible-values-for-uname-m
+    aarch64|arm64|aarch64_be|armv8b|armv8l)
+      os_arch="arm64"
+      ;;
+    x86_64)
+      os_arch="amd64"
+      ;;
+    *)
+      # We only support arm64/amd64 architectures for macOS
+      error_exit "$LINENO" "Unsupported os arch: $os_arch"
+      ;;
+  esac
+}
+
+# This will set the urls to use when downloading the collector and its plugins.
+# These urls are constructed based on the --version flag or COLLECTOR_VERSION env variable.
+# If not specified, the version defaults to whatever the latest release on github is.
+set_download_urls()
+{
+  if [ -z "$version" ] ; then
+    # shellcheck disable=SC2153
+    version=$COLLECTOR_VERSION
+  fi
+
+  if [ -z "$version" ] ; then
+    version=$(latest_version)
+  fi
+
+  if [ -z "$version" ] ; then
+    error_exit "$LINENO" "Could not determine version to install"
+  fi
+  if [ -z "$url" ] ; then
+    url=$DOWNLOAD_BASE
+    collector_download_url="$url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
+  else
+    collector_download_url="$url"
+  fi
 }
 
 set_opamp_endpoint()
@@ -360,106 +414,104 @@ set_opamp_secret_key()
   fi
 }
 
-set_formula_name()
+# latest_version gets the tag of the latest release.
+# It's also super hacky; It assumes that the output is formatted prettily.
+# Ideally we'd use jq, but we want to avoid external dependencies
+latest_version()
 {
-  # If version flag is not set use the COLLECTOR_VERSION
-  if [ -z "$version" ] ; then
-    version=$COLLECTOR_VERSION
-  fi
-
-  # If version is set append it to formula name
-  if [ -n "$version" ] ; then
-    FORMULA_NAME="$FORMULA_NAME@$version"
-  fi
+  curl -sSL -H"Accept: application/vnd.github.v3+json" https://api.github.com/repos/observIQ/observiq-otel-collector/releases/latest | \
+    grep "\"tag_name\"" | \
+    sed -E 's/ *"tag_name": "v([0-9]+\.[0-9]+\.[0-9+])",/\1/'
 }
 
-check_install_exists()
-{
-  set +e
-  brew list "$FORMULA_NAME" > /dev/null 2>&1
-  install_exists=$?
-  set -e
-}
-
-find_existing_formula_name()
-{
-  # This can return multiversion we are currently allowing this to go into a failure state.
-  # This can be fixed by the user by specifiying the version via the -v flag.
-  # This will be resolved in the future by either supporting multi versions correctly or only allowing a single version install.
-  set +e
-  found_name=$(brew list --full-name | grep "observiq/observiq-otel-collector/observiq-otel-collector")
-  set -e
-
-  if [ -n "$found_name" ]; then
-    FORMULA_NAME=$found_name
-  fi
-}
-
-set_formula_or_find_existing()
-{
-  # sets formula name with version
-  set_formula_name
-
-  # if not version is set then look at installed formulas
-  if [ -z "$version" ]; then
-    find_existing_formula_name
-  fi
-}
-
-# This will install the package by running brew to install then copying files to appropriate locations.
+# This will install the package by downloading & unpacking the tarball into the install directory
 install_package()
 {
   banner "Installing observIQ OpenTelemetry Collector"
-  increase_indent
+  increase_indent 
 
-  info "Tapping formula..."
-  brew tap observiq/homebrew-observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to tap formula"
+  # Remove temporary directory, if it exists
+  rm -rf "$TMP_DIR"
+  mkdir -p "$TMP_DIR"
+  mkdir -p "$TMP_DIR/artifacts"
+
+  # Download into tmp dir
+  info "Downloading tarball into temporary directory..."
+  curl -L "$collector_download_url" -o "$TMP_DIR/observiq-otel-collector.tar.gz" --progress-bar --fail || error_exit "$LINENO" "Failed to download package"
   succeeded
 
-  info "Checking if install exists ..."
-  check_install_exists
+  # unpack
+  info "Unpacking tarball..."
+  tar -xzf "$TMP_DIR/observiq-otel-collector.tar.gz" -C "$TMP_DIR/artifacts" || error_exit "$LINENO" "Failed to unack archive $TMP_DIR/observiq-otel-collector.tar.gz"
   succeeded
 
-  if [ $install_exists = 0 ] ; then
-    info "Found existing installation"
-    info ""
+  mkdir -p "$INSTALL_DIR" || error_exit "$LINENO" "Failed to create directory $INSTALL_DIR"
 
-    info "Stopping service..."
-    brew services stop "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service"
-    succeeded
-
-    info "Reinstalling collector..."
-    brew reinstall "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to reinstall formula"
-  else
-    info "Installing collector..."
-    brew update > /dev/null 2>&1 || error_exit "$LINENO" "Failed to run brew update"
-    brew install "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to install formula"
-  fi
-
+  info "Creating install directory structure..."
   increase_indent
-  info ""
-  info "In order to install the jmx metrics jar to the correct location, root permissions are needed."
-  info "Please enter your password if prompted to complete installation."
-  info ""
+  # Find all directorys in the unpackaged tar
+  DIRS=$(cd "$TMP_DIR/artifacts"; find "." -type d)
+  for d in $DIRS
+  do
+    mkdir -p "$INSTALL_DIR/$d" || error_exit "$LINENO" "Failed to create directory $INSTALL_DIR/$d"
+  done
   decrease_indent
-  sudo cp "$(brew --prefix "$FORMULA_NAME")/lib/opentelemetry-java-contrib-jmx-metrics.jar" /opt 2>&1 || error_exit "$LINENO" "Failed to move jmx jar to /opt"
   succeeded
 
-  # If an endpoint was specified, we need to write the manager.yml
-  if [ -n "$OPAMP_ENDPOINT" ]; then
-    info "Creating manager yaml..."
-    create_manager_yml "$BREW_ETC/$ETC_MANAGEMENT_YML_NAME" 
+  info "Copying artifacts to install directory..."
+  increase_indent
+
+  # This find command gets a list of all artifacts paths except config.yaml, logging.yaml, or opentelemetry-java-contrib-jmx-metrics.jar
+  FILES=$(cd "$TMP_DIR/artifacts"; find "." -type f -not \( -name config.yaml -or -name logging.yaml -or -name opentelemetry-java-contrib-jmx-metrics.jar \))
+  # Move files to install dir
+  for f in $FILES
+  do
+    cp "$TMP_DIR/artifacts/$f" "$INSTALL_DIR/$f" || error_exit "$LINENO" "Failed to copy artifact $f to install dir"
+  done
+  decrease_indent
+  succeeded
+
+  if [ ! -f "$INSTALL_DIR/config.yaml" ]; then
+    info "Copying default config.yaml..."
+    cp "$TMP_DIR/artifacts/config.yaml" "$INSTALL_DIR/config.yaml" || error_exit "$LINENO" "Failed to copy default config.yaml to install dir"
     succeeded
   fi
 
-  # Create symlink if needed
-  if [ -f "$BREW_ETC/$ETC_MANAGEMENT_YML_NAME" ]; then
-    ln -s $BREW_ETC/$ETC_MANAGEMENT_YML_NAME $(brew --prefix "$FORMULA_NAME")/$MANAGEMENT_YML_NAME
+  if [ ! -f "$INSTALL_DIR/logging.yaml" ]; then
+    info "Copying default logging.yaml..."
+    cp "$TMP_DIR/artifacts/logging.yaml" "$INSTALL_DIR/logging.yaml" || error_exit "$LINENO" "Failed to copy default logging.yaml to install dir"
+    succeeded
   fi
 
+  # If an endpoint was specified, we need to write the manager.yaml
+  if [ -n "$OPAMP_ENDPOINT" ]; then
+    create_manager_yml "$MANAGEMENT_YML_PATH"
+  fi
 
-  info "Enabling service..."
-  brew services start "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to enable service"
+  # Install jmx jar
+  info "Moving opentelemetry-java-contrib-jmx-metrics.jar to /opt..."
+  mv "$TMP_DIR/artifacts/opentelemetry-java-contrib-jmx-metrics.jar" "/opt/opentelemetry-java-contrib-jmx-metrics.jar" || error_exit "$LINENO" "Failed to copy opentelemetry-java-contrib-jmx-metrics.jar to /opt"
+  succeeded
+
+  if [ -f "/Library/LaunchDaemons/$SERVICE_NAME.plist" ]; then
+    # Existing service file, we should stop & unload first.
+    info "Uninstalling existing service file..."
+    launchctl stop "$SERVICE_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service $SERVICE_NAME"
+    launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+  fi
+
+  # Install service file
+  info "Installing service file..."
+  sed "s|\\[INSTALLDIR\\]|${INSTALL_DIR}/|g" "$INSTALL_DIR/install/$SERVICE_NAME.plist" | tee "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to install service file"
+  launchctl load -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to load service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+  succeeded
+
+  info "Starting service..."
+  launchctl start "$SERVICE_NAME" || error_exit "$LINENO" "Failed to start service file $SERVICE_NAME"
+  succeeded
+
+  info "Removing temporary files..."
+  rm -rf "$TMP_DIR" || error_exit "$LINENO" "Failed to remove temp dir: $TMP_DIR"
   succeeded
 
   success "observIQ OpenTelemetry Collector installation complete!"
@@ -471,10 +523,12 @@ create_manager_yml()
 {
   manager_yml_path="$1"
   if [ ! -f "$manager_yml_path" ]; then
+    info "Creating manager yaml..."
     command printf 'endpoint: "%s"\n' "$OPAMP_ENDPOINT" > "$manager_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf 'labels: "%s"\n' "$OPAMP_LABELS" >> "$manager_yml_path"
     [ -n "$OPAMP_SECRET_KEY" ] && command printf 'secret_key: "%s"\n' "$OPAMP_SECRET_KEY" >> "$manager_yml_path"
     command printf 'agent_id: "%s"\n' "$(uuidgen | tr "[:upper:]" "[:lower:]")" >> "$manager_yml_path"
+    succeeded
   fi
 }
 
@@ -482,14 +536,13 @@ create_manager_yml()
 # This will display the results of an installation
 display_results()
 {
-    collector_home="$(brew --prefix "$FORMULA_NAME")"
     banner 'Information'
     increase_indent
-    info "Collector Home:     $(fg_cyan "$collector_home")$(reset)"
-    info "Collector Config:   $(fg_cyan "$collector_home/$CONFIG_YML_NAME")$(reset)"
-    info "Start Command:      $(fg_cyan "brew services start $FORMULA_NAME")$(reset)"
-    info "Stop Command:       $(fg_cyan "brew services stop $FORMULA_NAME")$(reset)"
-    info "Logs Command:       $(fg_cyan "tail -F $collector_home/log/collector.log")$(reset)"
+    info "Collector Home:     $(fg_cyan "$INSTALL_DIR")$(reset)"
+    info "Collector Config:   $(fg_cyan "$INSTALL_DIR/config.yaml")$(reset)"
+    info "Start Command:      $(fg_cyan "sudo launchctl start $SERVICE_NAME")$(reset)"
+    info "Stop Command:       $(fg_cyan "sudo launchctl stop $SERVICE_NAME")$(reset)"
+    info "Logs Command:       $(fg_cyan "sudo tail -F $INSTALL_DIR/log/collector.log")$(reset)"
     decrease_indent
 
     banner 'Support'
@@ -499,8 +552,6 @@ display_results()
     info "$(fg_cyan "https://github.com/observiq/observiq-otel-collector/tree/main#observiq-opentelemetry-collector")$(reset)"
     decrease_indent
     info "If you have any other questions please contact us at $(fg_cyan support@observiq.com)$(reset)"
-    increase_indent
-    decrease_indent
     decrease_indent
 
     banner "$(fg_green Installation Complete!)"
@@ -514,107 +565,60 @@ uninstall()
   banner "Uninstalling observIQ OpenTelemetry Collector"
   increase_indent
 
-  set_formula_or_find_existing
-  info "Uninstalling formula $(fg_green "$FORMULA_NAME")"
-  info ""
-
-  info "Checking if install exists ..."
-  check_install_exists
-  succeeded
-
-  # exit early if no installation found
-  if [ $install_exists = 1 ]; then
-    info "No installation found"
-    decrease_indent
-    banner "$(fg_green Uninstallation Complete!)"
-    return
-  fi
-
   info "Stopping service..."
-  brew services stop "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service"
+  launchctl stop "$SERVICE_NAME" || error_exit "$LINENO" "Failed to stop service $SERVICE_NAME"
   succeeded
 
-  info "Uninstalling collector..."
-  brew uninstall "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to uninstall formula"
-  
-  increase_indent
-  info ""
-  info "In order to remove the jmx metrics jar, root permissions are needed."
-  info "Please enter your password if prompted to complete installation."
-  info ""
+
+  info "Uninstalling service file..."
+  launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+  rm -f "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to remove service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+  succeeded
+
+  # Removes the whole install directory, including configs.
+  info "Removing installed artifacts..."
+  # This find command gets a list of all artifacts paths except config.yaml or the root directory.
+  FILES=$(cd "$INSTALL_DIR"; find "." -not \( -name config.yaml -or -name "." \))
+  for f in $FILES
+  do
+    rm -rf "${INSTALL_DIR:?}/$f" || error_exit "$LINENO" "Failed to remove artifact ${INSTALL_DIR:?}/$f"
+  done
+
+  # Copy the old config to a backup. This is similar to how RPM handles this.
+  # This way, the file is recoverable if the uninstall was somehow accidental,
+  # but if a new install occurs, the default config will still be used.
+  cp "$INSTALL_DIR/config.yaml" "$INSTALL_DIR/config.bak.yaml" || error_exit "$LINENO" "Failed to backup config.yaml to config.bak.yaml"
+  rm -f "$INSTALL_DIR/config.yaml" || error_exit "$LINENO" "Failed to remove original config.yaml"
+  succeeded
+
+  info "Removing opentelemetry-java-contrib-jmx-metrics.jar from /opt..."
+  rm -f "/opt/opentelemetry-java-contrib-jmx-metrics.jar" || error_exit "$LINENO" "Failed to remove /opt/opentelemetry-java-contrib-jmx-metrics.jar"
+  succeeded
+
   decrease_indent
-
-  sudo rm -f /opt/opentelemetry-java-contrib-jmx-metrics.jar > /dev/null 2>&1 || error_exit "$LINENO" "Failed to remove jmx jar from /opt"
-  succeeded
-
-  info "Untapping formula..."
-  brew untap observiq/homebrew-observiq-otel-collector > /dev/null 2>&1 || error_exit "$LINENO" "Failed to untap formula"
-  succeeded
-
-  info "Removing config files..."
-  rm -f $BREW_ETC/$ETC_CONFIG_YML_NAME.default > /dev/null 2>&1
-  rm -f $BREW_ETC/$ETC_CONFIG_YML_NAME > /dev/null 2>&1
-  rm -f $BREW_ETC/$ETC_MANAGEMENT_YML_NAME > /dev/null 2>&1
-  succeeded
-  decrease_indent
-
   banner "$(fg_green Uninstallation Complete!)"
-}
-
-upgrade()
-{
-  observiq_banner
-
-  banner "Upgrading observIQ OpenTelemetry Collector"
-  increase_indent
-
-  set_formula_or_find_existing
-  info "Upgrading formula $(fg_green "$FORMULA_NAME")"
-  info ""
-
-  info "Checking if install exists ..."
-  brew list "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "No installation currently exists"
-  succeeded
-
-  info "Stopping service..."
-  brew services stop "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service"
-  succeeded
-
-  info "Upgrading collector..."
-  brew update > /dev/null 2>&1 || error_exit "$LINENO" "Failed to run brew update"
-  brew upgrade "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to upgrade formula"
-
-  increase_indent
-  info ""
-  info "In order to install the jmx metrics jar to the correct location, root permissions are needed."
-  info "Please enter your password if prompted to complete installation."
-  info ""
-  decrease_indent
-  
-  sudo cp "$(brew --prefix "$FORMULA_NAME")/lib/opentelemetry-java-contrib-jmx-metrics.jar" /opt 2>&1 || error_exit "$LINENO" "Failed to move jmx jar to /opt"
-  succeeded
-
-  info "Starting service..."
-  brew services start "$FORMULA_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to start service"
-  succeeded
-  decrease_indent
-
-  banner "$(fg_green Upgrade Complete!)"
 }
 
 main()
 {
+  # We do these checks before we process arguments, because
+  # some of these options bail early, and we'd like to be sure that those commands
+  # (e.g. uninstall) can run
+
+  observiq_banner
+
+  root_check
+  check_prereqs
+
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do
       case "$1" in
+        -l|--url)
+          url=$2 ; shift 2 ;;
         -v|--version)
           version=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
-          exit 0
-          ;;
-        -u|--upgrade)
-          upgrade
           exit 0
           ;;
         -h|--help)
@@ -638,8 +642,6 @@ main()
     done
   fi
 
-  observiq_banner
-  check_prereqs
   setup_installation
   install_package
   display_results

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -566,10 +566,14 @@ uninstall()
   rm -f "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to remove service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
   succeeded
 
+  info "Backing up config.yaml to config.bak.yaml"
+  cp "$INSTALL_DIR/config.yaml" "$INSTALL_DIR/config.bak.yaml" || error_exit "$LINENO" "Failed to backup config.yaml to config.bak.yaml"
+  succeeded
+
   # Removes the whole install directory, including configs.
   info "Removing installed artifacts..."
   # This find command gets a list of all artifacts paths except config.yaml or the root directory.
-  FILES=$(cd "$INSTALL_DIR"; find "." -not \( -name config.yaml -or -name "." \))
+  FILES=$(cd "$INSTALL_DIR"; find "." -not \( -name config.bak.yaml -or -name "." \))
   for f in $FILES
   do
     rm -rf "${INSTALL_DIR:?}/$f" || error_exit "$LINENO" "Failed to remove artifact ${INSTALL_DIR:?}/$f"
@@ -578,8 +582,6 @@ uninstall()
   # Copy the old config to a backup. This is similar to how RPM handles this.
   # This way, the file is recoverable if the uninstall was somehow accidental,
   # but if a new install occurs, the default config will still be used.
-  cp "$INSTALL_DIR/config.yaml" "$INSTALL_DIR/config.bak.yaml" || error_exit "$LINENO" "Failed to backup config.yaml to config.bak.yaml"
-  rm -f "$INSTALL_DIR/config.yaml" || error_exit "$LINENO" "Failed to remove original config.yaml"
   succeeded
 
   info "Removing opentelemetry-java-contrib-jmx-metrics.jar from /opt..."

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -359,19 +359,20 @@ set_os_arch()
 # If not specified, the version defaults to whatever the latest release on github is.
 set_download_urls()
 {
-  if [ -z "$version" ] ; then
-    # shellcheck disable=SC2153
-    version=$COLLECTOR_VERSION
-  fi
-
-  if [ -z "$version" ] ; then
-    version=$(latest_version)
-  fi
-
-  if [ -z "$version" ] ; then
-    error_exit "$LINENO" "Could not determine version to install"
-  fi
   if [ -z "$url" ] ; then
+    if [ -z "$version" ] ; then
+      # shellcheck disable=SC2153
+      version=$COLLECTOR_VERSION
+    fi
+
+    if [ -z "$version" ] ; then
+      version=$(latest_version)
+    fi
+
+    if [ -z "$version" ] ; then
+      error_exit "$LINENO" "Could not determine version to install"
+    fi
+    
     url=$DOWNLOAD_BASE
     collector_download_url="$url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
   else

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -415,9 +415,7 @@ set_opamp_secret_key()
   fi
 }
 
-# latest_version gets the tag of the latest release.
-# It's also super hacky; It assumes that the output is formatted prettily.
-# Ideally we'd use jq, but we want to avoid external dependencies
+# latest_version gets the tag of the latest release, without the v prefix.
 latest_version()
 {
   curl -sSL -H"Accept: application/vnd.github.v3+json" https://api.github.com/repos/observIQ/observiq-otel-collector/releases/latest | \
@@ -433,7 +431,6 @@ install_package()
 
   # Remove temporary directory, if it exists
   rm -rf "$TMP_DIR"
-  mkdir -p "$TMP_DIR"
   mkdir -p "$TMP_DIR/artifacts"
 
   # Download into tmp dir

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -372,7 +372,7 @@ set_download_urls()
     if [ -z "$version" ] ; then
       error_exit "$LINENO" "Could not determine version to install"
     fi
-    
+
     url=$DOWNLOAD_BASE
     collector_download_url="$url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
   else
@@ -561,8 +561,6 @@ display_results()
 
 uninstall()
 {
-  observiq_banner
-
   banner "Uninstalling observIQ OpenTelemetry Collector"
   increase_indent
 

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -494,7 +494,6 @@ install_package()
   if [ -f "/Library/LaunchDaemons/$SERVICE_NAME.plist" ]; then
     # Existing service file, we should stop & unload first.
     info "Uninstalling existing service file..."
-    launchctl stop "$SERVICE_NAME" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to stop service $SERVICE_NAME"
     launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
     succeeded
   fi
@@ -561,11 +560,6 @@ uninstall()
 {
   banner "Uninstalling observIQ OpenTelemetry Collector"
   increase_indent
-
-  info "Stopping service..."
-  launchctl stop "$SERVICE_NAME" || error_exit "$LINENO" "Failed to stop service $SERVICE_NAME"
-  succeeded
-
 
   info "Uninstalling service file..."
   launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -598,8 +598,8 @@ main()
 
   observiq_banner
 
-  root_check
   check_prereqs
+  root_check  
 
   if [ $# -ge 1 ]; then
     while [ -n "$1" ]; do

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -6,18 +6,22 @@
     <string>com.observiq.collector</string>
     <key>EnvironmentVariables</key>
     <dict>
-    <key>OIQ_OTEL_COLLECTOR_HOME</key>
-    <string>[INSTALLDIR]</string>
+        <key>OIQ_OTEL_COLLECTOR_HOME</key>
+        <string>[INSTALLDIR]</string>
     </dict>
     <key>ProgramArguments</key>
     <array>
-    <string>[INSTALLDIR]observiq-otel-collector</string>
-    <string>--config</string>
-    <string>[INSTALLDIR]config.yaml</string>
-    <string>--logging</string>
-    <string>[INSTALLDIR]logging.yaml</string>
+        <string>[INSTALLDIR]observiq-otel-collector</string>
+        <string>--config</string>
+        <string>[INSTALLDIR]config.yaml</string>
+        <string>--logging</string>
+        <string>[INSTALLDIR]logging.yaml</string>
+        <string>--manager</string>
+        <string>[INSTALLDIR]manager.yaml</string>
     </array>
     <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
     <true/>
 </dict>
 </plist>

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -23,5 +23,7 @@
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>WorkingDirectory</key>
+    <string>[INSTALLDIR]</string>
 </dict>
 </plist>

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.observiq.collector</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+    <key>OIQ_OTEL_COLLECTOR_HOME</key>
+    <string>[INSTALLDIR]</string>
+    </dict>
+    <key>ProgramArguments</key>
+    <array>
+    <string>[INSTALLDIR]observiq-otel-collector</string>
+    <string>--config</string>
+    <string>[INSTALLDIR]config.yaml</string>
+    <string>--logging</string>
+    <string>[INSTALLDIR]logging.yaml</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Proposed Change
* Add a plist file to the archive for the macOS service.
  * Like with the windows one, there doesn't seem to be a way to restrict this to specific tarballs, so it's packaged with all archives.
* Rework the macOS script to install from tarball instead of brew
* Remove brew references from docs
* Remove brew from goreleaser

Since the new service file is required in the tarball, I've been testing using the `-l` flag to specify a local tarball built with `make release-test`.
- Configs (config.yaml, logging.yaml, manager.yaml) are not overwritten on re-install.
- On uninstall, config.yaml is preserved as config.bak.yaml, which is similar to behavior when uninstalling through RPM.
- Installing on top of an existing install will overwrite files of the existing install, similar to the linux behavior.
- The collector is installed under `/opt/observiq-otel-collector`, similar to the linux installs.
- The collector is installed as root, meaning all the files belong to the "root" user and the "wheel" group. MacOS groups and users seem a little different than on linux (useradd/groupadd don't exist).
  - This might be something we need to take a closer look at, but I think we'd have similar issues either way, since the collector runs as root and creates its log files as root.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
