### PR TITLE
feat(plugin): Add support for more log formats in IIS log plugin

### DIFF
--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -15,6 +15,10 @@ parameters:
       - iis
       - ncsa
     default: w3c
+  - name: w3c_header
+    description: "The W3C header which specifies the field names. Only applicable if log_format is w3c."
+    type: "string"
+    default: "date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken"
   - name: exclude_file_log_path
     description: Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory
     type: "[]string"
@@ -67,26 +71,55 @@ template: |
       include_file_path_resolved: {{ .include_file_path_resolved }}
       start_at: {{ .start_at }}
       operators: 
-    
-      - id: add_log_type
-        type: add
-        field: 'attributes.log_type'
-        value: 'microsoft_iis'
-
-      - id: body_parser
-        type: regex_parser
-        regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+(?P<address>[^\s]+)\s+(?P<operation>\w{3})\s+(?P<cs_uri_stem>[^\s]+)\s(?P<cs_uri_query>[^\s]+)\s+(?P<s_port>[^\s]+)\s+-\s+(?P<remoteIp>[^\s]+)\s+(?P<userAgent>[^\s]+)\s+-\s+(?P<status>\d{3})\s+(?P<sc_status>\d)\s+(?P<sc_win32_status>\d)\s+(?P<time_taken>[^\n]+)'
-        timestamp:
-          parse_from: attributes.timestamp
-          layout: '%Y-%m-%d %H:%M:%S'
-          location: {{.timezone}}
+      - type: filter
+        expr: 'body matches "^#"'
+        
+      - type: csv_parser
+        header: '{{ .w3c_header }}'
+        delimiter: " "
         severity: 
-          parse_from: attributes.status
+          parse_from: 'attributes["sc-status"]'
+          if: 'attributes["sc-status"] != nil'
           mapping:
             info: 2xx
             info2: 3xx
             warn: 4xx
             error: 5xx
+
+      # If both date & time field exists, parse the timestamp
+      - type: router
+        routes:
+        - output: add_timestamp
+          expr: 'attributes.date != nil and attributes.time != nil'
+        default: add_log_type
+
+      # Combines data + time fields into timestamp field
+      - id: add_timestamp
+        type: add
+        field: attributes.timestamp
+        value: EXPR(attributes.date + " " + attributes.time)
+
+      # Remove date field
+      - id: remove_date
+        type: remove
+        field: attributes.date
+
+      # Remove time field
+      - id: remove_time
+        type: remove
+        field: attributes.time
+
+      - id: time_parser
+        type: time_parser
+        if: 'attributes.timestamp != nil'
+        parse_from: attributes.timestamp
+        layout: '%Y-%m-%d %H:%M:%S'
+        location: {{.timezone}}
+
+      - id: add_log_type
+        type: add
+        field: 'attributes.log_type'
+        value: 'microsoft_iis'
     {{end}}
     # IIS format
     {{if eq .log_format "iis"}}
@@ -129,7 +162,7 @@ template: |
         if: 'attributes.date != nil'
         field: attributes.date
 
-      # Remove date field
+      # Remove time field
       - id: remove_time
         type: remove
         if: 'attributes.time != nil'

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 title: IIS
 description: Log parser for IIS
 parameters:
@@ -73,7 +73,7 @@ template: |
       operators: 
       - type: filter
         expr: 'body matches "^#"'
-        
+
       - type: csv_parser
         header: '{{ .w3c_header }}'
         delimiter: " "
@@ -141,9 +141,9 @@ template: |
       start_at: {{ .start_at }}
       operators: 
       - type: regex_parser
-        regex: '^(?P<remoteIp>[^,]+), (?P<user>[^,]+), (?P<date>[^,]+), (?P<time>[^,]+), (?P<service>[^,]+), (?P<server_name>[^,]+), (?P<address>[^,]+), (?P<time_taken>[^,]+), (?P<cs_bytes_sent>[^,]+), (?P<sc_bytes_sent>[^,]+), (?P<sc_status>[^,]+), (?P<sc_win32_status>[^,]+), (?P<operation>[^,]+), (?P<cs_uri_stem>[^,]+), (?P<cs_uri_query>[^,]+),$'
+        regex: '^(?P<c_ip>[^,]+), (?P<cs_username>[^,]+), (?P<date>[^,]+), (?P<time>[^,]+), (?P<s_sitename>[^,]+), (?P<s_computername>[^,]+), (?P<s_ip>[^,]+), (?P<time_taken>[^,]+), (?P<cs_bytes>[^,]+), (?P<sc_bytes>[^,]+), (?P<sc_status>[^,]+), (?P<sc_win32_status>[^,]+), (?P<cs_method>[^,]+), (?P<cs_uri_stem>[^,]+), (?P<cs_uri_query>[^,]+),$'
         severity:
-          parse_from: attributes.sc_status
+          parse_from: 'attributes["sc_status"]'
           mapping:
             info: 2xx
             info2: 3xx
@@ -202,9 +202,9 @@ template: |
       operators: 
       - type: regex_parser
         # Note: The second, uncaptured group here is "Remote log name". This value is always "-" in IIS, so we don't include it
-        regex: '^(?P<remoteIp>[^\s]+) (?:[^\s]+) (?P<user>[^\s]+) \[(?P<timestamp>[^]]+)\] "(?P<operation>[^\s]+) (?P<cs_uri_stem>[^\s?]+)(?:\?(?P<cs_uri_query>[^\s]+))? (?P<protocol>[^\s]+)" (?P<sc_status>[^\s]+) (?P<sc_bytes>[^\s]+)$'
+        regex: '^(?P<c_ip>[^\s]+) (?:[^\s]+) (?P<cs_username>[^\s]+) \[(?P<timestamp>[^]]+)\] "(?P<cs_method>[^\s]+) (?P<cs_uri_stem>[^\s?]+)(?:\?(?P<cs_uri_query>[^\s]+))? (?P<cs_version>[^\s]+)" (?P<sc_status>[^\s]+) (?P<sc_bytes>[^\s]+)$'
         severity:
-          parse_from: attributes.sc_status
+          parse_from: 'attributes["sc_status"]'
           mapping:
             info: 2xx
             info2: 3xx

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -7,6 +7,14 @@ parameters:
     type: "[]string"
     default: 
       - "C:/inetpub/logs/LogFiles/W3SVC*/**/*.log"
+  - name: log_format
+    description: "The format of the IIS logs. For more information on the various log formats, see: https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807%28v=vs.90%29"
+    type: "string"
+    supported:
+      - w3c
+      - iis
+      - ncsa
+    default: w3c
   - name: exclude_file_log_path
     description: Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory
     type: "[]string"
@@ -39,7 +47,9 @@ parameters:
       - end
     default: end
 template: |
-  receivers: 
+  receivers:
+    # W3C format
+    {{if eq .log_format "w3c"}}
     filelog:
       include: 
       {{ range $i, $fp := .file_path }}
@@ -77,7 +87,105 @@ template: |
             info2: 3xx
             warn: 4xx
             error: 5xx
-    
+    {{end}}
+    # IIS format
+    {{if eq .log_format "iis"}}
+    filelog:
+      include: 
+      {{ range $i, $fp := .file_path }}
+        - '{{ $fp }}'
+      {{ end }}
+      {{ if .exclude_file_log_path }}  
+      exclude: 
+      {{ range $i, $efp := .exclude_file_log_path }}
+        - '{{ $efp }}'
+      {{ end }}
+     {{ end }}
+      include_file_name: {{ .include_file_name }}
+      include_file_path: {{ .include_file_path }}
+      include_file_name_resolved: {{ .include_file_name_resolved }}
+      include_file_path_resolved: {{ .include_file_path_resolved }}
+      start_at: {{ .start_at }}
+      operators: 
+      - type: regex_parser
+        regex: '^(?P<remoteIp>[^,]+), (?P<user>[^,]+), (?P<date>[^,]+), (?P<time>[^,]+), (?P<service>[^,]+), (?P<server_name>[^,]+), (?P<address>[^,]+), (?P<time_taken>[^,]+), (?P<cs_bytes_sent>[^,]+), (?P<sc_bytes_sent>[^,]+), (?P<sc_status>[^,]+), (?P<sc_win32_status>[^,]+), (?P<operation>[^,]+), (?P<cs_uri_stem>[^,]+), (?P<cs_uri_query>[^,]+),$'
+        severity:
+          parse_from: attributes.sc_status
+          mapping:
+            info: 2xx
+            info2: 3xx
+            warn: 4xx
+            error: 5xx
+
+      - id: add_timestamp
+        type: add
+        if: 'attributes.date != nil and attributes.time != nil'
+        field: attributes.timestamp
+        value: EXPR(attributes.date + " " + attributes.time)
+
+      # Remove date field
+      - id: remove_date
+        type: remove
+        if: 'attributes.date != nil'
+        field: attributes.date
+
+      # Remove date field
+      - id: remove_time
+        type: remove
+        if: 'attributes.time != nil'
+        field: attributes.time
+
+      - id: time_parser
+        type: time_parser
+        if: 'attributes.timestamp != nil'
+        parse_from: attributes.timestamp
+        layout: '%q/%g/%Y %H:%M:%S'
+        location: {{.timezone}}
+
+      - id: add_log_type
+        type: add
+        field: 'attributes.log_type'
+        value: 'microsoft_iis'
+    {{end}}
+
+    # NCSA format
+    {{if eq .log_format "ncsa"}}
+    filelog:
+      include: 
+      {{ range $i, $fp := .file_path }}
+        - '{{ $fp }}'
+      {{ end }}
+      {{ if .exclude_file_log_path }}  
+      exclude: 
+      {{ range $i, $efp := .exclude_file_log_path }}
+        - '{{ $efp }}'
+      {{ end }}
+     {{ end }}
+      include_file_name: {{ .include_file_name }}
+      include_file_path: {{ .include_file_path }}
+      include_file_name_resolved: {{ .include_file_name_resolved }}
+      include_file_path_resolved: {{ .include_file_path_resolved }}
+      start_at: {{ .start_at }}
+      operators: 
+      - type: regex_parser
+        # Note: The second, uncaptured group here is "Remote log name". This value is always "-" in IIS, so we don't include it
+        regex: '^(?P<remoteIp>[^\s]+) (?:[^\s]+) (?P<user>[^\s]+) \[(?P<timestamp>[^]]+)\] "(?P<operation>[^\s]+) (?P<cs_uri_stem>[^\s?]+)(?:\?(?P<cs_uri_query>[^\s]+))? (?P<protocol>[^\s]+)" (?P<sc_status>[^\s]+) (?P<sc_bytes>[^\s]+)$'
+        severity:
+          parse_from: attributes.sc_status
+          mapping:
+            info: 2xx
+            info2: 3xx
+            warn: 4xx
+            error: 5xx
+        timestamp:
+          parse_from: attributes.timestamp
+          layout: '%d/%b/%Y:%H:%M:%S %z'
+      
+      - id: add_log_type
+        type: add
+        field: 'attributes.log_type'
+        value: 'microsoft_iis'
+    {{end}}
   service:
     pipelines:
       logs:


### PR DESCRIPTION
### Proposed Change
* Add support for IIS format
* Add support for NCSA format
* Extend W3C support to allow for specifying a custom header.
  * This allows us to support extra fields to be configured in IIS.
  * Because of this change, the attribute names are different than they were previously.

Note on field naming; I tried to keep them consistent with the W3C logs, the main difference is that instead of hyphens I have underscores, since go's regexes do not allow hyphens in capture group names.

<details>
<summary>Sample W3C default log</summary>

```
LogRecord #1
ObservedTimestamp: 2022-08-09 20:21:04.443152 +0000 UTC
Timestamp: 2022-08-09 19:42:33 +0000 UTC
Severity: Warn
Body: 2022-08-09 19:42:33 127.0.0.1 GET /query param1=1&parma2=2 80 - 127.0.0.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - 404 0 2 0
Attributes:
     -> sc-status: STRING(404)
     -> timestamp: STRING(2022-08-09 19:42:33)
     -> sc-win32-status: STRING(2)
     -> cs-uri-query: STRING(param1=1&parma2=2)
     -> cs(Referer): STRING(-)
     -> sc-substatus: STRING(0)
     -> log.file.name: STRING(w3c_format_logs.log)
     -> cs(User-Agent): STRING(Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0)
     -> cs-uri-stem: STRING(/query)
     -> log_type: STRING(microsoft_iis)
     -> s-ip: STRING(127.0.0.1)
     -> c-ip: STRING(127.0.0.1)
     -> log.file.path: STRING(tmp/w3c_format_logs.log)
     -> cs-username: STRING(-)
     -> time-taken: STRING(0)
     -> cs-method: STRING(GET)
     -> s-port: STRING(80)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>Sample W3C log with extra fields</summary>

```
LogRecord #0
ObservedTimestamp: 2022-08-09 20:27:26.172604 +0000 UTC
Timestamp: 2022-08-09 20:25:26 +0000 UTC
Severity: Warn
Body: 2022-08-09 20:25:26 W3SVC1 <Server> 127.0.0.1 GET /query param1=1&parma2=2 80 - 127.0.0.1 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - - localhost 404 0 2 5029 464 83
Attributes:
     -> timestamp: STRING(2022-08-09 20:25:26)
     -> cs-uri-query: STRING(param1=1&parma2=2)
     -> cs-bytes: STRING(464)
     -> cs-version: STRING(HTTP/1.1)
     -> sc-bytes: STRING(5029)
     -> time-taken: STRING(83)
     -> cs(Referer): STRING(-)
     -> cs-method: STRING(GET)
     -> cs-username: STRING(-)
     -> cs-host: STRING(localhost)
     -> log_type: STRING(microsoft_iis)
     -> s-computername: STRING(<Server>)
     -> s-port: STRING(80)
     -> log.file.path: STRING(tmp/w3c_format_logs.log)
     -> s-sitename: STRING(W3SVC1)
     -> cs-uri-stem: STRING(/query)
     -> s-ip: STRING(127.0.0.1)
     -> sc-win32-status: STRING(2)
     -> c-ip: STRING(127.0.0.1)
     -> cs(User-Agent): STRING(Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0)
     -> log.file.name: STRING(w3c_format_logs.log)
     -> cs(Cookie): STRING(-)
     -> sc-substatus: STRING(0)
     -> sc-status: STRING(404)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>Sample log for "IIS" format</summary>

```
LogRecord #7
ObservedTimestamp: 2022-08-09 20:40:20.087039 +0000 UTC
Timestamp: 2022-08-09 17:35:32 +0000 UTC
Severity: Warn
Body: 127.0.0.1, -, 8/9/2022, 17:35:32, W3SVC1, <Server>, 127.0.0.1, 0, 455, 5015, 404, 2, GET, /help, query=yes,
Attributes:
     -> sc_status: STRING(404)
     -> log_type: STRING(microsoft_iis)
     -> s_sitename: STRING(W3SVC1)
     -> log.file.name: STRING(iis_format_logs.log)
     -> log.file.path: STRING(tmp/iis_format_logs.log)
     -> sc_bytes: STRING(5015)
     -> s_computername: STRING(<Server>)
     -> cs_uri_query: STRING(query=yes)
     -> c_ip: STRING(127.0.0.1)
     -> time_taken: STRING(0)
     -> timestamp: STRING(8/9/2022 17:35:32)
     -> cs_username: STRING(-)
     -> cs_method: STRING(GET)
     -> s_ip: STRING(127.0.0.1)
     -> cs_uri_stem: STRING(/help)
     -> cs_bytes: STRING(455)
     -> sc_win32_status: STRING(2)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>Sample log for "NCSA" format</summary>

```
LogRecord #7
ObservedTimestamp: 2022-08-09 20:41:13.020209 +0000 UTC
Timestamp: 2022-08-09 19:33:36 +0000 UTC
Severity: Warn
Body: 127.0.0.1 - - [09/Aug/2022:19:33:36 +0000] \"GET /query?param1=1&parma2=2 HTTP/1.1\" 404 5029
Attributes:
     -> log_type: STRING(microsoft_iis)
     -> log.file.name: STRING(ncsa_format_logs.log)
     -> log.file.path: STRING(tmp/ncsa_format_logs.log)
     -> c_ip: STRING(127.0.0.1)
     -> cs_uri_stem: STRING(/query)
     -> cs_username: STRING(-)
     -> timestamp: STRING(09/Aug/2022:19:33:36 +0000)
     -> cs_version: STRING(HTTP/1.1)
     -> cs_method: STRING(GET)
     -> sc_status: STRING(404)
     -> sc_bytes: STRING(5029)
     -> cs_uri_query: STRING(param1=1&parma2=2)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
