### PR TITLE
fix: Generate Agent ID if `manager.yaml` exists and does not supply the field

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -110,11 +110,10 @@ func logOptions(loggingConfigPath *string) ([]zap.Option, error) {
 
 func checkManagerConfig(configPath *string) error {
 	_, statErr := os.Stat(*configPath)
-
 	switch {
 	case statErr == nil:
-		// We found the file just return nil
-		return nil
+		// We found the file, ensure it has identifying fields before establishing any opamp connections
+		return ensureIdentity(*configPath)
 	case errors.Is(statErr, os.ErrNotExist):
 		var ok bool
 
@@ -158,4 +157,32 @@ func checkManagerConfig(configPath *string) error {
 	}
 	// Return non os.ErrNotExist
 	return statErr
+}
+
+func ensureIdentity(configPath string) error {
+	cBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("unable to read file: %w", err)
+	}
+	var candidateConfig opamp.Config
+	err = yaml.Unmarshal(cBytes, &candidateConfig)
+	if err != nil {
+		return fmt.Errorf("unable to interpret config file: %w", err)
+	}
+
+	// if they already have an AgentID, don't generate it
+	if candidateConfig.AgentID != "" {
+		return nil
+	}
+
+	candidateConfig.AgentID = uuid.NewString()
+	newBytes, err := yaml.Marshal(candidateConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sanitized config: %w", err)
+	}
+
+	if err = os.WriteFile(configPath, newBytes, 0600); err != nil {
+		return fmt.Errorf("failed to rewrite manager config with identifying fields: %w", err)
+	}
+	return nil
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	_ "time/tzdata"
 
 	"github.com/google/uuid"
@@ -161,7 +162,7 @@ func checkManagerConfig(configPath *string) error {
 }
 
 func ensureIdentity(configPath string) error {
-	cBytes, err := os.ReadFile(configPath)
+	cBytes, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
 		return fmt.Errorf("unable to read file: %w", err)
 	}
@@ -182,7 +183,7 @@ func ensureIdentity(configPath string) error {
 		return fmt.Errorf("failed to marshal sanitized config: %w", err)
 	}
 
-	if err = os.WriteFile(configPath, newBytes, 0600); err != nil {
+	if err = os.WriteFile(filepath.Clean(configPath), newBytes, 0600); err != nil {
 		return fmt.Errorf("failed to rewrite manager config with identifying fields: %w", err)
 	}
 	return nil

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -147,8 +147,8 @@ func TestManagerConfigCheckFileModes(t *testing.T) {
 			expectedErr: errors.New("failed to rewrite manager config with identifying fields"),
 		},
 		{
-			name:        "execute_only",
-			fileMode:    0100,
+			name:        "write_only",
+			fileMode:    0222,
 			expectedErr: errors.New("unable to read file"),
 		},
 		{

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -76,7 +76,6 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 
 func TestManagerConfigNoAgentIDWillSet(t *testing.T) {
 	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
 	manager := filepath.Join(tmpDir, "manager.yaml")
 	data := []byte("")
 	require.NoError(t, os.WriteFile(manager, data, 0600))
@@ -96,7 +95,6 @@ func TestManagerConfigNoAgentIDWillSet(t *testing.T) {
 
 func TestManagerConfigWillNotOverwriteCurrentAgentID(t *testing.T) {
 	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
 	manager := filepath.Join(tmpDir, "manager.yaml")
 
 	id := uuid.NewString()
@@ -118,7 +116,6 @@ agent_id: %s
 
 func TestManagerConfigWillErrorOnInvalidOpAmpConfig(t *testing.T) {
 	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
 	manager := filepath.Join(tmpDir, "manager.yaml")
 	data := []byte(`
 ---
@@ -134,7 +131,6 @@ agent_id:
 
 func TestManagerConfigCheckFileModes(t *testing.T) {
 	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
 
 	testCases := []struct {
 		name        string

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -147,11 +147,6 @@ func TestManagerConfigCheckFileModes(t *testing.T) {
 			expectedErr: errors.New("failed to rewrite manager config with identifying fields"),
 		},
 		{
-			name:        "write_only",
-			fileMode:    0222,
-			expectedErr: errors.New("unable to read file"),
-		},
-		{
 			name:     "valid_read_write",
 			fileMode: 0600,
 		},

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -15,12 +15,17 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/observiq/observiq-otel-collector/opamp"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCheckManagerNoConfig(t *testing.T) {
@@ -69,12 +74,99 @@ func TestCheckManagerConfigNoFile(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestCheckManagerConfig(t *testing.T) {
-	tmpdir := t.TempDir()
-	manager := filepath.Join(tmpdir, "manager.yaml")
-
-	data := []byte("temporary directory")
-	os.WriteFile(manager, data, 0600)
+func TestManagerConfigNoAgentIDWillSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+	manager := filepath.Join(tmpDir, "manager.yaml")
+	data := []byte("")
+	require.NoError(t, os.WriteFile(manager, data, 0600))
 	err := checkManagerConfig(&manager)
 	require.NoError(t, err)
+
+	cfgBytes, err := ioutil.ReadFile(manager)
+	require.NoError(t, err)
+
+	var config opamp.Config
+	require.NoError(t, yaml.Unmarshal(cfgBytes, &config))
+	require.NotEmpty(t, config.AgentID)
+	uuidv4, err := uuid.Parse(config.AgentID)
+	require.NoError(t, err)
+	require.NotEmpty(t, uuidv4)
+}
+
+func TestManagerConfigWillNotOverwriteCurrentAgentID(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+	manager := filepath.Join(tmpDir, "manager.yaml")
+
+	id := uuid.NewString()
+	data := []byte(fmt.Sprintf(`
+---
+agent_id: %s
+`, id))
+	require.NoError(t, os.WriteFile(manager, data, 0600))
+	err := checkManagerConfig(&manager)
+	require.NoError(t, err)
+
+	cfgBytes, err := ioutil.ReadFile(manager)
+	require.NoError(t, err)
+
+	var config opamp.Config
+	require.NoError(t, yaml.Unmarshal(cfgBytes, &config))
+	require.Equal(t, config.AgentID, id)
+}
+
+func TestManagerConfigWillErrorOnInvalidOpAmpConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+	manager := filepath.Join(tmpDir, "manager.yaml")
+	data := []byte(`
+---
+agent_id:
+  - some-kind-of-array
+  - should-blow-up
+`)
+	require.NoError(t, os.WriteFile(manager, data, 0600))
+	err := checkManagerConfig(&manager)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unable to interpret config file")
+}
+
+func TestManagerConfigCheckFileModes(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer os.RemoveAll(tmpDir)
+
+	testCases := []struct {
+		name        string
+		fileMode    os.FileMode
+		expectedErr error
+	}{
+		{
+			name:        "read_only",
+			fileMode:    0400,
+			expectedErr: errors.New("failed to rewrite manager config with identifying fields"),
+		},
+		{
+			name:        "execute_only",
+			fileMode:    0100,
+			expectedErr: errors.New("unable to read file"),
+		},
+		{
+			name:     "valid_read_write",
+			fileMode: 0600,
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := filepath.Join(tmpDir, fmt.Sprintf("manager-%d.yaml", idx))
+			require.NoError(t, os.WriteFile(manager, []byte(""), tc.fileMode))
+			err := checkManagerConfig(&manager)
+			if tc.expectedErr != nil {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
For users that specify a `manager.yaml` and do not supply an agent ID, we should generate a valid UUIDv4 and rewrite the config before establishing any opamp connections. This should not impede standalone collector usage as the manager 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
