### PR TITLE
feat: Copy updater executable to CWD of collector before executing

### DIFF
--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -77,6 +77,10 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 	clientLogger := args.DefaultLogger.Named("opamp")
 
 	configManager := NewAgentConfigManager(args.DefaultLogger)
+	updaterManger, err := newUpdaterManager(clientLogger, args.TmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create updaterManager: %w", err)
+	}
 
 	observiqClient := &Client{
 		logger:                  clientLogger,
@@ -86,7 +90,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		collector:               args.Collector,
 		currentConfig:           args.Config,
 		packagesStateProvider:   newPackagesStateProvider(clientLogger, packagestate.DefaultFileName),
-		updaterManager:          newUpdaterManager(clientLogger, args.TmpPath),
+		updaterManager:          updaterManger,
 	}
 
 	// Parse URL to determin scheme

--- a/opamp/observiq/updater_manager.go
+++ b/opamp/observiq/updater_manager.go
@@ -25,8 +25,6 @@ import (
 
 const updaterDir = "latest"
 
-var updaterName = "updater"
-
 // updaterManager handles working with the Updater binary
 type updaterManager interface {
 	// StartAndMonitorUpdater starts the Updater binary and monitors it for failure

--- a/opamp/observiq/updater_manager.go
+++ b/opamp/observiq/updater_manager.go
@@ -49,7 +49,7 @@ func copyExecutable(logger *zap.Logger, inputPath, cwd string) (string, error) {
 	// Output path is just whatever the actual file name is (e.g. updater.exe),
 	// on top of the CWD. We take the absolute path, because it is needed to actually ensure you can
 	// exec a file not on your PATH.
-	outputPath, err := filepath.Abs(filepath.Base(inputPath))
+	outputPath, err := filepath.Abs(filepath.Join(cwd, filepath.Base(inputPath)))
 	if err != nil {
 		return "", fmt.Errorf("failed to get absolute path for output: %w", err)
 	}

--- a/opamp/observiq/updater_manager.go
+++ b/opamp/observiq/updater_manager.go
@@ -34,7 +34,9 @@ type updaterManager interface {
 // copyExecutable copies the executable at the input file path to the cwd.
 // Returns the output path of the executable.
 func copyExecutable(logger *zap.Logger, inputPath, cwd string) (string, error) {
-	inputFile, err := os.Open(inputPath)
+	inputPathClean := filepath.Clean(inputPath)
+
+	inputFile, err := os.Open(inputPathClean)
 	if err != nil {
 		return "", fmt.Errorf("failed to open updater binary for reading: %w", err)
 	}
@@ -52,13 +54,15 @@ func copyExecutable(logger *zap.Logger, inputPath, cwd string) (string, error) {
 		return "", fmt.Errorf("failed to get absolute path for output: %w", err)
 	}
 
+	outputPathClean := filepath.Clean(outputPath)
+
 	// Remove the file if it already exists, need this for macOS
-	if err := os.RemoveAll(outputPath); err != nil {
+	if err := os.RemoveAll(outputPathClean); err != nil {
 		return "", fmt.Errorf("failed to remove any existing executable: %w", err)
 	}
 
-	// Make 0700 instead of 0600 since the executable bit needs to be flipped
-	outputFile, err := os.OpenFile(outputPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0700)
+	//#nosec G302 - 0700 instead of 0600 since the executable bit needs to be flipped
+	outputFile, err := os.OpenFile(outputPathClean, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0700)
 	if err != nil {
 		return "", fmt.Errorf("failed to open output file: %w", err)
 	}
@@ -72,5 +76,5 @@ func copyExecutable(logger *zap.Logger, inputPath, cwd string) (string, error) {
 		return "", fmt.Errorf("failed to copy executable to output: %w", err)
 	}
 
-	return outputPath, nil
+	return outputPathClean, nil
 }

--- a/opamp/observiq/updater_manager_others.go
+++ b/opamp/observiq/updater_manager_others.go
@@ -31,11 +31,14 @@ import (
 // Ensure interface is satisfied
 var _ updaterManager = (*othersUpdaterManager)(nil)
 
+const defaultOthersUpdaterName = "updater"
+
 // othersUpdaterManager handles starting a Updater binary and watching it for failure with a timeout
 type othersUpdaterManager struct {
-	tmpPath string
-	cwd     string
-	logger  *zap.Logger
+	tmpPath     string
+	cwd         string
+	updaterName string
+	logger      *zap.Logger
 }
 
 // newUpdaterManager creates a new UpdaterManager
@@ -46,16 +49,17 @@ func newUpdaterManager(defaultLogger *zap.Logger, tmpPath string) (updaterManage
 	}
 
 	return &othersUpdaterManager{
-		tmpPath: filepath.Clean(tmpPath),
-		logger:  defaultLogger.Named("updater manager"),
-		cwd:     cwd,
+		tmpPath:     filepath.Clean(tmpPath),
+		logger:      defaultLogger.Named("updater manager"),
+		updaterName: defaultOthersUpdaterName,
+		cwd:         cwd,
 	}, nil
 }
 
 // StartAndMonitorUpdater will start the Updater binary and wait to see if it finishes unexpectedly.
 // While waiting for Updater, it should kill the collector and we should never execute any code past running it
 func (m othersUpdaterManager) StartAndMonitorUpdater() error {
-	initialUpdaterPath := filepath.Join(m.tmpPath, updaterDir, updaterName)
+	initialUpdaterPath := filepath.Join(m.tmpPath, updaterDir, m.updaterName)
 	updaterPath, err := copyExecutable(m.logger.Named("copy-executable"), initialUpdaterPath, m.cwd)
 	if err != nil {
 		return fmt.Errorf("failed to copy updater to cwd: %w", err)

--- a/opamp/observiq/updater_manager_others.go
+++ b/opamp/observiq/updater_manager_others.go
@@ -47,7 +47,11 @@ func newUpdaterManager(defaultLogger *zap.Logger, tmpPath string) updaterManager
 // StartAndMonitorUpdater will start the Updater binary and wait to see if it finishes unexpectedly.
 // While waiting for Updater, it should kill the collector and we should never execute any code past running it
 func (m othersUpdaterManager) StartAndMonitorUpdater() error {
-	updaterPath := filepath.Join(m.tmpPath, updaterDir, updaterName)
+	initialUpdaterPath := filepath.Join(m.tmpPath, updaterDir, updaterName)
+	updaterPath, err := copyExecutable(m.logger.Named("copy-executable"), initialUpdaterPath)
+	if err != nil {
+		return fmt.Errorf("failed to copy updater to cwd: %w", err)
+	}
 
 	//#nosec G204 -- paths are not determined via user input
 	cmd := exec.Command(updaterPath)

--- a/opamp/observiq/updater_manager_others_test.go
+++ b/opamp/observiq/updater_manager_others_test.go
@@ -39,9 +39,10 @@ func TestNewOthersUpdaterManager(t *testing.T) {
 				require.NoError(t, err)
 
 				expected := &othersUpdaterManager{
-					tmpPath: tmpPath,
-					logger:  logger.Named("updater manager"),
-					cwd:     cwd,
+					tmpPath:     tmpPath,
+					logger:      logger.Named("updater manager"),
+					updaterName: "updater",
+					cwd:         cwd,
 				}
 
 				actual, err := newUpdaterManager(logger, tmpPath)
@@ -66,6 +67,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater does not exist at path",
 			testFunc: func(t *testing.T) {
+				t.Parallel()
+
 				tmpDir := t.TempDir()
 				updateManager, err := newUpdaterManager(zap.NewNop(), tmpDir)
 				require.NoError(t, err)
@@ -81,13 +84,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater is not executable",
 			testFunc: func(t *testing.T) {
+				t.Parallel()
+
 				tmpDir := t.TempDir()
-				updaterName = "badupdater"
+
 				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
 				require.NoError(t, err)
 
-				oum := updateManager.(*othersUpdaterManager)
-				oum.cwd = tmpDir
+				updateManager.(*othersUpdaterManager).cwd = tmpDir
+				updateManager.(*othersUpdaterManager).updaterName = "badupdater"
 
 				err = updateManager.StartAndMonitorUpdater()
 
@@ -97,13 +102,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater exits quickly",
 			testFunc: func(t *testing.T) {
+				t.Parallel()
+
 				tmpDir := t.TempDir()
-				updaterName = "quickupdater"
+
 				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
 				require.NoError(t, err)
 
-				oum := updateManager.(*othersUpdaterManager)
-				oum.cwd = tmpDir
+				updateManager.(*othersUpdaterManager).cwd = tmpDir
+				updateManager.(*othersUpdaterManager).updaterName = "quickupdater"
 
 				err = updateManager.StartAndMonitorUpdater()
 
@@ -113,13 +120,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater times out",
 			testFunc: func(t *testing.T) {
+				t.Parallel()
+
 				tmpDir := t.TempDir()
-				updaterName = "slowupdater"
+
 				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
 				require.NoError(t, err)
 
-				oum := updateManager.(*othersUpdaterManager)
-				oum.cwd = tmpDir
+				updateManager.(*othersUpdaterManager).cwd = tmpDir
+				updateManager.(*othersUpdaterManager).updaterName = "slowupdater"
 
 				err = updateManager.StartAndMonitorUpdater()
 

--- a/opamp/observiq/updater_manager_others_test.go
+++ b/opamp/observiq/updater_manager_others_test.go
@@ -17,6 +17,7 @@
 package observiq
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,13 +35,17 @@ func TestNewOthersUpdaterManager(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				tmpPath := "/tmp"
 				logger := zap.NewNop()
+				cwd, err := os.Getwd()
+				require.NoError(t, err)
 
 				expected := &othersUpdaterManager{
 					tmpPath: tmpPath,
 					logger:  logger.Named("updater manager"),
+					cwd:     cwd,
 				}
 
-				actual := newUpdaterManager(logger, tmpPath)
+				actual, err := newUpdaterManager(logger, tmpPath)
+				require.NoError(t, err)
 				require.Equal(t, expected, actual)
 			},
 		},
@@ -62,8 +67,13 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 			desc: "Updater does not exist at path",
 			testFunc: func(t *testing.T) {
 				tmpDir := t.TempDir()
-				updateManager := newUpdaterManager(zap.NewNop(), tmpDir)
-				err := updateManager.StartAndMonitorUpdater()
+				updateManager, err := newUpdaterManager(zap.NewNop(), tmpDir)
+				require.NoError(t, err)
+
+				oum := updateManager.(*othersUpdaterManager)
+				oum.cwd = tmpDir
+
+				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "no such file or directory")
 			},
@@ -71,9 +81,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater is not executable",
 			testFunc: func(t *testing.T) {
+				tmpDir := t.TempDir()
 				updaterName = "badupdater"
-				updateManager := newUpdaterManager(zap.NewNop(), "./testdata")
-				err := updateManager.StartAndMonitorUpdater()
+				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
+				require.NoError(t, err)
+
+				oum := updateManager.(*othersUpdaterManager)
+				oum.cwd = tmpDir
+
+				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "updater had an issue while starting:")
 			},
@@ -81,9 +97,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater exits quickly",
 			testFunc: func(t *testing.T) {
+				tmpDir := t.TempDir()
 				updaterName = "quickupdater"
-				updateManager := newUpdaterManager(zap.NewNop(), "./testdata")
-				err := updateManager.StartAndMonitorUpdater()
+				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
+				require.NoError(t, err)
+
+				oum := updateManager.(*othersUpdaterManager)
+				oum.cwd = tmpDir
+
+				err = updateManager.StartAndMonitorUpdater()
 
 				assert.EqualError(t, err, "updater failed to update collector")
 			},
@@ -91,9 +113,15 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 		{
 			desc: "Updater times out",
 			testFunc: func(t *testing.T) {
+				tmpDir := t.TempDir()
 				updaterName = "slowupdater"
-				updateManager := newUpdaterManager(zap.NewNop(), "./testdata")
-				err := updateManager.StartAndMonitorUpdater()
+				updateManager, err := newUpdaterManager(zap.NewNop(), "./testdata")
+				require.NoError(t, err)
+
+				oum := updateManager.(*othersUpdaterManager)
+				oum.cwd = tmpDir
+
+				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "updater failed to update collector")
 			},

--- a/opamp/observiq/updater_manager_windows.go
+++ b/opamp/observiq/updater_manager_windows.go
@@ -47,7 +47,11 @@ func newUpdaterManager(defaultLogger *zap.Logger, tmpPath string) updaterManager
 // StartAndMonitorUpdater will start the Updater binary and wait to see if it finishes unexpectedly.
 // While waiting for Updater, it should kill the collector and we should never execute any code past running it
 func (m windowsUpdaterManager) StartAndMonitorUpdater() error {
-	updaterPath := filepath.Join(m.tmpPath, updaterDir, updaterName)
+	initialUpdaterPath := filepath.Join(m.tmpPath, updaterDir, updaterName)
+	updaterPath, err := copyExecutable(m.logger.Named("copy-executable"), initialUpdaterPath)
+	if err != nil {
+		return fmt.Errorf("failed to copy updater to cwd: %w", err)
+	}
 
 	//#nosec G204 -- paths are not determined via user input
 	cmd := exec.Command(updaterPath)

--- a/opamp/observiq/updater_manager_windows_test.go
+++ b/opamp/observiq/updater_manager_windows_test.go
@@ -40,9 +40,10 @@ func TestNewWindowsUpdaterManager(t *testing.T) {
 				require.NoError(t, err)
 
 				expected := &windowsUpdaterManager{
-					tmpPath: tmpPath,
-					logger:  logger.Named("updater manager"),
-					cwd:     cwd,
+					tmpPath:     tmpPath,
+					logger:      logger.Named("updater manager"),
+					updaterName: "updater.exe",
+					cwd:         cwd,
 				}
 
 				actual, err := newUpdaterManager(logger, tmpPath)


### PR DESCRIPTION
### Proposed Change
* Copy the updater to CWD, and execute it there.
* Tweak tests for updaterManager to run in parallel (this knocks like 4-5 seconds, from 11-12 seconds to ~6-7 seconds)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
