### PR TITLE
deps: Updated Tool versions

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -26,6 +26,6 @@ jobs:
           go-version: "1.18"
           check-latest: true
       - name: Install Goec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.10.0
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
       - name: Run Gosec Security Scanner
         run: make gosec

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -5,7 +5,7 @@ on:
       version:
         description: "Collector Version"
         required: true
-        default: 'v0.0.1'
+        default: "v0.0.1"
 
 jobs:
   build-msi:
@@ -32,7 +32,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: "v1.9.1"
+          version: "v1.10.3"
           args: build --single-target --skip-validate --rm-dist --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
-          version: "v1.9.1"
+          version: "v1.10.3"
           args: build --single-target --skip-validate --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -133,7 +133,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser
-          version: "v1.9.1"
+          version: "v1.10.3"
           args: release --rm-dist --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install-tools:
 	go install github.com/google/addlicense@v1.0.0
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
-	go install github.com/sigstore/cosign/cmd/cosign@v1.5.2
+	go install github.com/sigstore/cosign/cmd/cosign@v1.10.1
 	go install github.com/goreleaser/goreleaser@v1.9.1
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.10.0
 	go install github.com/uw-labs/lichen@v0.1.7

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ install-tools:
 	go install github.com/goreleaser/goreleaser@v1.10.3
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
 	go install github.com/uw-labs/lichen@v0.1.7
-	go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.47.0
-	
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ install-tools:
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/sigstore/cosign/cmd/cosign@v1.10.1
-	go install github.com/goreleaser/goreleaser@v1.9.1
+	go install github.com/goreleaser/goreleaser@v1.10.3
 	go install github.com/securego/gosec/v2/cmd/gosec@v2.10.0
 	go install github.com/uw-labs/lichen@v0.1.7
 	go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.47.0

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ install-tools:
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/sigstore/cosign/cmd/cosign@v1.10.1
 	go install github.com/goreleaser/goreleaser@v1.10.3
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.10.0
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
 	go install github.com/uw-labs/lichen@v0.1.7
 	go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@v0.47.0
 	

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ build-windows-amd64:
 # tool-related commands
 .PHONY: install-tools
 install-tools:
-	go install github.com/mgechev/revive@v1.2.0
+	go install github.com/mgechev/revive@v1.2.3
 	go install github.com/google/addlicense@v1.0.0
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4

--- a/receiver/pluginreceiver/rendered_config_test.go
+++ b/receiver/pluginreceiver/rendered_config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
### Proposed Change
- Updated revive to 1.2.3
- Updated cosign to 1.10.1
- Updated goreleaser to 1.10.3
- Updated gosec to 2.12.0
- Removed unused mdatagen tool
- Fixed fmt error in license comment

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
