### PR TITLE
Increased timeout of goreleaser to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "v1.9.1"
-          args: release --rm-dist
+          args: release --rm-dist --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
           COSIGN_PWD: ${{ secrets.ORG_COSIGN_PWD }}


### PR DESCRIPTION
### Proposed Change
Sometimes releasing fails on goreleaser step when it takes longer than 30m. Increased timeout to 60m.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
