### PR TITLE
deps: Updated OpAMP lib to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v0.5.0
 	github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor v0.5.0
 	github.com/observiq/observiq-otel-collector/receiver/pluginreceiver v0.5.0
-	github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870
+	github.com/open-telemetry/opamp-go v0.2.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.54.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.54.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -1114,8 +1114,8 @@ github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870 h1:BhAV0W1i8rqOC99bIQJq0jJiEvszE6oOl5hS8Pw2pKM=
-github.com/open-telemetry/opamp-go v0.0.0-20220531162705-3f2eab449870/go.mod h1:IMdeuHGVc5CjKSu5/oNV0o+UmiXuahoHvoZ4GOmAI9M=
+github.com/open-telemetry/opamp-go v0.2.0 h1:dV7wTkG5XNiorU62N1CJPr3f5dM0PGEtUUBtvK+LEG0=
+github.com/open-telemetry/opamp-go v0.2.0/go.mod h1:IMdeuHGVc5CjKSu5/oNV0o+UmiXuahoHvoZ4GOmAI9M=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.54.0 h1:bLOTsnh+ctD1n9jqQ1TgWba5NgHVA0H4ygCpK2dyqJk=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.54.0/go.mod h1:9k9/UPofhLdDvhNQwyPlpfe5TALtWD2NY5BzA2EDS2c=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.54.0 h1:CwLXO94vnwSxL78jFrja+K/K6edSdGqmOGdNrBIQ290=

--- a/opamp/config_manager.go
+++ b/opamp/config_manager.go
@@ -38,7 +38,7 @@ type ConfigManager interface {
 
 	// ApplyConfigChanges compares the remoteConfig to the existing and applies changes.
 	// Calculates new effective config
-	ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (effectiveConfig *protobufs.EffectiveConfig, changed bool, err error)
+	ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (changed bool, err error)
 }
 
 // DetermineContentType looks at the file extension for the given filepath and returns the content type

--- a/opamp/mocks/mock_config_manager.go
+++ b/opamp/mocks/mock_config_manager.go
@@ -21,33 +21,24 @@ func (_m *MockConfigManager) AddConfig(configName string, reloader *opamp.Manage
 }
 
 // ApplyConfigChanges provides a mock function with given fields: remoteConfig
-func (_m *MockConfigManager) ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (*protobufs.EffectiveConfig, bool, error) {
+func (_m *MockConfigManager) ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (bool, error) {
 	ret := _m.Called(remoteConfig)
 
-	var r0 *protobufs.EffectiveConfig
-	if rf, ok := ret.Get(0).(func(*protobufs.AgentRemoteConfig) *protobufs.EffectiveConfig); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*protobufs.AgentRemoteConfig) bool); ok {
 		r0 = rf(remoteConfig)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*protobufs.EffectiveConfig)
-		}
+		r0 = ret.Get(0).(bool)
 	}
 
-	var r1 bool
-	if rf, ok := ret.Get(1).(func(*protobufs.AgentRemoteConfig) bool); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*protobufs.AgentRemoteConfig) error); ok {
 		r1 = rf(remoteConfig)
 	} else {
-		r1 = ret.Get(1).(bool)
+		r1 = ret.Error(1)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(*protobufs.AgentRemoteConfig) error); ok {
-		r2 = rf(remoteConfig)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // ComposeEffectiveConfig provides a mock function with given fields:

--- a/opamp/mocks/mock_opamp_client.go
+++ b/opamp/mocks/mock_opamp_client.go
@@ -48,6 +48,34 @@ func (_m *MockOpAMPClient) SetAgentDescription(descr *protobufs.AgentDescription
 	return r0
 }
 
+// SetPackageStatuses provides a mock function with given fields: statuses
+func (_m *MockOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+	ret := _m.Called(statuses)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*protobufs.PackageStatuses) error); ok {
+		r0 = rf(statuses)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetRemoteConfigStatus provides a mock function with given fields: status
+func (_m *MockOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	ret := _m.Called(status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*protobufs.RemoteConfigStatus) error); ok {
+		r0 = rf(status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Start provides a mock function with given fields: ctx, settings
 func (_m *MockOpAMPClient) Start(ctx context.Context, settings types.StartSettings) error {
 	ret := _m.Called(ctx, settings)
@@ -90,7 +118,7 @@ func (_m *MockOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
 	return r0
 }
 
-// NewMockClient creates a new instance of MockClient. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
+// NewMockOpAMPClient creates a new instance of MockOpAMPClient. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMockOpAMPClient(t testing.TB) *MockOpAMPClient {
 	mock := &MockOpAMPClient{}
 	mock.Mock.Test(t)

--- a/opamp/observiq/agent_config_manager.go
+++ b/opamp/observiq/agent_config_manager.go
@@ -91,16 +91,7 @@ func (a *AgentConfigManager) ComposeEffectiveConfig() (*protobufs.EffectiveConfi
 }
 
 // ApplyConfigChanges compares the remoteConfig to the existing and applies changes
-func (a *AgentConfigManager) ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (effectiveConfig *protobufs.EffectiveConfig, changed bool, returnErr error) {
-	// Always compute effective config at the end. This ensures we always have the most up to date copy when we respond to the server
-	defer func() {
-		var err error
-		effectiveConfig, err = a.ComposeEffectiveConfig()
-		if err != nil {
-			a.logger.Error("Failed to compute effective config while applying config changes", zap.Error(returnErr))
-		}
-	}()
-
+func (a *AgentConfigManager) ApplyConfigChanges(remoteConfig *protobufs.AgentRemoteConfig) (changed bool, returnErr error) {
 	remoteConfigMap := remoteConfig.GetConfig().GetConfigMap()
 
 	// No remote config Map

--- a/opamp/observiq/agent_config_manager_test.go
+++ b/opamp/observiq/agent_config_manager_test.go
@@ -164,11 +164,14 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
+				assert.NoError(t, err)
+				assert.False(t, changed)
 
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
 				assert.NoError(t, err)
 				assert.Equal(t, expectedEffCfg, effCfg)
-				assert.False(t, changed)
 			},
 		},
 		{
@@ -207,11 +210,15 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
 
 				assert.NoError(t, err)
-				assert.Equal(t, expectedEffCfg, effCfg)
 				assert.False(t, changed)
+
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedEffCfg, effCfg)
 			},
 		},
 		{
@@ -255,16 +262,19 @@ func TestApplyConfigChanges(t *testing.T) {
 					},
 				}
 
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
-
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
 				assert.NoError(t, err)
-				assert.Equal(t, expectedEffCfg, effCfg)
 				assert.True(t, changed)
 
 				// Verify on disk matches what is expected
 				diskContents, err := os.ReadFile(configPath)
 				assert.NoError(t, err)
 				assert.Equal(t, configContents, diskContents)
+
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedEffCfg, effCfg)
 			},
 		},
 		{
@@ -304,11 +314,14 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
+				assert.NoError(t, err)
+				assert.False(t, changed)
 
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
 				assert.NoError(t, err)
 				assert.Equal(t, expectedEffCfg, effCfg)
-				assert.False(t, changed)
 			},
 		},
 		{
@@ -357,13 +370,18 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
 
 				assert.NoError(t, err)
-				assert.Equal(t, expectedEffCfg, effCfg)
 				assert.True(t, changed)
 				assert.FileExists(t, filepath.Join(".", LoggingConfigName))
 
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedEffCfg, effCfg)
+
+				// Cleanup
 				err = os.Remove(filepath.Join(".", LoggingConfigName))
 				assert.NoError(t, err)
 			},
@@ -410,11 +428,14 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
+				assert.NoError(t, err)
+				assert.True(t, changed)
 
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
 				assert.NoError(t, err)
 				assert.Equal(t, expectedEffCfg, effCfg)
-				assert.True(t, changed)
 			},
 		},
 		{
@@ -459,11 +480,14 @@ func TestApplyConfigChanges(t *testing.T) {
 						},
 					},
 				}
-				effCfg, changed, err := manager.ApplyConfigChanges(remoteConfig)
-
+				changed, err := manager.ApplyConfigChanges(remoteConfig)
 				assert.ErrorIs(t, err, expectedError)
-				assert.Equal(t, expectedEffCfg, effCfg)
 				assert.False(t, changed)
+
+				// Verify effective config is as expected
+				effCfg, err := manager.ComposeEffectiveConfig()
+				assert.NoError(t, err)
+				assert.Equal(t, expectedEffCfg, effCfg)
 			},
 		},
 	}

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -149,17 +149,13 @@ func (c *Client) Connect(ctx context.Context) error {
 			OnConnectFunc:          c.onConnectHandler,
 			OnConnectFailedFunc:    c.onConnectFailedHandler,
 			OnErrorFunc:            c.onErrorHandler,
-			OnRemoteConfigFunc:     c.onRemoteConfigHandler,
+			OnMessageFunc:          c.onMessageFuncHandler,
 			GetEffectiveConfigFunc: c.onGetEffectiveConfigHandler,
-			// Unimplemented Handles
-			// SaveRemoteConfigStatusFunc:
+			// Unimplemented handlers
 			// OnOpampConnectionSettingsFunc
 			// OnOpampConnectionSettingsAcceptedFunc
-			// OnOwnTelemetryConnectionSettingsFunc
-			// OnOtherConnectionSettingsFunc
-			// OnPackagesAvailableFunc
-			// OnAgentIdentificationFunc
 			// OnCommandFunc
+			// SaveRemoteConfigStatusFunc
 		},
 	}
 
@@ -193,16 +189,45 @@ func (c *Client) onErrorHandler(errResp *protobufs.ServerErrorResponse) {
 	c.logger.Error("Server returned an error response", zap.String("Error", errResp.GetErrorMessage()))
 }
 
-func (c *Client) onRemoteConfigHandler(_ context.Context, remoteConfig *protobufs.AgentRemoteConfig) (*protobufs.EffectiveConfig, bool, error) {
+func (c *Client) onMessageFuncHandler(ctx context.Context, msg *types.MessageData) {
+	switch {
+	// Fill in other message types as needed
+	case msg.RemoteConfig != nil:
+		if err := c.onRemoteConfigHandler(ctx, msg.RemoteConfig); err != nil {
+			c.logger.Error("Error while processing Remote Config Change", zap.Error(err))
+		}
+	}
+}
+
+func (c *Client) onRemoteConfigHandler(ctx context.Context, remoteConfig *protobufs.AgentRemoteConfig) error {
 	c.logger.Debug("Remote config handler")
 
-	effectiveConfig, changed, err := c.configManager.ApplyConfigChanges(remoteConfig)
-	if err != nil {
-		c.logger.Error("Failed applying remote config", zap.Error(err))
-		return nil, changed, fmt.Errorf("Failed to apply config changes: %w", err)
+	changed, err := c.configManager.ApplyConfigChanges(remoteConfig)
+	remoteCfgStatus := &protobufs.RemoteConfigStatus{
+		LastRemoteConfigHash: remoteConfig.GetConfigHash(),
+		Status:               protobufs.RemoteConfigStatus_APPLIED,
 	}
 
-	return effectiveConfig, changed, nil
+	// If we received and error apply it to the config
+	if err != nil {
+		c.logger.Error("Failed applying remote config", zap.Error(err))
+
+		remoteCfgStatus.Status = protobufs.RemoteConfigStatus_FAILED
+		remoteCfgStatus.ErrorMessage = fmt.Sprintf("Failed to apply config changes: %s", err.Error())
+	}
+
+	// Set the remote config status
+	if err := c.opampClient.SetRemoteConfigStatus(remoteCfgStatus); err != nil {
+		return fmt.Errorf("failed to set remote config status: %w", err)
+	}
+
+	// If we changed the config call UpdateEffectiveConfig
+	if changed {
+		if err := c.opampClient.UpdateEffectiveConfig(ctx); err != nil {
+			return fmt.Errorf("failed to update effective config: %w", err)
+		}
+	}
+	return nil
 }
 
 func (c *Client) onGetEffectiveConfigHandler(_ context.Context) (*protobufs.EffectiveConfig, error) {

--- a/opamp/version.go
+++ b/opamp/version.go
@@ -15,7 +15,7 @@
 package opamp
 
 // opampVersion is currently an internally set version to track the version of the OpAMP library we're using to be compatible with platforms
-const opampVersion = "v0.1.0"
+const opampVersion = "v0.2.0"
 
 // Version returns the internally set OpAMP version
 func Version() string {


### PR DESCRIPTION
### Proposed Change
- Updated `github.com/open-telemetry/opamp-go` to v0.2.0
- Updated Callbacks to use newer `OnMessageFunc`
- Updated mocks and interfaces as required

Leaving in draft until I can test with Bindplane

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
