### PR TITLE
feat: Harden collector shutdown while updating

### DIFF
--- a/opamp/observiq/updater_manager.go
+++ b/opamp/observiq/updater_manager.go
@@ -19,11 +19,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"go.uber.org/zap"
 )
 
 const updaterDir = "latest"
+const defaultShutdownWaitTimeout = 30 * time.Second
 
 // updaterManager handles working with the Updater binary
 type updaterManager interface {

--- a/opamp/observiq/updater_manager_others_test.go
+++ b/opamp/observiq/updater_manager_others_test.go
@@ -19,6 +19,7 @@ package observiq
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,10 +40,11 @@ func TestNewOthersUpdaterManager(t *testing.T) {
 				require.NoError(t, err)
 
 				expected := &othersUpdaterManager{
-					tmpPath:     tmpPath,
-					logger:      logger.Named("updater manager"),
-					updaterName: "updater",
-					cwd:         cwd,
+					tmpPath:             tmpPath,
+					logger:              logger.Named("updater manager"),
+					updaterName:         "updater",
+					cwd:                 cwd,
+					shutdownWaitTimeout: 30 * time.Second,
 				}
 
 				actual, err := newUpdaterManager(logger, tmpPath)
@@ -73,8 +75,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 				updateManager, err := newUpdaterManager(zap.NewNop(), tmpDir)
 				require.NoError(t, err)
 
-				oum := updateManager.(*othersUpdaterManager)
-				oum.cwd = tmpDir
+				updateManager.(*othersUpdaterManager).cwd = tmpDir
+				updateManager.(*othersUpdaterManager).shutdownWaitTimeout = 5 * time.Second
 
 				err = updateManager.StartAndMonitorUpdater()
 
@@ -93,6 +95,7 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*othersUpdaterManager).cwd = tmpDir
 				updateManager.(*othersUpdaterManager).updaterName = "badupdater"
+				updateManager.(*othersUpdaterManager).shutdownWaitTimeout = 5 * time.Second
 
 				err = updateManager.StartAndMonitorUpdater()
 
@@ -111,6 +114,7 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*othersUpdaterManager).cwd = tmpDir
 				updateManager.(*othersUpdaterManager).updaterName = "quickupdater"
+				updateManager.(*othersUpdaterManager).shutdownWaitTimeout = 5 * time.Second
 
 				err = updateManager.StartAndMonitorUpdater()
 
@@ -129,6 +133,7 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*othersUpdaterManager).cwd = tmpDir
 				updateManager.(*othersUpdaterManager).updaterName = "slowupdater"
+				updateManager.(*othersUpdaterManager).shutdownWaitTimeout = 5 * time.Second
 
 				err = updateManager.StartAndMonitorUpdater()
 

--- a/opamp/observiq/updater_manager_windows_test.go
+++ b/opamp/observiq/updater_manager_windows_test.go
@@ -40,10 +40,11 @@ func TestNewWindowsUpdaterManager(t *testing.T) {
 				require.NoError(t, err)
 
 				expected := &windowsUpdaterManager{
-					tmpPath:     tmpPath,
-					logger:      logger.Named("updater manager"),
-					updaterName: "updater.exe",
-					cwd:         cwd,
+					tmpPath:             tmpPath,
+					logger:              logger.Named("updater manager"),
+					updaterName:         "updater.exe",
+					cwd:                 cwd,
+					shutdownWaitTimeout: 30 * time.Second,
 				}
 
 				actual, err := newUpdaterManager(logger, tmpPath)
@@ -75,6 +76,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 				require.NoError(t, err)
 
 				updateManager.(*windowsUpdaterManager).cwd = tmpDir
+				updateManager.(*windowsUpdaterManager).shutdownWaitTimeout = 5 * time.Second
+
 				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "failed to copy updater to cwd")
@@ -91,6 +94,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*windowsUpdaterManager).cwd = tmpDir
 				updateManager.(*windowsUpdaterManager).updaterName = "badupdater"
+				updateManager.(*windowsUpdaterManager).shutdownWaitTimeout = 5 * time.Second
+
 				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "updater had an issue while starting:")
@@ -107,6 +112,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*windowsUpdaterManager).cwd = tmpDir
 				updateManager.(*windowsUpdaterManager).updaterName = "quickupdater.exe"
+				updateManager.(*windowsUpdaterManager).shutdownWaitTimeout = 5 * time.Second
+
 				err = updateManager.StartAndMonitorUpdater()
 
 				assert.EqualError(t, err, "updater failed to update collector")
@@ -123,6 +130,8 @@ func TestStartAndMonitorUpdater(t *testing.T) {
 
 				updateManager.(*windowsUpdaterManager).cwd = tmpDir
 				updateManager.(*windowsUpdaterManager).updaterName = "slowupdater.exe"
+				updateManager.(*windowsUpdaterManager).shutdownWaitTimeout = 5 * time.Second
+
 				err = updateManager.StartAndMonitorUpdater()
 
 				assert.ErrorContains(t, err, "updater failed to update collector")

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -25,5 +25,7 @@
     <true/>
     <key>WorkingDirectory</key>
     <string>[INSTALLDIR]</string>
+    <key>ExitTimeOut</key>
+    <integer>20</integer>
 </dict>
 </plist>

--- a/service/observiq-otel-collector.service
+++ b/service/observiq-otel-collector.service
@@ -13,7 +13,7 @@ Environment=OIQ_OTEL_COLLECTOR_STORAGE=/opt/observiq-otel-collector/storage
 WorkingDirectory=/opt/observiq-otel-collector
 ExecStart=/opt/observiq-otel-collector/observiq-otel-collector --config config.yaml
 SuccessExitStatus=0
-TimeoutSec=120
+TimeoutSec=20
 StandardOutput=journal
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
### Proposed Change
* Change service timeouts to be 20 seconds
  * This is the default for macOS, but I added it in just to be sure
  * Windows default is 20s and isn't easy to set, so I left it where it was
* Change collector wait timeout for updater to 30 seconds
* Change updater to stop the collector before performing the backup, in order to reduce time to service shutdown

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
