### PR TITLE
fix: Makes sure JMX jar is installed and rolled back properly

### DIFF
--- a/updater/internal/path/path.go
+++ b/updater/internal/path/path.go
@@ -36,6 +36,12 @@ func ServiceFileDir(installDir string) string {
 	return filepath.Join(installDir, "install")
 }
 
+// SpecialJarDir gets the directory where linux and darwin installs put the JMX jar
+// Keeping this relative for now so we don't have to deal with /opt in tests
+func SpecialJarDir(installDir string) string {
+	return filepath.Join(installDir, "..")
+}
+
 // BackupServiceFile returns the full path to the backup service file
 func BackupServiceFile(installDir string) string {
 	return filepath.Join(BackupDir(installDir), "backup.service")
@@ -44,4 +50,14 @@ func BackupServiceFile(installDir string) string {
 // LogFile returns the full path to the log file for the updater
 func LogFile(installDir string) string {
 	return filepath.Join(installDir, "log", "updater.log")
+}
+
+// LatestJMXJarFile returns the full path to the latest JMX jar to be installed
+func LatestJMXJarFile(latestDir string) string {
+	return filepath.Join(latestDir, "opentelemetry-java-contrib-jmx-metrics.jar")
+}
+
+// SpecialJMXJarFile returns the full path to the JMX Jar on linux and darwin installs
+func SpecialJMXJarFile(installDir string) string {
+	return filepath.Join(SpecialJarDir(installDir), "opentelemetry-java-contrib-jmx-metrics.jar")
 }

--- a/updater/internal/path/path_test.go
+++ b/updater/internal/path/path_test.go
@@ -37,10 +37,22 @@ func TestServiceFileDir(t *testing.T) {
 	require.Equal(t, filepath.Join("install", "install"), ServiceFileDir("install"))
 }
 
+func TestSpecialJarDir(t *testing.T) {
+	require.Equal(t, filepath.Join("install", ".."), SpecialJarDir("install"))
+}
+
 func TestBackupServiceFile(t *testing.T) {
 	require.Equal(t, filepath.Join("install", "tmp", "rollback", "backup.service"), BackupServiceFile("install"))
 }
 
 func TestLogFile(t *testing.T) {
 	require.Equal(t, filepath.Join("install", "log", "updater.log"), LogFile("install"))
+}
+
+func TestLatestJMXJarFile(t *testing.T) {
+	require.Equal(t, filepath.Join("latest", "opentelemetry-java-contrib-jmx-metrics.jar"), LatestJMXJarFile("latest"))
+}
+
+func TestSpecialJMXJarFile(t *testing.T) {
+	require.Equal(t, filepath.Join("install", "..", "opentelemetry-java-contrib-jmx-metrics.jar"), SpecialJMXJarFile("install"))
 }

--- a/updater/internal/service/service_darwin.go
+++ b/updater/internal/service/service_darwin.go
@@ -140,7 +140,7 @@ func (d darwinService) Update() error {
 }
 
 func (d darwinService) Backup() error {
-	if err := file.CopyFile(d.logger.Named("copy-file"), d.installedServiceFilePath, path.BackupServiceFile(d.installDir), false); err != nil {
+	if err := file.CopyFile(d.logger.Named("copy-file"), d.installedServiceFilePath, path.BackupServiceFile(d.installDir), false, false); err != nil {
 		return fmt.Errorf("failed to copy service file: %w", err)
 	}
 

--- a/updater/internal/service/service_linux.go
+++ b/updater/internal/service/service_linux.go
@@ -165,7 +165,7 @@ func (l linuxService) Update() error {
 }
 
 func (l linuxService) Backup() error {
-	if err := file.CopyFile(l.logger.Named("copy-file"), l.installedServiceFilePath, path.BackupServiceFile(l.installDir), false); err != nil {
+	if err := file.CopyFile(l.logger.Named("copy-file"), l.installedServiceFilePath, path.BackupServiceFile(l.installDir), false, false); err != nil {
 		return fmt.Errorf("failed to copy service file: %w", err)
 	}
 


### PR DESCRIPTION
### Proposed Change
Ensures JMX jar is both installed and rolled back properly
Also making sure that we use the backed up file permissions when
rolling back a file that no longer exists in the install directory
Updated some tests that were extremely hard to debug.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
