### PR TITLE
feat: Updater cleans up temporary directory

### DIFF
--- a/updater/cmd/updater/main.go
+++ b/updater/cmd/updater/main.go
@@ -56,6 +56,7 @@ func main() {
 	logger, err := logging.NewLogger(installDir)
 	if err != nil {
 		log.Default().Printf("Failed to create logger: %s\n", err)
+		// No logger, can't really log if we fail to remove tmpdir
 		fail(zap.NewNop(), installDir)
 	}
 
@@ -109,6 +110,7 @@ func main() {
 
 		rb.Rollback()
 		removeTmpDir(logger, installDir)
+
 		logger.Error("Rollback complete")
 		fail(logger, installDir)
 	}

--- a/updater/internal/install/install.go
+++ b/updater/internal/install/install.go
@@ -38,15 +38,14 @@ type Installer struct {
 }
 
 // NewInstaller returns a new instance of an Installer.
-func NewInstaller(logger *zap.Logger, installDir string) (*Installer, error) {
+func NewInstaller(logger *zap.Logger, installDir string) *Installer {
 	namedLogger := logger.Named("installer")
-
 	return &Installer{
 		latestDir:  path.LatestDir(installDir),
 		svc:        service.NewService(namedLogger, installDir),
 		installDir: installDir,
 		logger:     namedLogger,
-	}, nil
+	}
 }
 
 // Install installs the unpacked artifacts in latestDir to installDir,

--- a/updater/internal/rollback/rollback.go
+++ b/updater/internal/rollback/rollback.go
@@ -45,20 +45,15 @@ type Rollbacker struct {
 }
 
 // NewRollbacker returns a new Rollbacker
-func NewRollbacker(logger *zap.Logger, installDir string) (*Rollbacker, error) {
+func NewRollbacker(logger *zap.Logger, installDir string) *Rollbacker {
 	namedLogger := logger.Named("rollbacker")
-
-	installDir, err := path.InstallDir(namedLogger.Named("install-dir"))
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine install dir: %w", err)
-	}
 
 	return &Rollbacker{
 		backupDir:   path.BackupDir(installDir),
 		installDir:  installDir,
 		logger:      namedLogger,
 		originalSvc: service.NewService(namedLogger, installDir),
-	}, nil
+	}
 }
 
 // AppendAction records the action that was performed, so that it may be undone later.


### PR DESCRIPTION
### Proposed Change
* On error, call "fail" function, which removes the temporary directory before exiting
  * Before we were calling logger.Fatal in these scenarios to exit
* On success, remove temporary directory.
* Remove error from signature of NewRollbacker and NewInstaller
  * Neither of these need to return an error

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
