### PR TITLE
fix(plugin): Use ignore_quotes option for w3c type logs

### DIFF
--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.1
+version: 0.2.2
 title: IIS
 description: Log parser for IIS
 parameters:
@@ -77,7 +77,7 @@ template: |
       - type: csv_parser
         header: '{{ .w3c_header }}'
         delimiter: " "
-        lazy_quotes: true
+        ignore_quotes: true
         severity: 
           parse_from: 'attributes["sc-status"]'
           if: 'attributes["sc-status"] != nil'

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.2
+version: 0.0.3
 title: W3C
 description: Log Parser for W3C
 parameters:
@@ -89,7 +89,7 @@ template: |
           expr: 'body matches "^#"'
 
         - type: csv_parser
-          lazy_quotes: true
+          ignore_quotes: true
           delimiter: '{{ .delimiter }}'
           header: '{{ .header }}'
           


### PR DESCRIPTION
### Proposed Change
* Use `ignore_quotes` instead of `lazy_quotes` for W3C based logs.

<details>
<summary>IIS Sample log</summary>

```
# date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(Cookie) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
2022-06-04 00:15:42 "10.88.32.238 'GET "/ "><script>alert(document.domain)</script> "6080 "- "10.104.11.16 "- "- 403 "14 "0 "3
```
</details>

<details>
<summary>IIS Sample output</summary>

Note: The quotes are escaped here when being printed to console, but they (`\"`) are actually just a raw quote(`"`).
```
LogRecord #0
ObservedTimestamp: 2022-09-01 14:39:45.446754 +0000 UTC
Timestamp: 2022-06-04 00:15:42 +0000 UTC
Severity: 403
Body: 2022-06-04 00:15:42 \"10.88.32.238 'GET \"/ \"><script>alert(document.domain)</script> \"6080 \"- \"10.104.11.16 \"- \"- 403 \"14 \"0 \"3
Attributes:
     -> time-taken: STRING(\"3)
     -> sc-status: STRING(403)
     -> cs-username: STRING(\"-)
     -> s-ip: STRING(\"10.88.32.238)
     -> cs-method: STRING('GET)
     -> cs(Referer): STRING(\"-)
     -> cs-uri-stem: STRING(\"/)
     -> timestamp: STRING(2022-06-04 00:15:42)
     -> log_type: STRING(microsoft_iis)
     -> log.file.path: STRING(tmp/tmp.log)
     -> sc-win32-status: STRING(\"0)
     -> c-ip: STRING(\"10.104.11.16)
     -> s-port: STRING(\"6080)
     -> sc-substatus: STRING(\"14)
     -> cs-uri-query: STRING(\"><script>alert(document.domain)</script>)
     -> cs(Cookie): STRING(\"-)
     -> log.file.name: STRING(tmp.log)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

<details>
<summary>W3C output</summary>

Note: The quotes are escaped here when being printed to console, but they (`\"`) are actually just a raw quote(`"`).
```
LogRecord #0
ObservedTimestamp: 2022-09-01 14:47:28.398519 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: 2022-06-04 00:15:42 \"10.88.32.238 'GET \"/ \"><script>alert(document.domain)</script> \"6080 \"- \"10.104.11.16 \"- \"- 403 \"14 \"0 \"3
Attributes:
     -> cs(Cookie): STRING(\"-)
     -> sc-win32-status: STRING(\"0)
     -> date: STRING(2022-06-04)
     -> cs-method: STRING('GET)
     -> sc-status: STRING(403)
     -> c-ip: STRING(\"10.104.11.16)
     -> cs-username: STRING(\"-)
     -> s-ip: STRING(\"10.88.32.238)
     -> time-taken: STRING(\"3)
     -> time: STRING(00:15:42)
     -> s-port: STRING(\"6080)
     -> sc-substatus: STRING(\"14)
     -> log_type: STRING(w3c)
     -> log.file.name: STRING(tmp.log)
     -> cs(Referer): STRING(\"-)
     -> cs-uri-stem: STRING(\"/)
     -> cs-uri-query: STRING(\"><script>alert(document.domain)</script>)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
