### PR TITLE
fix(plugin): Make start_at description consistent for common_event_format_logs plugin

### DIFF
--- a/plugins/common_event_format_logs.yaml
+++ b/plugins/common_event_format_logs.yaml
@@ -20,7 +20,7 @@ parameters:
     default: UTC
   - name: start_at
     type: string
-    description: Start reading file from 'beginning' or 'end'
+    description: At startup, where to start reading logs from the file (`beginning` or `end`)
     supported:
       - beginning
       - end


### PR DESCRIPTION
### Proposed Change
* Make start_at description consistent with other plugin's start_at descriptions for common_event_format_logs plugin

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
