### PR TITLE
fix: Cisco ASA plugin typo

### DIFF
--- a/plugins/cisco_asa_logs.yaml
+++ b/plugins/cisco_asa_logs.yaml
@@ -12,7 +12,7 @@ parameters:
     default: "0.0.0.0"
 
 template: |
-  receiver:
+  receivers:
     tcplog:
       listen_address: '{{ .listen_ip }}:{{ .listen_port }}'
       attributes:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Cisco ASA was failing to start for me. This is because `receiver` should be `receivers` in the template.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
