### PR TITLE
feat: Apache http plugin

### DIFF
--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -2,8 +2,9 @@ version: 0.0.1
 title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
+  # For optimal Apache HTTP parsing and enrichment, we recommend choosing 'observIQ' log format in which log Apache logging configuration is modified to output log entries as JSON files.
   - name: log_format
-    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file. See the Apache HTTP Server source page for more information.
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file.
     type: string
     supported:
       - default
@@ -34,6 +35,10 @@ parameters:
      - beginning
      - end
     default: end
+  - name: timezone
+    type: string
+    default: "UTC"
+    supported: ["UTC","Africa/Abidjan","Africa/Accra","Africa/Addis_Ababa","Africa/Algiers","Africa/Asmara","Africa/Bamako","Africa/Bangui","Africa/Banjul","Africa/Bissau","Africa/Blantyre","Africa/Brazzaville","Africa/Bujumbura","Africa/Cairo","Africa/Casablanca","Africa/Ceuta","Africa/Conakry","Africa/Dakar","Africa/Dar_es_Salaam","Africa/Djibouti","Africa/Douala","Africa/El_Aaiun","Africa/Freetown","Africa/Gaborone","Africa/Harare","Africa/Johannesburg","Africa/Juba","Africa/Kampala","Africa/Khartoum","Africa/Kigali","Africa/Kinshasa","Africa/Lagos","Africa/Libreville","Africa/Lome","Africa/Luanda","Africa/Lubumbashi","Africa/Lusaka","Africa/Malabo","Africa/Maputo","Africa/Maseru","Africa/Mbabane","Africa/Mogadishu","Africa/Monrovia","Africa/Nairobi","Africa/Ndjamena","Africa/Niamey","Africa/Nouakchott","Africa/Ouagadougou","Africa/Porto-Novo","Africa/Sao_Tome","Africa/Tripoli","Africa/Tunis","Africa/Windhoek","America/Adak","America/Anchorage","America/Anguilla","America/Antigua","America/Araguaina","America/Argentina/Buenos_Aires","America/Argentina/Catamarca","America/Argentina/Cordoba","America/Argentina/Jujuy","America/Argentina/La_Rioja","America/Argentina/Mendoza","America/Argentina/Rio_Gallegos","America/Argentina/Salta","America/Argentina/San_Juan","America/Argentina/San_Luis","America/Argentina/Tucuman","America/Argentina/Ushuaia","America/Aruba","America/Asuncion","America/Atikokan","America/Bahia","America/Bahia_Banderas","America/Barbados","America/Belem","America/Belize","America/Blanc-Sablon","America/Boa_Vista","America/Bogota","America/Boise","America/Cambridge_Bay","America/Campo_Grande","America/Cancun","America/Caracas","America/Cayenne","America/Cayman","America/Chicago","America/Chihuahua","America/Costa_Rica","America/Creston","America/Cuiaba","America/Curacao","America/Danmarkshavn","America/Dawson","America/Dawson_Creek","America/Denver","America/Detroit","America/Dominica","America/Edmonton","America/Eirunepe","America/El_Salvador","America/Fort_Nelson","America/Fortaleza","America/Glace_Bay","America/Goose_Bay","America/Grand_Turk","America/Grenada","America/Guadeloupe","America/Guatemala","America/Guayaquil","America/Guyana","America/Halifax","America/Havana","America/Hermosillo","America/Indiana/Indianapolis","America/Indiana/Knox","America/Indiana/Marengo","America/Indiana/Petersburg","America/Indiana/Tell_City","America/Indiana/Vevay","America/Indiana/Vincennes","America/Indiana/Winamac","America/Inuvik","America/Iqaluit","America/Jamaica","America/Juneau","America/Kentucky/Louisville","America/Kentucky/Monticello","America/Kralendijk","America/La_Paz","America/Lima","America/Los_Angeles","America/Lower_Princes","America/Maceio","America/Managua","America/Manaus","America/Marigot","America/Martinique","America/Matamoros","America/Mazatlan","America/Menominee","America/Merida","America/Metlakatla","America/Mexico_City","America/Miquelon","America/Moncton","America/Monterrey","America/Montevideo","America/Montserrat","America/Nassau","America/New_York","America/Nipigon","America/Nome","America/Noronha","America/North_Dakota/Beulah","America/North_Dakota/Center","America/North_Dakota/New_Salem","America/Nuuk","America/Ojinaga","America/Panama","America/Pangnirtung","America/Paramaribo","America/Phoenix","America/Port-au-Prince","America/Port_of_Spain","America/Porto_Velho","America/Puerto_Rico","America/Punta_Arenas","America/Rainy_River","America/Rankin_Inlet","America/Recife","America/Regina","America/Resolute","America/Rio_Branco","America/Santarem","America/Santiago","America/Santo_Domingo","America/Sao_Paulo","America/Scoresbysund","America/Sitka","America/St_Barthelemy","America/St_Johns","America/St_Kitts","America/St_Lucia","America/St_Thomas","America/St_Vincent","America/Swift_Current","America/Tegucigalpa","America/Thule","America/Thunder_Bay","America/Tijuana","America/Toronto","America/Tortola","America/Vancouver","America/Whitehorse","America/Winnipeg","America/Yakutat","America/Yellowknife","Antarctica/Casey","Antarctica/Davis","Antarctica/DumontDUrville","Antarctica/Macquarie","Antarctica/Mawson","Antarctica/McMurdo","Antarctica/Palmer","Antarctica/Rothera","Antarctica/Syowa","Antarctica/Troll","Antarctica/Vostok","Arctic/Longyearbyen","Asia/Aden","Asia/Almaty","Asia/Amman","Asia/Anadyr","Asia/Aqtau","Asia/Aqtobe","Asia/Ashgabat","Asia/Atyrau","Asia/Baghdad","Asia/Bahrain","Asia/Baku","Asia/Bangkok","Asia/Barnaul","Asia/Beirut","Asia/Bishkek","Asia/Brunei","Asia/Chita","Asia/Choibalsan","Asia/Colombo","Asia/Damascus","Asia/Dhaka","Asia/Dili","Asia/Dubai","Asia/Dushanbe","Asia/Famagusta","Asia/Gaza","Asia/Hebron","Asia/Ho_Chi_Minh","Asia/Hong_Kong","Asia/Hovd","Asia/Irkutsk","Asia/Jakarta","Asia/Jayapura","Asia/Jerusalem","Asia/Kabul","Asia/Kamchatka","Asia/Karachi","Asia/Kathmandu","Asia/Khandyga","Asia/Kolkata","Asia/Krasnoyarsk","Asia/Kuala_Lumpur","Asia/Kuching","Asia/Kuwait","Asia/Macau","Asia/Magadan","Asia/Makassar","Asia/Manila","Asia/Muscat","Asia/Nicosia","Asia/Novokuznetsk","Asia/Novosibirsk","Asia/Omsk","Asia/Oral","Asia/Phnom_Penh","Asia/Pontianak","Asia/Pyongyang","Asia/Qatar","Asia/Qostanay","Asia/Qyzylorda","Asia/Riyadh","Asia/Sakhalin","Asia/Samarkand","Asia/Seoul","Asia/Shanghai","Asia/Singapore","Asia/Srednekolymsk","Asia/Taipei","Asia/Tashkent","Asia/Tbilisi","Asia/Tehran","Asia/Thimphu","Asia/Tokyo","Asia/Tomsk","Asia/Ulaanbaatar","Asia/Urumqi","Asia/Ust-Nera","Asia/Vientiane","Asia/Vladivostok","Asia/Yakutsk","Asia/Yangon","Asia/Yekaterinburg","Asia/Yerevan","Atlantic/Azores","Atlantic/Bermuda","Atlantic/Canary","Atlantic/Cape_Verde","Atlantic/Faroe","Atlantic/Madeira","Atlantic/Reykjavik","Atlantic/South_Georgia","Atlantic/St_Helena","Atlantic/Stanley","Australia/Adelaide","Australia/Brisbane","Australia/Broken_Hill","Australia/Currie","Australia/Darwin","Australia/Eucla","Australia/Hobart","Australia/Lindeman","Australia/Lord_Howe","Australia/Melbourne","Australia/Perth","Australia/Sydney","Europe/Amsterdam","Europe/Andorra","Europe/Astrakhan","Europe/Athens","Europe/Belgrade","Europe/Berlin","Europe/Bratislava","Europe/Brussels","Europe/Bucharest","Europe/Budapest","Europe/Busingen","Europe/Chisinau","Europe/Copenhagen","Europe/Dublin","Europe/Gibraltar","Europe/Guernsey","Europe/Helsinki","Europe/Isle_of_Man","Europe/Istanbul","Europe/Jersey","Europe/Kaliningrad","Europe/Kiev","Europe/Kirov","Europe/Lisbon","Europe/Ljubljana","Europe/London","Europe/Luxembourg","Europe/Madrid","Europe/Malta","Europe/Mariehamn","Europe/Minsk","Europe/Monaco","Europe/Moscow","Europe/Oslo","Europe/Paris","Europe/Podgorica","Europe/Prague","Europe/Riga","Europe/Rome","Europe/Samara","Europe/San_Marino","Europe/Sarajevo","Europe/Saratov","Europe/Simferopol","Europe/Skopje","Europe/Sofia","Europe/Stockholm","Europe/Tallinn","Europe/Tirane","Europe/Ulyanovsk","Europe/Uzhgorod","Europe/Vaduz","Europe/Vatican","Europe/Vienna","Europe/Vilnius","Europe/Volgograd","Europe/Warsaw","Europe/Zagreb","Europe/Zaporozhye","Europe/Zurich","Indian/Antananarivo","Indian/Chagos","Indian/Christmas","Indian/Cocos","Indian/Comoro","Indian/Kerguelen","Indian/Mahe","Indian/Maldives","Indian/Mauritius","Indian/Mayotte","Indian/Reunion","Pacific/Apia","Pacific/Auckland","Pacific/Bougainville","Pacific/Chatham","Pacific/Chuuk","Pacific/Easter","Pacific/Efate","Pacific/Enderbury","Pacific/Fakaofo","Pacific/Fiji","Pacific/Funafuti","Pacific/Galapagos","Pacific/Gambier","Pacific/Guadalcanal","Pacific/Guam","Pacific/Honolulu","Pacific/Kiritimati","Pacific/Kosrae","Pacific/Kwajalein","Pacific/Majuro","Pacific/Marquesas","Pacific/Midway","Pacific/Nauru","Pacific/Niue","Pacific/Norfolk","Pacific/Noumea","Pacific/Pago_Pago","Pacific/Palau","Pacific/Pitcairn","Pacific/Pohnpei","Pacific/Port_Moresby","Pacific/Rarotonga","Pacific/Saipan","Pacific/Tahiti","Pacific/Tarawa","Pacific/Tongatapu","Pacific/Wake","Pacific/Wallis"]
 
 template: |
   receivers:
@@ -57,7 +62,6 @@ template: |
           severity:
             parse_from: attributes.status
             preset: none
-            preserve_to: attributes.status
             mapping:
               info: 2xx
               info2: 3xx
@@ -74,7 +78,6 @@ template: |
           severity:
             parse_from: attributes.status
             preset: none
-            preserve_to: attributes.status
             mapping:
               info: 2xx
               info2: 3xx
@@ -115,6 +118,7 @@ template: |
           timestamp:
             parse_from: attributes.timestamp
             layout: '%a %b %d %T.%s %Y'
+            location: {{ .timezone }}
           severity:
             parse_from: attributes.log_level
             mapping:
@@ -139,6 +143,7 @@ template: |
           timestamp:
             parse_from: attributes.time
             layout: '%Y-%m-%d %H:%M:%S.%s'
+            location: {{ .timezone }}
           severity:
             parse_from: attributes.log_level
             mapping:

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -179,3 +179,4 @@ template: |
         # {{ if .enable_error_log }}
           - filelog/error_log
         # {{ end }}
+

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -179,5 +179,3 @@ template: |
         # {{ if .enable_error_log }}
           - filelog/error_log
         # {{ end }}
-
-        

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -1,0 +1,181 @@
+version: 0.0.1
+title: Apache HTTP Server
+description: Log parser for Apache HTTP Server
+parameters:
+  - name: log_format
+    description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file. See the Apache HTTP Server source page for more information.
+    type: string
+    supported:
+      - default
+      - observiq
+    default: default
+  - name: enable_access_log
+    description: Enable to collect Apache HTTP Server access logs
+    type: bool
+    default: true
+  - name: access_log_path
+    description: Path to access log file
+    type: "[]string"
+    default: 
+      - "/var/log/apache2/access.log"
+  - name: enable_error_log
+    description: Enable to collect Apache HTTP Server error logs
+    type: bool
+    default: true
+  - name: error_log_path
+    description: Path to error log file
+    type: "[]string"
+    default: 
+      - "/var/log/apache2/error.log"
+  - name: start_at
+    description: Start reading file from 'beginning' or 'end'
+    type: string
+    supported:
+     - beginning
+     - end
+    default: end
+
+template: |
+  receivers:
+  {{ if .enable_access_log }}
+    filelog/access_log:
+      include:
+        # {{ range $fp := .access_log_path }}
+        - '{{ $fp }}'
+        # {{end}}
+      start_at: {{ .start_at }}
+      attributes:
+        log_type: 'apache_http.access'
+      operators:
+        {{ if eq .log_format "default" }}
+        - id: access_regex_parser
+          type: regex_parser
+          regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<timestamp>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*)(?: "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)"(?:\s+(?P<http_x_forwarded_for>[^ ]+))?)?'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%d/%b/%Y:%H:%M:%S %z'
+          severity:
+            parse_from: attributes.status
+            preset: none
+            preserve_to: attributes.status
+            mapping:
+              info: 2xx
+              info2: 3xx
+              warn: 4xx
+              error: 5xx
+          output: end_filter
+        {{ end }}
+
+        - id: access_json_parser
+          type: json_parser
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%dT%H:%M:%S.%s%z'
+          severity:
+            parse_from: attributes.status
+            preset: none
+            preserve_to: attributes.status
+            mapping:
+              info: 2xx
+              info2: 3xx
+              warn: 4xx
+              error: 5xx
+          output: access_protocol_parser
+        
+        - id: access_protocol_parser
+          type: regex_parser
+          parse_from: attributes.protocol
+          regex: '(?P<protocol>[^/]*)/(?P<protocol_version>.*)'
+          output: end_filter
+
+        # Noop filter to allow an exit point for other operators
+        - id: end_filter
+          type: filter
+          expr: 'body == ""'
+    {{ end }}
+
+  {{ if .enable_error_log }}
+    filelog/error_log:
+      include:
+        {{ range $fp := .error_log_path }}
+        - '{{ $fp }}'
+        {{end}}
+      start_at: {{ .start_at }}
+      # {{ if eq .log_format "default" }}
+      multiline:
+        line_start_pattern: '\[(?P<time>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] '
+      # {{ end }}
+      attributes:
+        log_type: 'apache_http.error'
+      operators:
+        {{ if eq .log_format "default" }}
+        - id: error_regex_parser
+          type: regex_parser
+          regex: '^\[(?P<timestamp>\w+ \w+ \d{2} \d{2}:\d{2}:\d{2}\.\d+ \d+)\] \[(?P<module>\w+):(?P<log_level>[\w\d]+)\] \[pid (?P<pid>\d+)(?::tid (?P<tid>[\d]+))?\](?: \[client (?P<client>[^\]]*)\])? (?P<error_code>[^:]+): (?P<message>.*)'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%a %b %d %T.%s %Y'
+          severity:
+            parse_from: attributes.log_level
+            mapping:
+              info2: notice
+              error2: crit
+              error3: alert
+              fatal2: emerg
+              trace:
+                - trace1
+                - trace2
+                - trace3
+                - trace4
+                - trace5
+                - trace6
+                - trace7
+                - trace8
+          output: end_filter
+        {{ end }}
+
+        - id: error_json_parser
+          type: json_parser
+          timestamp:
+            parse_from: attributes.time
+            layout: '%Y-%m-%d %H:%M:%S.%s'
+          severity:
+            parse_from: attributes.log_level
+            mapping:
+              info2: notice
+              error2: crit
+              error3: alert
+              fatal2: emerg
+              trace:
+                - trace1
+                - trace2
+                - trace3
+                - trace4
+                - trace5
+                - trace6
+                - trace7
+                - trace8
+          output: error_message_parser
+
+        - id: error_message_parser
+          type: regex_parser
+          parse_from: attributes.message
+          regex: '(?P<error_code>[^:]*):(?P<message>.*)'
+          output: end_filter
+
+        # Noop filter to allow an exit point for other operators
+        - id: end_filter
+          type: filter
+          expr: 'body == ""'
+  {{ end }}
+  
+  service:
+    pipelines:
+      logs:
+        receivers:  
+        #  {{ if .enable_access_log }}
+          - filelog/access_log
+        # {{ end }}
+        # {{ if .enable_error_log }}
+          - filelog/error_log
+        # {{ end }}

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -3,6 +3,10 @@ title: Apache HTTP Server
 description: Log parser for Apache HTTP Server
 parameters:
   # For optimal Apache HTTP parsing and enrichment, we recommend choosing 'observIQ' log format in which log Apache logging configuration is modified to output log entries as JSON files.
+ 
+  # The 'observIQ' log format is defined for access logs and error logs as follows:
+  # Logformat "{\"timestamp\":\"%{%Y-%m-%dT%T}t.%{usec_frac}t%{%z}t\",\"remote_addr\":\"%a\",\"protocol\":\"%H\",\"method\":\"%m\",\"query\":\"%q\",\"path\":\"%U\",\"status\":\"%>s\",\"http_user_agent\":\"%{User-agent}i\",\"http_referer\":\"%{Referer}i\",\"remote_user\":\"%u\",\"body_bytes_sent\":\"%b\",\"request_time_microseconds\":\"%D\",\"http_x_forwarded_for\":\"%{X-Forwarded-For}i\"}" observiq
+  # ErrorLogFormat "{\"time\":\"%{cu}t\",\"module\":\"%-m\",\"client\":\"%-a\",\"http_x_forwarded_for\":\"%-{X-Forwarded-For}i\",\"log_level\":\"%-l\",\"pid\":\"%-P\",\"tid\":\"%-T\",\"message\":\"%-M\",\"logid\":{\"request\":\"%-L\",\"connection\":\"%-{c}L\"},\"request_note_name\":\"%-{name}n\"}"
   - name: log_format
     description: When choosing the 'default' option, the agent will expect and parse logs in a format that matches the default logging configuration. When choosing the 'observIQ' option, the agent will expect and parse logs in an optimized JSON format that adheres to the observIQ specification, requiring an update to the apache2.conf file.
     type: string

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -69,7 +69,7 @@ template: |
         - id: access_json_parser
           type: json_parser
           timestamp:
-            parse_from: attributes.time
+            parse_from: attributes.timestamp
             layout: '%Y-%m-%dT%H:%M:%S.%s%z'
           severity:
             parse_from: attributes.status

--- a/plugins/apache_http_logs.yaml
+++ b/plugins/apache_http_logs.yaml
@@ -179,3 +179,5 @@ template: |
         # {{ if .enable_error_log }}
           - filelog/error_log
         # {{ end }}
+
+        


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
* Ported Apache Http Server plugin from stanza


##### Checklist
- [x] Changes are tested
- [ ] CI has passed

Example Config (ObservIQ log format):

```yaml
receivers:
  plugin:
    path: './plugins/apache_http_logs.yaml'
    parameters:
      log_format: observiq
      access_log_path:
        - "./apache_access_logs.log"
      error_log_path: 
        - "./apache_error_logs.json"
      start_at: beginning
      enable_error_log: true
      enable_access_log: false

exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
  telemetry:
    metrics:
      level: none
```

Example Output:
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/48131175/176217552-6eb803ea-a4f8-47e1-8d47-2fe135cde50c.png">

Example Config (Default):
```yaml
receivers:
  plugin:
    path: './plugins/apache_http_logs.yaml'
    parameters:
      log_format: default
      access_log_path:
        - "./apache_access_logs.log"
      error_log_path: 
        - "./apache_error_logs.log"
      start_at: beginning
      enable_error_log: true
      enable_access_log: false

exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
  telemetry:
    metrics:
      level: none
```

Example Output:
<img width="1145" alt="image" src="https://user-images.githubusercontent.com/48131175/176218132-292ad752-83a8-4a4d-ba00-102f3ffdaf52.png">

