### PR TITLE
fix(plugin): Enable lazy quotes when parsing W3C

### DIFF
--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.2.1
 title: IIS
 description: Log parser for IIS
 parameters:
@@ -77,6 +77,7 @@ template: |
       - type: csv_parser
         header: '{{ .w3c_header }}'
         delimiter: " "
+        lazy_quotes: true
         severity: 
           parse_from: 'attributes["sc-status"]'
           if: 'attributes["sc-status"] != nil'

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: W3C
 description: Log Parser for W3C
 parameters:
@@ -88,24 +88,8 @@ template: |
         - type: filter
           expr: 'body matches "^#"'
 
-        - type: router
-          default: csv_parser
-          routes:
-            - output: quote_handler_parser
-              expr: body matches '.*".*".*' and not (body matches "^#")
-
-        - id: quote_handler_parser
-          type: regex_parser
-          parse_from: body
-          regex: '(?P<message1>[^"]*)(?P<first_quote>[\"])(?P<message2>[^"]*)(?P<second_quote>[\"])(?P<message3>.*)'
-
-        - id: quote_handler_restructurer
-          type: add
-          field: body
-          value: 'EXPR(attributes.message1 + attributes.message2 + attributes.message3)'
-          output: csv_parser
-
         - type: csv_parser
+          lazy_quotes: true
           delimiter: '{{ .delimiter }}'
           header: '{{ .header }}'
           


### PR DESCRIPTION
### Proposed Change
* Enable lazy_quotes in the csv parsers for W3C and iis
* Remove the unneeded quote manipulation in the W3C plugin (this existed as an alternative to the lazy quotes option)

This fix allows records to have quotes in the middle of its fields.

Resolves #655

<details>
<summary>Parsing an IIS record with a quote in it (before this change)</summary>

```
LogRecord #0
ObservedTimestamp: 2022-08-18 22:03:02.205955 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: 2022-08-09 20:25:26 W3SVC1 <Server> 127.0.0.1 GET /query param1=1&parma2=2\\\">\\\"<script> 80 - 127.0.0.1 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - - localhost 404 0 2 5029 464 83
Attributes:
     -> log.file.name: STRING(w3c_format_logs_quote.log)
     -> log.file.path: STRING(tmp/w3c_format_logs_quote.log)
     -> log_type: STRING(microsoft_iis)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>Parsing a record with an IIS quote in it (after this change)</summary>

```
LogRecord #0
ObservedTimestamp: 2022-08-18 21:52:23.498647 +0000 UTC
Timestamp: 2022-08-09 20:25:26 +0000 UTC
Severity: Warn
Body: 2022-08-09 20:25:26 W3SVC1 <Server> 127.0.0.1 GET /query param1=1&parma2=2\\\">\\\"<script> 80 - 127.0.0.1 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - - localhost 404 0 2 5029 464 83
Attributes:
     -> cs-version: STRING(HTTP/1.1)
     -> cs-method: STRING(GET)
     -> s-port: STRING(80)
     -> sc-status: STRING(404)
     -> cs(Referer): STRING(-)
     -> s-sitename: STRING(W3SVC1)
     -> timestamp: STRING(2022-08-09 20:25:26)
     -> cs-host: STRING(localhost)
     -> cs(Cookie): STRING(-)
     -> cs-bytes: STRING(464)
     -> cs-uri-stem: STRING(/query)
     -> sc-bytes: STRING(5029)
     -> time-taken: STRING(83)
     -> s-computername: STRING(<Server>)
     -> log.file.name: STRING(w3c_format_logs_quote.log)
     -> sc-substatus: STRING(0)
     -> c-ip: STRING(127.0.0.1)
     -> s-ip: STRING(127.0.0.1)
     -> log_type: STRING(microsoft_iis)
     -> log.file.path: STRING(tmp/w3c_format_logs_quote.log)
     -> cs(User-Agent): STRING(Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0)
     -> sc-win32-status: STRING(2)
     -> cs-username: STRING(-)
     -> cs-uri-query: STRING(param1=1&parma2=2\\\">\\\"<script>)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>Same result with the W3C plugin</summary>

```
LogRecord #0
ObservedTimestamp: 2022-08-18 21:57:05.888297 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: 2022-08-09 20:25:26 W3SVC1 <Server> 127.0.0.1 GET /query param1=1&parma2=2\\\">\\\"<script> 80 - 127.0.0.1 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - - localhost 404 0 2 5029 464 83
Attributes:
     -> s-port: STRING(80)
     -> sc-status: STRING(404)
     -> sc-substatus: STRING(0)
     -> s-computername: STRING(<Server>)
     -> cs-uri-query: STRING(param1=1&parma2=2\\\">\\\"<script>)
     -> sc-bytes: STRING(5029)
     -> s-ip: STRING(127.0.0.1)
     -> s-sitename: STRING(W3SVC1)
     -> c-ip: STRING(127.0.0.1)
     -> cs-host: STRING(localhost)
     -> date: STRING(2022-08-09)
     -> cs-method: STRING(GET)
     -> cs-bytes: STRING(464)
     -> log.file.name: STRING(w3c_format_logs_quote.log)
     -> cs(Cookie): STRING(-)
     -> time: STRING(20:25:26)
     -> cs-uri-stem: STRING(/query)
     -> cs(Referer): STRING(-)
     -> time-taken: STRING(83)
     -> cs(User-Agent): STRING(Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0)
     -> log_type: STRING(w3c)
     -> sc-win32-status: STRING(2)
     -> cs-version: STRING(HTTP/1.1)
     -> cs-username: STRING(-)
Trace ID: 
Span ID: 
Flags: 0

```
</details>

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
