### PR TITLE
Replaced interface{} with any

### DIFF
--- a/processor/resourceattributetransposerprocessor/processor_logs_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_logs_test.go
@@ -121,7 +121,7 @@ func TestConsumeLogs(t *testing.T) {
 	err := p.ConsumeLogs(ctx, logs)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 		"resourceattrib2": false,
 		"resourceattrib3": []byte("some bytes"),
@@ -164,11 +164,11 @@ func TestConsumeLogsMoveToMultipleMetrics(t *testing.T) {
 	err := p.ConsumeLogs(ctx, logs)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(1).Attributes().AsRaw())
 }
@@ -211,7 +211,7 @@ func TestConsumeLogsDoesNotOverwrite(t *testing.T) {
 	err := p.ConsumeLogs(ctx, logs)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"out": "value1",
 	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
 }
@@ -255,7 +255,7 @@ func TestConsumeLogsDoesNotOverwrite2(t *testing.T) {
 	err := p.ConsumeLogs(ctx, logs)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"out": "originalvalue",
 	}, logsOut.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().AsRaw())
 }

--- a/processor/resourceattributetransposerprocessor/processor_metrics_test.go
+++ b/processor/resourceattributetransposerprocessor/processor_metrics_test.go
@@ -155,7 +155,7 @@ func TestConsumeMetricsMoveExistingAttribs(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 		"resourceattrib2": false,
 		"resourceattrib3": []byte("some bytes"),
@@ -206,11 +206,11 @@ func TestConsumeMetricsMoveToMultipleMetrics(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 	}, getMetricAttrsFromMetric(getMetricSlice(metricsOut).At(0)))
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1": "value",
 	}, getMetricAttrsFromMetric(getMetricSlice(metricsOut).At(1)))
 }
@@ -252,7 +252,7 @@ func TestConsumeMetricsMixedExistence(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1out": "value1",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -293,7 +293,7 @@ func TestConsumeMetricsSum(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1out": "value1",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -334,7 +334,7 @@ func TestConsumeMetricsHistogram(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1out": "value1",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -375,7 +375,7 @@ func TestConsumeMetricsSummary(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"resourceattrib1out": "value1",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -414,7 +414,7 @@ func TestConsumeMetricsNone(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}(nil), getMetricAttrsFromMetrics(metricsOut))
+	require.Equal(t, map[string]any(nil), getMetricAttrsFromMetrics(metricsOut))
 }
 
 func TestConsumeMetricsDoesNotOverwrite(t *testing.T) {
@@ -458,7 +458,7 @@ func TestConsumeMetricsDoesNotOverwrite(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"out": "value1",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -506,7 +506,7 @@ func TestConsumeMetricsDoesNotOverwrite2(t *testing.T) {
 	err := p.ConsumeMetrics(ctx, metrics)
 	require.NoError(t, err)
 
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"out": "originalvalue",
 	}, getMetricAttrsFromMetrics(metricsOut))
 }
@@ -549,11 +549,11 @@ func createMetrics() pmetric.Metrics {
 	return metrics
 }
 
-func getMetricAttrsFromMetrics(m pmetric.Metrics) map[string]interface{} {
+func getMetricAttrsFromMetrics(m pmetric.Metrics) map[string]any {
 	return getMetricAttrsFromMetric(getMetric(m))
 }
 
-func getMetricAttrsFromMetric(m pmetric.Metric) map[string]interface{} {
+func getMetricAttrsFromMetric(m pmetric.Metric) map[string]any {
 	switch m.DataType() {
 	case pmetric.MetricDataTypeGauge:
 		return m.Gauge().DataPoints().At(0).Attributes().AsRaw()

--- a/receiver/pluginreceiver/factory.go
+++ b/receiver/pluginreceiver/factory.go
@@ -33,15 +33,15 @@ const (
 // Config is the configuration of a plugin receiver
 type Config struct {
 	config.ReceiverSettings `mapstructure:",squash"`
-	Path                    string                 `mapstructure:"path"`
-	Parameters              map[string]interface{} `mapstructure:"parameters"`
+	Path                    string         `mapstructure:"path"`
+	Parameters              map[string]any `mapstructure:"parameters"`
 }
 
 // createDefaultConfig creates a default config for a plugin receiver
 func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
-		Parameters:       make(map[string]interface{}),
+		Parameters:       make(map[string]any),
 	}
 }
 

--- a/receiver/pluginreceiver/factory_test.go
+++ b/receiver/pluginreceiver/factory_test.go
@@ -53,7 +53,7 @@ func TestCreateReceiver(t *testing.T) {
 			name: "invalid plugin parameter",
 			cfg: &Config{
 				Path: "./testdata/plugin-valid.yaml",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"env": 5,
 				},
 			},
@@ -63,7 +63,7 @@ func TestCreateReceiver(t *testing.T) {
 			name: "invalid plugin template",
 			cfg: &Config{
 				Path: "./testdata/plugin-invalid-template.yaml",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"env": "prod",
 				},
 			},
@@ -73,7 +73,7 @@ func TestCreateReceiver(t *testing.T) {
 			name: "valid plugin",
 			cfg: &Config{
 				Path: "./testdata/plugin-valid.yaml",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"env": "prod",
 				},
 			},
@@ -107,7 +107,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 	set := component.ReceiverCreateSettings{}
 	cfg := &Config{
 		Path: "./testdata/plugin-valid.yaml",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"env": "prod",
 		},
 	}
@@ -124,7 +124,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	set := component.ReceiverCreateSettings{}
 	cfg := &Config{
 		Path: "./testdata/plugin-valid.yaml",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"env": "prod",
 		},
 	}
@@ -141,7 +141,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	set := component.ReceiverCreateSettings{}
 	cfg := &Config{
 		Path: "./testdata/plugin-valid.yaml",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"env": "prod",
 		},
 	}
@@ -157,6 +157,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	pluginConfig, ok := config.(*Config)
 	require.True(t, ok)
-	require.Equal(t, make(map[string]interface{}), pluginConfig.Parameters)
+	require.Equal(t, make(map[string]any), pluginConfig.Parameters)
 	require.Empty(t, pluginConfig.Path)
 }

--- a/receiver/pluginreceiver/plugin.go
+++ b/receiver/pluginreceiver/plugin.go
@@ -50,7 +50,7 @@ func LoadPlugin(path string) (*Plugin, error) {
 }
 
 // Render renders the plugin's template as a config
-func (p *Plugin) Render(values map[string]interface{}) (*RenderedConfig, error) {
+func (p *Plugin) Render(values map[string]any) (*RenderedConfig, error) {
 	template, err := template.New(p.Title).Parse(p.Template)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create plugin template: %w", err)
@@ -73,8 +73,8 @@ func (p *Plugin) Render(values map[string]interface{}) (*RenderedConfig, error) 
 
 // ApplyDefaults returns a copy of the values map with parameter defaults applied.
 // If a value is already present in the map, it supercedes the default.
-func (p *Plugin) ApplyDefaults(values map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
+func (p *Plugin) ApplyDefaults(values map[string]any) map[string]any {
+	result := make(map[string]any)
 
 	for _, parameter := range p.Parameters {
 		if parameter.Default == nil {
@@ -92,7 +92,7 @@ func (p *Plugin) ApplyDefaults(values map[string]interface{}) map[string]interfa
 }
 
 // CheckParameters checks the supplied values against the defined parameters of the plugin
-func (p *Plugin) CheckParameters(values map[string]interface{}) error {
+func (p *Plugin) CheckParameters(values map[string]any) error {
 	if err := p.checkDefined(values); err != nil {
 		return fmt.Errorf("definition failure: %w", err)
 	}
@@ -113,7 +113,7 @@ func (p *Plugin) CheckParameters(values map[string]interface{}) error {
 }
 
 // checkDefined checks if any of the supplied values are not defined by the plugin
-func (p *Plugin) checkDefined(values map[string]interface{}) error {
+func (p *Plugin) checkDefined(values map[string]any) error {
 	parameterMap := make(map[string]struct{})
 	for _, parameter := range p.Parameters {
 		parameterMap[parameter.Name] = struct{}{}
@@ -129,7 +129,7 @@ func (p *Plugin) checkDefined(values map[string]interface{}) error {
 }
 
 // checkRequired checks if required values are defined
-func (p *Plugin) checkRequired(values map[string]interface{}) error {
+func (p *Plugin) checkRequired(values map[string]any) error {
 	for _, parameter := range p.Parameters {
 		_, ok := values[parameter.Name]
 		if parameter.Required && !ok {
@@ -141,7 +141,7 @@ func (p *Plugin) checkRequired(values map[string]interface{}) error {
 }
 
 // checkType checks if the values match their parameter type
-func (p *Plugin) checkType(values map[string]interface{}) error {
+func (p *Plugin) checkType(values map[string]any) error {
 	for _, parameter := range p.Parameters {
 		value, ok := values[parameter.Name]
 		if !ok {
@@ -154,7 +154,7 @@ func (p *Plugin) checkType(values map[string]interface{}) error {
 				return fmt.Errorf("parameter %s must be a string", parameter.Name)
 			}
 		case stringArrayType:
-			raw, ok := value.([]interface{})
+			raw, ok := value.([]any)
 			if !ok {
 				return fmt.Errorf("parameter %s must be a []string", parameter.Name)
 			}
@@ -190,7 +190,7 @@ func (p *Plugin) checkType(values map[string]interface{}) error {
 }
 
 // checkSupported checks the values against the plugin's supported values
-func (p *Plugin) checkSupported(values map[string]interface{}) error {
+func (p *Plugin) checkSupported(values map[string]any) error {
 OUTER:
 	for _, parameter := range p.Parameters {
 		if parameter.Supported == nil {
@@ -218,8 +218,8 @@ OUTER:
 type Parameter struct {
 	Name      string        `yaml:"name,omitempty"`
 	Type      ParameterType `yaml:"type,omitempty"`
-	Default   interface{}   `yaml:"default,omitempty"`
-	Supported []interface{} `yaml:"supported,omitempty"`
+	Default   any           `yaml:"default,omitempty"`
+	Supported []any         `yaml:"supported,omitempty"`
 	Required  bool          `yaml:"required,omitempty"`
 }
 

--- a/receiver/pluginreceiver/plugin_test.go
+++ b/receiver/pluginreceiver/plugin_test.go
@@ -42,7 +42,7 @@ func TestLoadPlugin(t *testing.T) {
 						Name:      "env",
 						Type:      stringType,
 						Default:   "prod",
-						Supported: []interface{}{"prod", "dev"},
+						Supported: []any{"prod", "dev"},
 						Required:  true,
 					},
 				},
@@ -79,7 +79,7 @@ func TestRenderComponents(t *testing.T) {
 	testCases := []struct {
 		name           string
 		plugin         *Plugin
-		values         map[string]interface{}
+		values         map[string]any
 		dataType       config.DataType
 		expectedResult *RenderedConfig
 		expectedErr    error
@@ -118,14 +118,14 @@ service:
     metrics:
       receivers: [test]`,
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"enabled": true,
 			},
 			expectedResult: &RenderedConfig{
-				Receivers: map[string]interface{}{
+				Receivers: map[string]any{
 					"test": nil,
 				},
-				Exporters: map[string]interface{}{
+				Exporters: map[string]any{
 					emitterTypeStr: nil,
 				},
 				Service: ServiceConfig{
@@ -162,10 +162,10 @@ service:
 				},
 			},
 			expectedResult: &RenderedConfig{
-				Receivers: map[string]interface{}{
+				Receivers: map[string]any{
 					"test": nil,
 				},
-				Exporters: map[string]interface{}{
+				Exporters: map[string]any{
 					emitterTypeStr: nil,
 				},
 				Service: ServiceConfig{
@@ -203,18 +203,18 @@ func TestApplyDefaults(t *testing.T) {
 	testCases := []struct {
 		name           string
 		plugin         *Plugin
-		values         map[string]interface{}
-		expectedResult map[string]interface{}
+		values         map[string]any
+		expectedResult map[string]any
 	}{
 		{
 			name: "with no parameters",
 			plugin: &Plugin{
 				Parameters: nil,
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value",
 			},
-			expectedResult: map[string]interface{}{
+			expectedResult: map[string]any{
 				"param1": "value",
 			},
 		},
@@ -230,10 +230,10 @@ func TestApplyDefaults(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value",
 			},
-			expectedResult: map[string]interface{}{
+			expectedResult: map[string]any{
 				"param1": "value",
 			},
 		},
@@ -251,10 +251,10 @@ func TestApplyDefaults(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value",
 			},
-			expectedResult: map[string]interface{}{
+			expectedResult: map[string]any{
 				"param1": "value",
 				"param2": "defaultValue2",
 			},
@@ -273,13 +273,13 @@ func TestCheckParameters(t *testing.T) {
 	testCases := []struct {
 		name        string
 		plugin      *Plugin
-		values      map[string]interface{}
+		values      map[string]any
 		expectedErr error
 	}{
 		{
 			name:   "undefined parameters",
 			plugin: &Plugin{},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
 			},
 			expectedErr: errors.New("definition failure"),
@@ -294,7 +294,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values:      map[string]interface{}{},
+			values:      map[string]any{},
 			expectedErr: errors.New("required failure"),
 		},
 		{
@@ -307,7 +307,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": 5,
 			},
 			expectedErr: errors.New("must be a string"),
@@ -322,7 +322,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": 5,
 			},
 			expectedErr: errors.New("must be a []string"),
@@ -337,8 +337,8 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
-				"param1": []interface{}{
+			values: map[string]any{
+				"param1": []any{
 					5,
 				},
 			},
@@ -354,7 +354,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
 			},
 			expectedErr: errors.New("must be an int"),
@@ -369,7 +369,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
 			},
 			expectedErr: errors.New("must be a bool"),
@@ -384,7 +384,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
 			},
 			expectedErr: errors.New("unsupported parameter type: invalidType"),
@@ -396,11 +396,11 @@ func TestCheckParameters(t *testing.T) {
 					{
 						Name:      "param1",
 						Type:      stringType,
-						Supported: []interface{}{"value2"},
+						Supported: []any{"value2"},
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
 			},
 			expectedErr: errors.New("supported value failure"),
@@ -415,7 +415,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": true,
 			},
 			expectedErr: errors.New("must be a string"),
@@ -430,7 +430,7 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "Eastern",
 			},
 			expectedErr: errors.New("must be a valid timezone"),
@@ -443,7 +443,7 @@ func TestCheckParameters(t *testing.T) {
 						Name:      "param1",
 						Type:      stringType,
 						Required:  true,
-						Supported: []interface{}{"value1"},
+						Supported: []any{"value1"},
 					},
 					{
 						Name: "param2",
@@ -460,7 +460,7 @@ func TestCheckParameters(t *testing.T) {
 					{
 						Name:      "param5",
 						Type:      stringType,
-						Supported: []interface{}{"value5"},
+						Supported: []any{"value5"},
 					},
 					{
 						Name: "param6",
@@ -468,9 +468,9 @@ func TestCheckParameters(t *testing.T) {
 					},
 				},
 			},
-			values: map[string]interface{}{
+			values: map[string]any{
 				"param1": "value1",
-				"param2": []interface{}{"value2"},
+				"param2": []any{"value2"},
 				"param3": 5,
 				"param4": true,
 				"param6": "Pacific/Wallis",

--- a/receiver/pluginreceiver/receiver_test.go
+++ b/receiver/pluginreceiver/receiver_test.go
@@ -33,7 +33,7 @@ func TestReceiverGetFactoryFailure(t *testing.T) {
 	host.On("GetFactory", mock.Anything, mock.Anything).Return(nil)
 
 	renderedCfg := &RenderedConfig{
-		Receivers: map[string]interface{}{
+		Receivers: map[string]any{
 			"missing": nil,
 		},
 	}
@@ -59,7 +59,7 @@ func TestReceiverCreateServiceFailure(t *testing.T) {
 	host.On("GetFactory", mock.Anything, mock.Anything).Return(nopFactory)
 
 	renderedCfg := &RenderedConfig{
-		Receivers: map[string]interface{}{
+		Receivers: map[string]any{
 			"nop": nil,
 		},
 	}
@@ -88,7 +88,7 @@ func TestReceiverStartServiceFailure(t *testing.T) {
 	host.On("GetFactory", mock.Anything, mock.Anything).Return(nopFactory)
 
 	renderedCfg := &RenderedConfig{
-		Receivers: map[string]interface{}{
+		Receivers: map[string]any{
 			"nop": nil,
 		},
 	}
@@ -123,7 +123,7 @@ func TestReceiverStartServiceContext(t *testing.T) {
 	host.On("GetFactory", mock.Anything, mock.Anything).Return(nopFactory)
 
 	renderedCfg := &RenderedConfig{
-		Receivers: map[string]interface{}{
+		Receivers: map[string]any{
 			"nop": nil,
 		},
 	}
@@ -156,7 +156,7 @@ func TestReceiverStartSuccess(t *testing.T) {
 	host.On("GetFactory", mock.Anything, mock.Anything).Return(nopFactory)
 
 	renderedCfg := &RenderedConfig{
-		Receivers: map[string]interface{}{
+		Receivers: map[string]any{
 			"nop": nil,
 		},
 	}

--- a/receiver/pluginreceiver/rendered_config.go
+++ b/receiver/pluginreceiver/rendered_config.go
@@ -28,11 +28,11 @@ import (
 
 // RenderedConfig is the rendered config of a plugin
 type RenderedConfig struct {
-	Receivers  map[string]interface{} `yaml:"receivers,omitempty"`
-	Processors map[string]interface{} `yaml:"processors,omitempty"`
-	Exporters  map[string]interface{} `yaml:"exporters,omitempty"`
-	Extensions map[string]interface{} `yaml:"extensions,omitempty"`
-	Service    ServiceConfig          `yaml:"service,omitempty"`
+	Receivers  map[string]any `yaml:"receivers,omitempty"`
+	Processors map[string]any `yaml:"processors,omitempty"`
+	Exporters  map[string]any `yaml:"exporters,omitempty"`
+	Extensions map[string]any `yaml:"extensions,omitempty"`
+	Service    ServiceConfig  `yaml:"service,omitempty"`
 }
 
 // ServiceConfig is the config of a collector service
@@ -66,7 +66,7 @@ func NewRenderedConfig(yamlBytes []byte) (*RenderedConfig, error) {
 		return nil, fmt.Errorf("failed to unmarshal yaml bytes: %w", err)
 	}
 
-	renderedCfg.Exporters = map[string]interface{}{
+	renderedCfg.Exporters = map[string]any{
 		emitterTypeStr: nil,
 	}
 

--- a/receiver/pluginreceiver/rendered_config_test.go
+++ b/receiver/pluginreceiver/rendered_config_test.go
@@ -44,7 +44,7 @@ func TestGetRequiredFactories(t *testing.T) {
 		{
 			name: "missing receiver factory",
 			renderedCfg: &RenderedConfig{
-				Receivers: map[string]interface{}{
+				Receivers: map[string]any{
 					"missing": nil,
 				},
 			},
@@ -53,7 +53,7 @@ func TestGetRequiredFactories(t *testing.T) {
 		{
 			name: "missing processor factory",
 			renderedCfg: &RenderedConfig{
-				Processors: map[string]interface{}{
+				Processors: map[string]any{
 					"missing": nil,
 				},
 			},
@@ -62,7 +62,7 @@ func TestGetRequiredFactories(t *testing.T) {
 		{
 			name: "missing extension factory",
 			renderedCfg: &RenderedConfig{
-				Extensions: map[string]interface{}{
+				Extensions: map[string]any{
 					"missing": nil,
 				},
 			},
@@ -71,13 +71,13 @@ func TestGetRequiredFactories(t *testing.T) {
 		{
 			name: "all factories exist",
 			renderedCfg: &RenderedConfig{
-				Receivers: map[string]interface{}{
+				Receivers: map[string]any{
 					"test": nil,
 				},
-				Processors: map[string]interface{}{
+				Processors: map[string]any{
 					"test": nil,
 				},
-				Extensions: map[string]interface{}{
+				Extensions: map[string]any{
 					"test": nil,
 				},
 			},
@@ -99,15 +99,15 @@ func TestGetRequiredFactories(t *testing.T) {
 		{
 			name: "duplicate receivers defined",
 			renderedCfg: &RenderedConfig{
-				Receivers: map[string]interface{}{
+				Receivers: map[string]any{
 					"test":   nil,
 					"test/2": nil,
 				},
-				Processors: map[string]interface{}{
+				Processors: map[string]any{
 					"test":   nil,
 					"test/2": nil,
 				},
-				Extensions: map[string]interface{}{
+				Extensions: map[string]any{
 					"test":   nil,
 					"test/2": nil,
 				},

--- a/receiver/pluginreceiver/supplied_plugins_test.go
+++ b/receiver/pluginreceiver/supplied_plugins_test.go
@@ -43,7 +43,7 @@ func TestValidateSuppliedPlugins(t *testing.T) {
 			plugin, err := LoadPlugin(fullFilePath)
 			assert.NoError(t, err, "Failed to load file %s", entryName)
 
-			_, err = plugin.Render(map[string]interface{}{})
+			_, err = plugin.Render(map[string]any{})
 			assert.NoError(t, err, "Failed to render config for plugin %s", entryName)
 		})
 	}
@@ -66,7 +66,7 @@ func TestValidateSuppliedPluginsLoadSuppliedDefaults(t *testing.T) {
 			plugin, err := LoadPlugin(fullFilePath)
 			require.NoError(t, err, "Failed to load file %s", entryName)
 
-			parameterMap := plugin.ApplyDefaults(map[string]interface{}{})
+			parameterMap := plugin.ApplyDefaults(map[string]any{})
 
 			require.NoError(t, plugin.checkDefined(parameterMap))
 			require.NoError(t, plugin.checkSupported(parameterMap))


### PR DESCRIPTION
### Proposed Change
Per new alias in go 1.18 updated all instances of `interface{}` to `any`

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
