### PR TITLE
fix: Updated macOS script commands for service start and stop

### DIFF
--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -26,7 +26,7 @@ After installing the `observiq-otel-collector` you can change the configuration 
 
 The default configuration file can be found at `/opt/observiq-otel-collector/config.yaml`.
 
-After changing the configuration file run `sudo launchctl stop com.observiq.collector; sudo launchctl start com.observiq.collector` for the changes to take effect.
+After changing the configuration file run `sudo launchctl unload /Library/LaunchDaemons/com.observiq.collector.plist; sudo launchctl load /Library/LaunchDaemons/com.observiq.collector.plist` for the changes to take effect.
 
 For more information on configuring the collector, see the [OpenTelemetry docs](https://opentelemetry.io/docs/collector/configuration/).
 
@@ -36,10 +36,10 @@ The collector uses `launchctl` to control the collector lifecycle using the foll
 
 ```sh
 # Start the collector
-sudo launchctl start com.observiq.collector
+sudo launchctl load /Library/LaunchDaemons/com.observiq.collector.plist
 
 # Stop the collector
-sudo launchctl stop com.observiq.collector
+sudo launchctl unload /Library/LaunchDaemons/com.observiq.collector.plist
 ```
 
 ## Uninstalling

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -538,8 +538,8 @@ display_results()
     increase_indent
     info "Collector Home:     $(fg_cyan "$INSTALL_DIR")$(reset)"
     info "Collector Config:   $(fg_cyan "$INSTALL_DIR/config.yaml")$(reset)"
-    info "Start Command:      $(fg_cyan "sudo launchctl start $SERVICE_NAME")$(reset)"
-    info "Stop Command:       $(fg_cyan "sudo launchctl stop $SERVICE_NAME")$(reset)"
+    info "Start Command:      $(fg_cyan "sudo launchctl load /Library/LaunchDaemons/$SERVICE_NAME.plist")$(reset)"
+    info "Stop Command:       $(fg_cyan "sudo launchctl unload /Library/LaunchDaemons/$SERVICE_NAME.plist")$(reset)"
     info "Logs Command:       $(fg_cyan "sudo tail -F $INSTALL_DIR/log/collector.log")$(reset)"
     decrease_indent
 


### PR DESCRIPTION
### Proposed Change
Updated the service start and stop commands printed in the macOS install script. `launchctl stop` will stop the collector but the plist file will restart it because of the `<key>KeepAlive</key>` key we have set. Using `unload` and `load` will start and stop the service and give desired behavior.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
