### PR TITLE
feat: Manager Env Config

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -33,10 +33,11 @@ import (
 )
 
 const (
-	ENDPOINT   = "OPAMP_ENDPOINT"
-	AGENT_ID   = "OPAMP_AGENT_ID"
-	SECRET_KEY = "OPAMP_SECRET_KEY"
-	LABELS     = "OPAMP_LABELS"
+	// env variable name constants
+	endpoint  = "OPAMP_ENDPOINT"
+	agentID   = "OPAMP_AGENT_ID"
+	secretKey = "OPAMP_SECRET_KEY"
+	labels    = "OPAMP_LABELS"
 )
 
 func main() {
@@ -114,21 +115,21 @@ func checkManagerConfig(configPath *string) error {
 	} else if errors.Is(err, os.ErrNotExist) {
 		// manager.ymal file does *not* exist, create file using env variables
 		newConfig := &opamp.Config{}
-		if endpoint, ok := os.LookupEnv(ENDPOINT); ok {
-			newConfig.Endpoint = endpoint
+		if ep, ok := os.LookupEnv(endpoint); ok {
+			newConfig.Endpoint = ep
 
-			var agentID string
-			if agentID, ok = os.LookupEnv(AGENT_ID); !ok {
-				agentID = uuid.New().String()
+			var ai string
+			if ai, ok = os.LookupEnv(agentID); !ok {
+				ai = uuid.New().String()
 			}
-			newConfig.AgentID = agentID
+			newConfig.AgentID = ai
 
-			if secret_key, ok := os.LookupEnv(SECRET_KEY); ok {
-				newConfig.SecretKey = &secret_key
+			if sk, ok := os.LookupEnv(secretKey); ok {
+				newConfig.SecretKey = &sk
 			}
 
-			if labels, ok := os.LookupEnv(LABELS); ok {
-				newConfig.Labels = &labels
+			if label, ok := os.LookupEnv(labels); ok {
+				newConfig.Labels = &label
 			}
 
 			var data []byte
@@ -139,11 +140,9 @@ func checkManagerConfig(configPath *string) error {
 			if err := os.WriteFile(*configPath, data, 0777); err != nil {
 				panic(err)
 			}
-
 			return err
-		} else {
-			return os.ErrNotExist
 		}
+		return os.ErrNotExist
 	}
 	return os.ErrInvalid
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -116,21 +116,22 @@ func checkManagerConfig(configPath *string) error {
 		// We found the file just return nil
 		return nil
 	case errors.Is(statErr, os.ErrNotExist):
-		var ep, ai string
 		var ok bool
-		// Endpoint is only required env
-		if ep, ok = os.LookupEnv(endpointENV); !ok {
-			// Envs were not found and statErr is os.ErrNotExist so return that
-			return statErr
-		}
+
 		// manager.ymal file does *not* exist, create file using env variables
 		newConfig := &opamp.Config{}
 
-		newConfig.Endpoint = ep
-		if ai, ok = os.LookupEnv(agentIDENV); !ok {
-			ai = uuid.New().String()
+		// Endpoint is only required env
+		newConfig.Endpoint, ok = os.LookupEnv(endpointENV)
+		if !ok {
+			// Envs were not found and statErr is os.ErrNotExist so return that
+			return statErr
 		}
-		newConfig.AgentID = ai
+
+		newConfig.AgentID, ok = os.LookupEnv(agentIDENV)
+		if !ok {
+			newConfig.AgentID = uuid.New().String()
+		}
 
 		if sk, ok := os.LookupEnv(secretkeyENV); ok {
 			newConfig.SecretKey = &sk

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -38,6 +38,7 @@ const (
 	agentID   = "OPAMP_AGENT_ID"
 	secretKey = "OPAMP_SECRET_KEY"
 	labels    = "OPAMP_LABELS"
+	agentName = "OPAMP_AGENT_NAME"
 )
 
 func main() {
@@ -128,17 +129,21 @@ func checkManagerConfig(configPath *string) error {
 				newConfig.SecretKey = &sk
 			}
 
+			if an, ok := os.LookupEnv(agentName); ok {
+				newConfig.AgentName = &an
+			}
+
 			if label, ok := os.LookupEnv(labels); ok {
 				newConfig.Labels = &label
 			}
 
 			var data []byte
 			if data, err = yaml.Marshal(newConfig); err != nil {
-				return err
+				return fmt.Errorf("failed to marshal config: %w", err)
 			}
 			// write data to a manager.yaml file, with 0777 file permission
 			if err := os.WriteFile(*configPath, data, 0777); err != nil {
-				return err
+				return fmt.Errorf("failed to write config file created from ENVs: %w", err)
 			}
 			return err
 		}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -36,7 +36,7 @@ const (
 	// env variable name constants
 	endpoint  = "OPAMP_ENDPOINT"
 	agentID   = "OPAMP_AGENT_ID"
-	secretKey = "OPAMP_SECRET_KEY"
+	secretKey = "OPAMP_SECRET_KEY" //#nosec G101
 	labels    = "OPAMP_LABELS"
 	agentName = "OPAMP_AGENT_NAME"
 )
@@ -147,7 +147,7 @@ func checkManagerConfig(configPath *string) error {
 			}
 
 			// write data to a manager.yaml file, with 0777 file permission
-			if err := os.WriteFile(*configPath, data, 0777); err != nil {
+			if err := os.WriteFile(*configPath, data, 0600); err != nil {
 				return fmt.Errorf("failed to write config file created from ENVs: %w", err)
 			}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -34,11 +34,11 @@ import (
 
 const (
 	// env variable name constants
-	endpoint  = "OPAMP_ENDPOINT"
-	agentID   = "OPAMP_AGENT_ID"
-	secretKey = "OPAMP_SECRET_KEY" //#nosec G101
-	labels    = "OPAMP_LABELS"
-	agentName = "OPAMP_AGENT_NAME"
+	endpointENV  = "OPAMP_ENDPOINT"
+	agentIdENV   = "OPAMP_AGENT_ID"
+	secretkeyENV = "OPAMP_SECRET_KEY" //#nosec G101
+	labelsENV    = "OPAMP_LABELS"
+	agentNameENV = "OPAMP_AGENT_NAME"
 )
 
 func main() {
@@ -117,27 +117,27 @@ func checkManagerConfig(configPath *string) error {
 		return nil
 	case errors.Is(statErr, os.ErrNotExist):
 		// Endpoint is only required env
-		if ep, ok := os.LookupEnv(endpoint); ok {
+		if ep, ok := os.LookupEnv(endpointENV); ok {
 			// manager.ymal file does *not* exist, create file using env variables
 			newConfig := &opamp.Config{}
 
 			newConfig.Endpoint = ep
 
 			var ai string
-			if ai, ok = os.LookupEnv(agentID); !ok {
+			if ai, ok = os.LookupEnv(agentIdENV); !ok {
 				ai = uuid.New().String()
 			}
 			newConfig.AgentID = ai
 
-			if sk, ok := os.LookupEnv(secretKey); ok {
+			if sk, ok := os.LookupEnv(secretkeyENV); ok {
 				newConfig.SecretKey = &sk
 			}
 
-			if an, ok := os.LookupEnv(agentName); ok {
+			if an, ok := os.LookupEnv(agentNameENV); ok {
 				newConfig.AgentName = &an
 			}
 
-			if label, ok := os.LookupEnv(labels); ok {
+			if label, ok := os.LookupEnv(labelsENV); ok {
 				newConfig.Labels = &label
 			}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -136,7 +136,7 @@ func checkManagerConfig(configPath *string) error {
 				panic(err)
 			}
 			// write data to a manager.yaml file, with 0777 file permission
-			if err := os.WriteFile("./manager.yaml", data, 0777); err != nil {
+			if err := os.WriteFile(*configPath, data, 0777); err != nil {
 				panic(err)
 			}
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -134,11 +134,11 @@ func checkManagerConfig(configPath *string) error {
 
 			var data []byte
 			if data, err = yaml.Marshal(newConfig); err != nil {
-				panic(err)
+				return err
 			}
 			// write data to a manager.yaml file, with 0777 file permission
 			if err := os.WriteFile(*configPath, data, 0777); err != nil {
-				panic(err)
+				return err
 			}
 			return err
 		}

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -41,18 +41,18 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 	err := checkManagerConfig(&manager)
 	require.Error(t, err)
 
-	os.Setenv(endpoint, "0.0.0.0")
-	defer os.Unsetenv(endpoint)
+	os.Setenv(endpointENV, "0.0.0.0")
+	defer os.Unsetenv(endpointENV)
 
-	os.Setenv(agentName, "agent name")
-	defer os.Unsetenv(agentName)
+	os.Setenv(agentNameENV, "agent name")
+	defer os.Unsetenv(agentNameENV)
 
-	os.Setenv(secretKey, "secretKey")
-	defer os.Unsetenv(secretKey)
+	os.Setenv(secretkeyENV, "secretKey")
+	defer os.Unsetenv(secretkeyENV)
 
-	os.Setenv(labels, "this is a label")
-	defer os.Unsetenv(labels)
-	defer os.Unsetenv(agentID)
+	os.Setenv(labelsENV, "this is a label")
+	defer os.Unsetenv(labelsENV)
+	defer os.Unsetenv(agentIdENV)
 
 	manager = "./manager.yaml"
 	err = checkManagerConfig(&manager)

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/observiq/observiq-otel-collector/opamp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckManagerConfig(t *testing.T) {
+	manager := "./manager.yaml"
+	err := checkManagerConfig(&manager)
+	require.NoError(t, err)
+}
+
+func TestCheckManagerConfigNoFile(t *testing.T) {
+	exec.Command("rm", "-r", "./manager.yaml").Run()
+	manager := "./manager.yaml"
+	err := checkManagerConfig(&manager)
+	require.Error(t, err)
+
+	os.Setenv(ENDPOINT, "0.0.0.0")
+	defer os.Unsetenv(ENDPOINT)
+
+	os.Setenv(SECRET_KEY, "secret_key")
+	defer os.Unsetenv(SECRET_KEY)
+
+	os.Setenv(LABELS, "this is a label")
+	defer os.Unsetenv(LABELS)
+	defer os.Unsetenv(AGENT_ID)
+
+	manager = "./manager.yaml"
+	err = checkManagerConfig(&manager)
+	require.NoError(t, err)
+
+	dat, err := os.ReadFile("./manager.yaml")
+	out := &opamp.Config{}
+	err = yaml.Unmarshal(dat, out)
+	require.Equal(t,
+		&opamp.Config{
+			Endpoint: "0.0.0.0",
+		},
+		&opamp.Config{
+			Endpoint: out.Endpoint,
+		})
+}

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -1,3 +1,17 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -10,27 +24,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func TestCheckManagerConfig(t *testing.T) {
-	manager := "./manager.yaml"
-	err := checkManagerConfig(&manager)
-	require.NoError(t, err)
-}
-
 func TestCheckManagerConfigNoFile(t *testing.T) {
 	exec.Command("rm", "-r", "./manager.yaml").Run()
 	manager := "./manager.yaml"
 	err := checkManagerConfig(&manager)
 	require.Error(t, err)
 
-	os.Setenv(ENDPOINT, "0.0.0.0")
-	defer os.Unsetenv(ENDPOINT)
+	os.Setenv(endpoint, "0.0.0.0")
+	defer os.Unsetenv(endpoint)
 
-	os.Setenv(SECRET_KEY, "secret_key")
-	defer os.Unsetenv(SECRET_KEY)
+	os.Setenv(secretKey, "secretKey")
+	defer os.Unsetenv(secretKey)
 
-	os.Setenv(LABELS, "this is a label")
-	defer os.Unsetenv(LABELS)
-	defer os.Unsetenv(AGENT_ID)
+	os.Setenv(labels, "this is a label")
+	defer os.Unsetenv(labels)
+	defer os.Unsetenv(agentID)
 
 	manager = "./manager.yaml"
 	err = checkManagerConfig(&manager)
@@ -46,4 +54,10 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 		&opamp.Config{
 			Endpoint: out.Endpoint,
 		})
+}
+
+func TestCheckManagerConfig(t *testing.T) {
+	manager := "./manager.yaml"
+	err := checkManagerConfig(&manager)
+	require.NoError(t, err)
 }

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -24,6 +24,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestCheckManagerNoConfig(t *testing.T) {
+	exec.Command("rm", "-r", "./manager.yaml").Run()
+	manager := "./manager.yaml"
+	err := checkManagerConfig(&manager)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	tmp := "\000"
+	err = checkManagerConfig(&tmp)
+	require.Error(t, err)
+}
+
 func TestCheckManagerConfigNoFile(t *testing.T) {
 	exec.Command("rm", "-r", "./manager.yaml").Run()
 	manager := "./manager.yaml"
@@ -32,6 +43,9 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 
 	os.Setenv(endpoint, "0.0.0.0")
 	defer os.Unsetenv(endpoint)
+
+	os.Setenv(agentName, "agent name")
+	defer os.Unsetenv(agentName)
 
 	os.Setenv(secretKey, "secretKey")
 	defer os.Unsetenv(secretKey)


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
Implement dynamic manager.yaml loading/creation based upon pre-existing manager.yaml file or preconfigured environment variables.

Logic for loading/creating a yaml file:

1. Check if manager.yaml exists in flag specified location
2. If not check if endpoint env exists.
  - If so check all other envs
  - If agent id is not specified via env then create a UUID
  - Create opamp.Config with env values
  - Marshal created config to yaml and write out to disk at `./manager.yaml`
3. If file does not exist and no envs are set go into standalone mode



##### Checklist
- [x] Changes are tested
- [ ] CI has passed
