### PR TITLE
feat: Set ENV to path of collector config.yaml

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -102,9 +102,8 @@ func getDefaultCollectorConfigPaths() []string {
 	cp, ok := os.LookupEnv(configPathENV)
 	if ok {
 		return []string{cp}
-	} else {
-		return []string{"./config.yaml"}
 	}
+	return []string{"./config.yaml"}
 }
 
 func logOptions(loggingConfigPath *string) ([]zap.Option, error) {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -36,15 +36,16 @@ import (
 
 const (
 	// env variable name constants
-	endpointENV  = "OPAMP_ENDPOINT"
-	agentIDENV   = "OPAMP_AGENT_ID"
-	secretkeyENV = "OPAMP_SECRET_KEY" //#nosec G101
-	labelsENV    = "OPAMP_LABELS"
-	agentNameENV = "OPAMP_AGENT_NAME"
+	endpointENV   = "OPAMP_ENDPOINT"
+	agentIDENV    = "OPAMP_AGENT_ID"
+	secretkeyENV  = "OPAMP_SECRET_KEY" //#nosec G101
+	labelsENV     = "OPAMP_LABELS"
+	agentNameENV  = "OPAMP_AGENT_NAME"
+	configPathENV = "CONFIG_YAML_PATH"
 )
 
 func main() {
-	collectorConfigPaths := pflag.StringSlice("config", []string{"./config.yaml"}, "the collector config path")
+	collectorConfigPaths := pflag.StringSlice("config", getDefaultCollectorConfigPaths(), "the collector config path")
 	managerConfigPath := pflag.String("manager", "./manager.yaml", "The configuration for remote management")
 	loggingConfigPath := pflag.String("logging", "./logging.yaml", "the collector logging config path")
 
@@ -95,6 +96,15 @@ func main() {
 		logger.Fatal("RunService returned error", zap.Error(err))
 	}
 
+}
+
+func getDefaultCollectorConfigPaths() []string {
+	_, ok := os.LookupEnv(configPathENV)
+	if ok {
+		return []string{configPathENV}
+	} else {
+		return []string{"./config.yaml"}
+	}
 }
 
 func logOptions(loggingConfigPath *string) ([]zap.Option, error) {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -99,9 +99,9 @@ func main() {
 }
 
 func getDefaultCollectorConfigPaths() []string {
-	_, ok := os.LookupEnv(configPathENV)
+	cp, ok := os.LookupEnv(configPathENV)
 	if ok {
-		return []string{configPathENV}
+		return []string{cp}
 	} else {
 		return []string{"./config.yaml"}
 	}

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -31,8 +31,7 @@ import (
 func TestGetDefaultCollectorConfigPathENV(t *testing.T) {
 	fakeConfigPath := "./fake/path/config.yaml"
 
-	os.Setenv(configPathENV, fakeConfigPath)
-	defer os.Unsetenv(configPathENV)
+	t.Setenv(configPathENV, fakeConfigPath)
 
 	expected := []string{fakeConfigPath}
 	actual := getDefaultCollectorConfigPaths()

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -29,10 +29,12 @@ import (
 )
 
 func TestGetDefaultCollectorConfigPathENV(t *testing.T) {
-	os.Setenv(configPathENV, "./fake/path/config.yaml")
+	fakeConfigPath := "./fake/path/config.yaml"
+
+	os.Setenv(configPathENV, fakeConfigPath)
 	defer os.Unsetenv(configPathENV)
 
-	expected := []string{"./fake/path/config.yaml"}
+	expected := []string{fakeConfigPath}
 	actual := getDefaultCollectorConfigPaths()
 
 	require.Equal(t, expected, actual)

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -28,6 +28,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestGetDefaultCollectorConfigPathENV(t *testing.T) {
+	os.Setenv(configPathENV, "./fake/path/config.yaml")
+	defer os.Unsetenv(configPathENV)
+
+	expected := []string{"./fake/path/config.yaml"}
+	actual := getDefaultCollectorConfigPaths()
+
+	require.Equal(t, expected, actual)
+}
+
+func TestGetDefaultCollectorConfigPathNone(t *testing.T) {
+	expected := []string{"./config.yaml"}
+	actual := getDefaultCollectorConfigPaths()
+
+	require.Equal(t, expected, actual)
+}
+
 func TestCheckManagerNoConfig(t *testing.T) {
 	manager := "./manager.yaml"
 	err := checkManagerConfig(&manager)


### PR DESCRIPTION
### Proposed Change
- Added function for getting default collector config paths
- Will use an ENV variable if it is set
- If not will use default (./config.yaml)

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
