### PR TITLE
fix(logging): Write default logging yaml if not specified

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -121,7 +121,7 @@ func getDefaultLoggingConfigPath() string {
 	if ok {
 		return lp
 	}
-	return "./logging.yaml"
+	return logging.DefaultConfigPath
 }
 
 func logOptions(loggingConfigPath *string) ([]zap.Option, error) {

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -58,7 +58,7 @@ func NewLoggerConfig(configPath string) (*LoggerConfig, error) {
 			}
 			return defaultConf, nil
 		} else if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to stat config: %w", err)
 		}
 
 		// The default config exists; We'll use the default config path
@@ -74,11 +74,11 @@ func NewLoggerConfig(configPath string) (*LoggerConfig, error) {
 
 	confBytes, err := os.ReadFile(cleanPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read config: %w", err)
 	}
 
 	if err := yaml.Unmarshal(confBytes, conf); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	if conf.File != nil {

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -27,7 +27,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const defaultConfigPath = "./logging.yaml"
+// DefaultConfigPath is the relative path to the default logging.yaml
+const DefaultConfigPath = "./logging.yaml"
 
 const (
 	// fileOutput is an output option for logging to a file.
@@ -46,24 +47,21 @@ type LoggerConfig struct {
 
 // NewLoggerConfig returns a logger config.
 // If configPath is not set, stdout logging will be enabled, and a default
-// logging.yaml will be written to logging.yaml
+// configuration will be written to ./logging.yaml
 func NewLoggerConfig(configPath string) (*LoggerConfig, error) {
 	// No logger path specified, we'll assume the default path.
-	if configPath == "" {
+	if configPath == DefaultConfigPath {
 		// If the file doesn't exist, we will create the config with the default parameters.
-		if _, err := os.Stat(defaultConfigPath); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(DefaultConfigPath); errors.Is(err, os.ErrNotExist) {
 			defaultConf := defaultConfig()
-			if err := writeConfig(defaultConf, defaultConfigPath); err != nil {
+			if err := writeConfig(defaultConf, DefaultConfigPath); err != nil {
 				return nil, fmt.Errorf("failed to write default configuration: %w", err)
 			}
 			return defaultConf, nil
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to stat config: %w", err)
 		}
-
-		// The default config exists; We'll use the default config path
-		// to read from.
-		configPath = defaultConfigPath
+		// The config already exists; We should continue and read it like any other config.
 	}
 
 	cleanPath := filepath.Clean(configPath)

--- a/internal/logging/config.go
+++ b/internal/logging/config.go
@@ -39,11 +39,12 @@ const (
 type LoggerConfig struct {
 	Output string             `yaml:"output"`
 	Level  zapcore.Level      `yaml:"level"`
-	File   *lumberjack.Logger `yaml:"file"`
+	File   *lumberjack.Logger `yaml:"file,omitempty"`
 }
 
-// NewLoggerConfig returns a logger config. If configPath is not
-// set, stdout logging will be enabled.
+// NewLoggerConfig returns a logger config.
+// If configPath is not set, stdout logging will be enabled, and a default
+// logging.yaml will be written to logging.yaml
 func NewLoggerConfig(configPath string) (*LoggerConfig, error) {
 	conf := &LoggerConfig{
 		Output: stdOutput,
@@ -111,4 +112,23 @@ func newEncoder() zapcore.Encoder {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	return zapcore.NewJSONEncoder(encoderConfig)
+}
+
+func writeDefaultConfig(outLocation string) error {
+	defaultConfig := LoggerConfig{
+		Output: stdOutput,
+		Level:  zap.InfoLevel,
+	}
+
+	defaultConfigBytes, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	err = os.WriteFile(outLocation, defaultConfigBytes, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
 }

--- a/internal/logging/config_test.go
+++ b/internal/logging/config_test.go
@@ -101,21 +101,21 @@ func TestNewLoggerConfig(t *testing.T) {
 	}
 }
 
-func TestNewLoggerConfigNotSpecified(t *testing.T) {
+func TestNewLoggerConfigDefaultPath(t *testing.T) {
 	t.Run("config does not exist in default location", func(t *testing.T) {
 		tempDir := t.TempDir()
 		chDir(t, tempDir)
 
-		require.NoFileExists(t, defaultConfigPath)
+		require.NoFileExists(t, DefaultConfigPath)
 
-		conf, err := NewLoggerConfig("")
+		conf, err := NewLoggerConfig(DefaultConfigPath)
 		require.NoError(t, err)
 		require.Equal(t, defaultConfig(), conf)
 
-		require.FileExists(t, defaultConfigPath)
+		require.FileExists(t, DefaultConfigPath)
 
 		// Calling again with the existing config should give the same result
-		conf, err = NewLoggerConfig("")
+		conf, err = NewLoggerConfig(DefaultConfigPath)
 		require.NoError(t, err)
 		require.Equal(t, defaultConfig(), conf)
 	})
@@ -131,10 +131,10 @@ func TestNewLoggerConfigNotSpecified(t *testing.T) {
 
 		chDir(t, tempDir)
 
-		err = os.WriteFile(defaultConfigPath, testYamlBytes, 0600)
+		err = os.WriteFile(DefaultConfigPath, testYamlBytes, 0600)
 		require.NoError(t, err)
 
-		conf, err := NewLoggerConfig("")
+		conf, err := NewLoggerConfig(DefaultConfigPath)
 		require.NoError(t, err)
 		require.Equal(t, &LoggerConfig{
 			Output: fileOutput,

--- a/internal/logging/config_test.go
+++ b/internal/logging/config_test.go
@@ -15,6 +15,7 @@
 package logging
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/internal/logging/config_test.go
+++ b/internal/logging/config_test.go
@@ -87,10 +87,10 @@ func TestNewLoggerConfig(t *testing.T) {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tc.expectedErr)
 				return
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.expect, conf)
 			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, conf)
 
 			opts, err := conf.Options()
 			require.NoError(t, err)

--- a/internal/logging/config_test.go
+++ b/internal/logging/config_test.go
@@ -15,6 +15,7 @@
 package logging
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,14 +75,6 @@ func TestNewLoggerConfig(t *testing.T) {
 				},
 			},
 		},
-		{
-			"config does not exist",
-			"testdata/does-not-exist.yaml",
-			&LoggerConfig{
-				Output: stdOutput,
-				Level:  zapcore.InfoLevel,
-			},
-		},
 	}
 
 	for _, tc := range cases {
@@ -91,8 +84,28 @@ func TestNewLoggerConfig(t *testing.T) {
 			require.Equal(t, tc.expect, conf)
 
 			opts, err := conf.Options()
+			require.NoError(t, err)
 			require.NotNil(t, opts)
 			require.Len(t, opts, 1)
 		})
 	}
+}
+
+func TestNewLoggerConfigExistingFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	loggingYaml := filepath.Join(tempDir, "dne-logging.yaml")
+
+	require.NoFileExists(t, loggingYaml)
+
+	conf, err := NewLoggerConfig(loggingYaml)
+	require.NoError(t, err)
+	require.Equal(t, defaultConfig(), conf)
+
+	require.FileExists(t, loggingYaml)
+
+	// Calling again with the existing config should give the same result
+	conf, err = NewLoggerConfig(loggingYaml)
+	require.NoError(t, err)
+	require.Equal(t, defaultConfig(), conf)
 }

--- a/internal/logging/testdata/not-yaml.txt
+++ b/internal/logging/testdata/not-yaml.txt
@@ -1,0 +1,1 @@
+not a yaml file


### PR DESCRIPTION
### Proposed Change
* When the `--logging` flag is not specified, write out a default stdout config
  * This fixes an issue where the logging.yaml would not exist on the system, so managed mode would fail when attempting to report the config to BindPlane OP
* Make specifying a logging.yaml fail if the specified yaml does not exist

Tested with a local build to ensure the logging.yaml was created locally on startup without specifying its location.

The default logging.yaml looks like this:
```yaml
output: stdout
level: info
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
