### PR TITLE
fix: Container image default logging configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN adduser \
     --uid 10005 \
     otel
 
+RUN echo "output: stdout\nlevel: info\n" > /etc/otel/logging.yaml
+ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
+
 USER otel
 
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The logging configuration is created on collector startup, if it does not exist. This presents an issue with the container image, as the collector process does not have permission to write to `./logging.yaml` in its working directory.

There are several ways to resolve this, but I think the best solution is to just bake a logging.yaml into /etc/otel and point to it with the new environment variable.

This changes resolves issues that I am observing with 1.7.0 in Kubernetes and OpenShift. 

##### Checklist
- [x] Changes are tested
- [x] CI has passed
