### PR TITLE
fix: Fixed mac install script to remove files before copying them over

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -464,6 +464,7 @@ install_package()
   # Move files to install dir
   for f in $FILES
   do
+    rm -rf "$INSTALL_DIR/$f"
     cp "$TMP_DIR/artifacts/$f" "$INSTALL_DIR/$f" || error_exit "$LINENO" "Failed to copy artifact $f to install dir"
   done
   decrease_indent


### PR DESCRIPTION
### Proposed Change
M1 Macs apparently need (at least) the collector binary to be removed first before the new one is copied over on an upgrade type install. Without doing this, the new collector fails to run in the destination directory (even though there is nothing obviously wrong with it. It can still run in other directories if copied over). So to ensure this isn't a problem, I'm now removing any files/directories from the artifacts directory before copying them over.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
