### PR TITLE
feat: Added additional headers to OpAMP client

### DIFF
--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -139,7 +139,7 @@ func (c *Client) Connect(ctx context.Context) error {
 			"Authorization":  []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
 			"User-Agent":     []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
 			"OpAMP-Version":  []string{opamp.Version()},
-			"AgentID":        []string{c.ident.agentID},
+			"Agent-ID":       []string{c.ident.agentID},
 			"Agent-Version":  []string{version.Version()},
 			"Agent-Hostname": []string{c.ident.hostname},
 		},

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -136,8 +136,12 @@ func (c *Client) Connect(ctx context.Context) error {
 	settings := types.StartSettings{
 		OpAMPServerURL: c.currentConfig.Endpoint,
 		Header: http.Header{
-			"Authorization": []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
-			"User-Agent":    []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+			"Authorization":  []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
+			"User-Agent":     []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+			"OpAMP-Version":  []string{opamp.Version()},
+			"AgentID":        []string{c.ident.agentID},
+			"Agent-Version":  []string{version.Version()},
+			"Agent-Hostname": []string{c.ident.hostname},
 		},
 		TLSConfig:   tlsCfg,
 		InstanceUid: c.ident.agentID,

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -273,7 +273,7 @@ func TestClientConnect(t *testing.T) {
 						"Authorization":  []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
 						"User-Agent":     []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
 						"OpAMP-Version":  []string{opamp.Version()},
-						"AgentID":        []string{c.ident.agentID},
+						"Agent-ID":       []string{c.ident.agentID},
 						"Agent-Version":  []string{version.Version()},
 						"Agent-Hostname": []string{c.ident.hostname},
 					},

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -253,9 +253,12 @@ func TestClientConnect(t *testing.T) {
 				mockCollector.On("Run", mock.Anything).Return(nil)
 
 				c := &Client{
-					opampClient:   mockOpAmpClient,
-					logger:        zap.NewNop(),
-					ident:         &identity{agentID: "a69dcef0-0261-4f4f-9ac0-a483af42a6ba"},
+					opampClient: mockOpAmpClient,
+					logger:      zap.NewNop(),
+					ident: &identity{
+						agentID:  "a69dcef0-0261-4f4f-9ac0-a483af42a6ba",
+						hostname: "my.localnet",
+					},
 					configManager: nil,
 					collector:     mockCollector,
 					currentConfig: opamp.Config{
@@ -267,8 +270,12 @@ func TestClientConnect(t *testing.T) {
 				expectedSettings := types.StartSettings{
 					OpAMPServerURL: c.currentConfig.Endpoint,
 					Header: http.Header{
-						"Authorization": []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
-						"User-Agent":    []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+						"Authorization":  []string{fmt.Sprintf("Secret-Key %s", c.currentConfig.GetSecretKey())},
+						"User-Agent":     []string{fmt.Sprintf("observiq-otel-collector/%s", version.Version())},
+						"OpAMP-Version":  []string{opamp.Version()},
+						"AgentID":        []string{c.ident.agentID},
+						"Agent-Version":  []string{version.Version()},
+						"Agent-Hostname": []string{c.ident.hostname},
 					},
 					TLSConfig:   nil,
 					InstanceUid: c.ident.agentID,

--- a/opamp/version.go
+++ b/opamp/version.go
@@ -1,0 +1,23 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opamp
+
+// opampVersion is currently an internally set version to track the version of the OpAMP library we're using to be compatible with platforms
+const opampVersion = "v0.1.0"
+
+// Version returns the internally set OpAMP version
+func Version() string {
+	return opampVersion
+}

--- a/opamp/version_test.go
+++ b/opamp/version_test.go
@@ -1,0 +1,25 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opamp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Version(t *testing.T) {
+	require.Equal(t, opampVersion, Version())
+}


### PR DESCRIPTION
### Proposed Change
Added the following headers to the observIQ client:
- `OpAMP-Version`: internally determined version of OpAMP
- `AgentID`: UUID of Agent
- `Agent-Hostname`: Hostname of agent
- `Agent-Version`: Version of agent

These headers are meant as a fail safe for OpAMP communication with server. Since OpAMP is not stable yet it's possible proto definitions will change and that a user may have a sever and agent that are incompatible. These headers will be a way to allow the server to recognize if the version of OpAMP the client is using has compatible protos. If not the server can take action accordingly. We also include some identifying information in the headers so the server can have some identity on the server even if there are OpAMP compatibility issues.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
