### PR TITLE
deps: Update to point at official operations-collector again

### DIFF
--- a/docs/processors.md
+++ b/docs/processors.md
@@ -16,7 +16,7 @@ Below is a list of supported processors with links to their documentation pages.
 | Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/v0.57.2/processor/memorylimiterprocessor/README.md) |
 | Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/processor/metricsgenerationprocessor/README.md) |
 | Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/processor/metricstransformprocessor/README.md) |
-| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/observIQ/opentelemetry-operations-collector/tree/7ae64090f52c7be045eb782fbc03bc2f465dcd89/processor/normalizesumsprocessor/README.md) |
+| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/b3246a4024405e64ece879d2a3cc2146dbcb8d45/processor/normalizesumsprocessor/README.md) |
 | Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/processor/probabilisticsamplerprocessor/README.md) |
 | Resource Attribute Transposer Processor | [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md) |
 | Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/processor/resourcedetectionprocessor/README.md) |

--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -58,7 +58,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/syslogreceiver/README.md) |
 | TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/tcplogreceiver/README.md) |
 | UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/udplogreceiver/README.md) |
-| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/observIQ/opentelemetry-operations-collector/tree/7ae64090f52c7be045eb782fbc03bc2f465dcd89/receiver/varnishreceiver/README.md) |
+| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/b3246a4024405e64ece879d2a3cc2146dbcb8d45/receiver/varnishreceiver/README.md) |
 | vCenter Receiver                            | [vcenterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/vcenterreceiver/README.md) |
 | Windows Event Log Receiver                  | [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/windowseventlogreceiver/README.md) |
 | Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.57.2/receiver/windowsperfcountersreceiver/README.md) |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/observiq-otel-collector
 go 1.17
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220711143229-08f2752ed367
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220804181753-b3246a402440
 	github.com/google/uuid v1.3.0
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v1.3.0
 	github.com/observiq/observiq-otel-collector/packagestate v0.0.0
@@ -474,5 +474,3 @@ replace github.com/observiq/observiq-otel-collector/receiver/pluginreceiver => .
 replace github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter => ./exporter/googlecloudexporter
 
 replace github.com/observiq/observiq-otel-collector/packagestate => ./packagestate
-
-replace github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220711143229-08f2752ed367 => github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220804143341-7ae64090f52c

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220804181753-b3246a402440 h1:B1ULGub0Guv6sWLBn0y/OdO11NmPpWz8JtvSCiNJ6nQ=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220804181753-b3246a402440/go.mod h1:vZpMQGawvRxQZ79UKcp1kRCmLuy7HejL6APpro49FUk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4 h1:UyZMaiNzZpplk4mH8+NMVeHk6g/xmhx4RSziYWbw9WI=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.4/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.4 h1:cuBjW4kDHYj01QZXfEpHB2OFJ2mDorD8u2H1DECRjZc=
@@ -925,8 +927,6 @@ github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220804143341-7ae64090f52c h1:38spTgGw0dssMfw4VHsIkEzhbdxe3EO3Ajo3I94U4Qk=
-github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220804143341-7ae64090f52c/go.mod h1:vZpMQGawvRxQZ79UKcp1kRCmLuy7HejL6APpro49FUk=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=


### PR DESCRIPTION
### Proposed Change
* Points back to the official [operations collector](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector) instead of using our fork, now that v0.57.2 otel dependencies have been merged in.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
