### PR TITLE
fix(updater): Enable debug logs

### DIFF
--- a/updater/internal/logging/logging_others.go
+++ b/updater/internal/logging/logging_others.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/observiq/observiq-otel-collector/updater/internal/path"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // NewLogger returns a new logger, that logs to the log directory relative to installDir.
@@ -33,6 +34,7 @@ func NewLogger(installDir string) (*zap.Logger, error) {
 	conf.OutputPaths = []string{
 		logFile,
 	}
+	conf.Level.SetLevel(zapcore.DebugLevel)
 
 	err := os.RemoveAll(logFile)
 	if err != nil {


### PR DESCRIPTION
### Proposed Change
* Enable debug logs for updater logger

I noticed while testing that the logs were very sparse; We don't have the debug logs enabled right now, it must have got lost during the file logging PR.

Tested an update locally on my mac and the updater now emits debug logs.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
