### PR TITLE
feat: Set ENV to path of collector manager.yaml

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -42,12 +42,13 @@ const (
 	labelsENV      = "OPAMP_LABELS"
 	agentNameENV   = "OPAMP_AGENT_NAME"
 	configPathENV  = "CONFIG_YAML_PATH"
+	managerPathENV = "MANAGER_YAML_PATH"
 	loggingPathENV = "LOGGING_YAML_PATH"
 )
 
 func main() {
 	collectorConfigPaths := pflag.StringSlice("config", getDefaultCollectorConfigPaths(), "the collector config path")
-	managerConfigPath := pflag.String("manager", "./manager.yaml", "The configuration for remote management")
+	managerConfigPath := pflag.String("manager", getDefaultManagerConfigPath(), "The configuration for remote management")
 	loggingConfigPath := pflag.String("logging", getDefaultLoggingConfigPath(), "the collector logging config path")
 
 	_ = pflag.String("log-level", "", "not implemented") // TEMP(jsirianni): Required for OTEL k8s operator
@@ -105,6 +106,14 @@ func getDefaultCollectorConfigPaths() []string {
 		return []string{cp}
 	}
 	return []string{"./config.yaml"}
+}
+
+func getDefaultManagerConfigPath() string {
+	mp, ok := os.LookupEnv(managerPathENV)
+	if ok {
+		return mp
+	}
+	return "./manager.yaml"
 }
 
 func getDefaultLoggingConfigPath() string {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -146,7 +146,7 @@ func checkManagerConfig(configPath *string) error {
 	case errors.Is(statErr, os.ErrNotExist):
 		var ok bool
 
-		// manager.ymal file does *not* exist, create file using env variables
+		// manager.yaml file does *not* exist, create file using env variables
 		newConfig := &opamp.Config{}
 
 		// Endpoint is only required env

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -64,6 +64,24 @@ func TestGetDefaultLoggingConfigPathNone(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestGetDefaultManagerConfigPathENV(t *testing.T) {
+	fakeManagerPath := "./fake/path/Manager.yaml"
+
+	t.Setenv(managerPathENV, fakeManagerPath)
+
+	expected := fakeManagerPath
+	actual := getDefaultManagerConfigPath()
+
+	require.Equal(t, expected, actual)
+}
+
+func TestGetDefaultManagerConfigPathNone(t *testing.T) {
+	expected := "./manager.yaml"
+	actual := getDefaultManagerConfigPath()
+
+	require.Equal(t, expected, actual)
+}
+
 func TestCheckManagerNoConfig(t *testing.T) {
 	manager := "./manager.yaml"
 	err := checkManagerConfig(&manager)


### PR DESCRIPTION
### Proposed Change
- Added function for getting default collector manager path
- Will use an ENV variable if it is set
- If not will use default (./manager.yaml)

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
