### PR TITLE
fix(transformprocessor): Update `transformprocessor` to not panic on gauges

### DIFF
--- a/docs/processors.md
+++ b/docs/processors.md
@@ -26,4 +26,4 @@ Below is a list of supported processors with links to their documentation pages.
 | Span Processor                          | [spanprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.59.0/processor/spanprocessor/README.md) |
 | Tail Sampling Processor                 | [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.59.0/processor/tailsamplingprocessor/README.md) |
 | Throughput Measurement Processor        | [throughputmeasurementprocessor](../processor/throughputmeasurementprocessor/README.md) |
-| Transform Processor                     | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.59.0/processor/transformprocessor/README.md) |
+| Transform Processor                     | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/aa1c1f330ec9a2a785b6c7ea1cacb0eae23e86e7/processor/transformprocessor/README.md) |

--- a/go.mod
+++ b/go.mod
@@ -336,7 +336,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.59.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.59.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.59.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.59.0

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.59.0
@@ -429,7 +429,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
-	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220809184613-07c6da5e1ced // indirect
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocesso
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.59.0/go.mod h1:vz0KB77FVPZbpdzJM3YrYtVtydmhAHpuraRtW9wbwYY=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0 h1:7DSeiwwpL2i5d7v1mCCEgDY3l7RJX0eVVgdfp7sCaUA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0/go.mod h1:kSDoWNzWhdtIEcpKRwwdZYZWkmBfOamFtbPe20eBPRg=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0 h1:V/4kkttja+EOsfZhS35AYbdBpyBsET8B2ExKQ0eF/GM=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.0/go.mod h1:ca6WFweyts0gGNS3dNSK5rZ1PkCpBmQMponxl/eLcCI=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d h1:7PGTS9Q0oD3W2EZegoPqn9b7/FPtIPSFO6ackwBtGhk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0 h1:7U3SYlOgOrHzmenx/VpN+MHZRRTUNjjq0e0xKhUqK1w=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0/go.mod h1:l5fl9bEiXtImPS6Z8b4iOkZbAL5zvFW9GautY+52IvQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0 h1:DrvYcL91Y4EkfbetGPN6ayKjfx2izzsuTL9OuU21OyA=
@@ -1630,8 +1630,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 h1:x03zeu7B2B11ySp+daztnwM5oBJ/8wGUSqrwcw9L0RA=
-golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocesso
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor v0.59.0/go.mod h1:vz0KB77FVPZbpdzJM3YrYtVtydmhAHpuraRtW9wbwYY=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0 h1:7DSeiwwpL2i5d7v1mCCEgDY3l7RJX0eVVgdfp7sCaUA=
 github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.59.0/go.mod h1:kSDoWNzWhdtIEcpKRwwdZYZWkmBfOamFtbPe20eBPRg=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d h1:7PGTS9Q0oD3W2EZegoPqn9b7/FPtIPSFO6ackwBtGhk=
-github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906183641-4281e841024d/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9 h1:RQKChGBEuKfjjsA25b9pfV40OvhWDjCeFqmuR9a+dsA=
+github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.59.1-0.20220906184950-aa1c1f330ec9/go.mod h1:JnMJ5uICwCkl5Kjiie5K37uxjhfLl24HXdOMwizKknk=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0 h1:7U3SYlOgOrHzmenx/VpN+MHZRRTUNjjq0e0xKhUqK1w=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.59.0/go.mod h1:l5fl9bEiXtImPS6Z8b4iOkZbAL5zvFW9GautY+52IvQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.59.0 h1:DrvYcL91Y4EkfbetGPN6ayKjfx2izzsuTL9OuU21OyA=

--- a/go.sum
+++ b/go.sum
@@ -1066,8 +1066,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetr
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.59.0/go.mod h1:OBHCK29nLn16OUrnIf+7F3sA+LnIPZ2dUYr6CtLJxEU=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.59.0 h1:ctZkiE/pLk6F16GtQjuKrzDO4dYY6KIolDMP67FrFHw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.59.0/go.mod h1:DZnbVTIDiIq3Mqyp1Pa2ycLDvy673R9IeEi3QRj2lr0=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0 h1:uVQmiE4MY3KfXNkxzCJYnqHEsTWufbaufRmbdfwB/lE=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.0/go.mod h1:Z1WlPedBZ9JjN7BW330sdszqMBnxmBtD+Db4OkTI88k=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9 h1:9T5ir35iiNyc2I0rGEoCzjSPFnznvmyoXXzLpVadG80=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.59.1-0.20220906184950-aa1c1f330ec9/go.mod h1:Ik72N0d4FcOb6d3epDkBTJp3GFHLeo6b65BfQsxep8I=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.59.0 h1:+DOhvw+RKnc5QwP5h0y+W55hCvsTsccHVvF3vm1ZViI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.59.0/go.mod h1:hWJ/9y+vs86TyeTPjW1V9xicDVKWrqx+3iXT2UWKGWw=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.59.0 h1:/XBLDr44f+jOy0H5pOjxQu0kemccNsZuhC0ZLM85itw=


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change

Noticed gauges were causing the collector to panic in v0.59.0, for more information please refer to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13905

<details>
<summary>Config</summary>

```yaml
exporters:
  logging:
    loglevel: debug
processors:
  filter/couchbase_couchbase_1:
    metrics:
      exclude:
        match_type: strict
        metric_names:
        - scrape_samples_post_metric_relabeling
        - scrape_series_added
        - scrape_duration_seconds
        - scrape_samples_scraped
        - up
  transform/couchbase_couchbase_3:
    metrics:
      queries:
      - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.error.oom.count"
      - set(metric.description, "Number of out of memory errors.") where metric.name == "couchbase.bucket.error.oom.count"
      - set(metric.unit, "{errors}") where metric.name == "couchbase.bucket.error.oom.count"
      - set(metric.description, "Number of items that belong to the bucket.") where metric.name == "couchbase.bucket.item.count"
      - set(metric.unit, "{items}") where metric.name == "couchbase.bucket.item.count"
      - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.item.ejection.count"
      - set(metric.description, "Number of item value ejections from memory to disk.") where metric.name == "couchbase.bucket.item.ejection.count"
      - set(metric.unit, "{ejections}") where metric.name == "couchbase.bucket.item.ejection.count"
      - set(metric.description, "The memory usage at which items will be ejected.") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
      - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
      - set(metric.description, "The memory usage at which ejections will stop that were previously triggered by a high water mark breach.") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
      - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
      - set(metric.description, "Usage of total memory available to the bucket.") where metric.name == "couchbase.bucket.memory.usage"
      - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.usage"
      - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.operation.count"
      - set(metric.description, "Number of operations on the bucket.") where metric.name == "couchbase.bucket.operation.count"
      - set(metric.unit, "{operations}") where metric.name == "couchbase.bucket.operation.count"
      - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "couchbase.bucket.vbucket.count"
      - set(metric.unit, "{vbuckets}") where metric.name == "couchbase.bucket.vbucket.count"
receivers:
  prometheus/couchbase_couchbase:
    config:
      scrape_configs:
      - basic_auth:
          password: otelpassword
          username: otelu
        job_name: couchbase
        metric_relabel_configs:
        - action: keep
          regex: (kv_ops)|(kv_vb_curr_items)|(kv_num_vbuckets)|(kv_total_memory_used_bytes)|(kv_ep_num_value_ejects)|(kv_ep_mem_high_wat)|(kv_ep_mem_low_wat)|(kv_ep_oom_errors)
          source_labels:
          - __name__
        scrape_interval: 10s
        static_configs:
        - targets:
          - localhost:8091
service:
  pipelines:
    metrics/couchbase_couchbase:
      exporters:
      - logging
      processors:
      - filter/couchbase_couchbase_1
      - transform/couchbase_couchbase_3
      receivers:
      - prometheus/couchbase_couchbase
```

</details>

<details>
<summary>Error Message</summary>
```
goroutine 107 [running]:
go.opentelemetry.io/collector/pdata/pmetric.Sum.DataPoints(...)
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector/pdata@v0.59.0/pmetric/generated_metrics.go:843
github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics.(*Processor).ProcessMetrics(0xc000b7e6c0?, {0x10?, 0x83b7040?}, {0xc0008bac00?})
	/Users/keithschmitt/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.59.0/internal/metrics/processor.go:57 +0x259
go.opentelemetry.io/collector/processor/processorhelper.NewMetricsProcessor.func1({0x9db72f0, 0xc0006bd740}, {0xc0008bac00?})
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/processor/processorhelper/metrics.go:75 +0xf8
go.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics(...)
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/consumer/metrics.go:36
go.opentelemetry.io/collector/processor/processorhelper.NewMetricsProcessor.func1({0x9db72f0, 0xc0006bd740}, {0xc0008bac00?})
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/processor/processorhelper/metrics.go:83 +0x1dd
go.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics(...)
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/consumer/metrics.go:36
go.opentelemetry.io/collector/processor/processorhelper.NewMetricsProcessor.func1({0x9db72f0, 0xc0006bd740}, {0x0?})
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/processor/processorhelper/metrics.go:83 +0x1dd
go.opentelemetry.io/collector/consumer.ConsumeMetricsFunc.ConsumeMetrics(...)
	/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.59.0/consumer/metrics.go:36
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal.(*transaction).Commit(0xc00055cf20)
	/Users/keithschmitt/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.59.0/internal/otlp_transaction.go:160 +0x22a
github.com/prometheus/prometheus/scrape.(*scrapeLoop).scrapeAndReport.func1()
	/Users/keithschmitt/go/pkg/mod/github.com/prometheus/prometheus@v0.37.0/scrape/scrape.go:1275 +0x45
github.com/prometheus/prometheus/scrape.(*scrapeLoop).scrapeAndReport(0xc0006ba1c0, {0xedaa97867?, 0xcfc2fc0?, 0x0?}, {0xedaa97867?, 0xcfc2fc0?, 0xcfc2fc0?}, 0x0)
	/Users/keithschmitt/go/pkg/mod/github.com/prometheus/prometheus@v0.37.0/scrape/scrape.go:1346 +0xf70
github.com/prometheus/prometheus/scrape.(*scrapeLoop).run(0xc0006ba1c0, 0xc000a0d200?)
	/Users/keithschmitt/go/pkg/mod/github.com/prometheus/prometheus@v0.37.0/scrape/scrape.go:1228 +0x345
created by github.com/prometheus/prometheus/scrape.(*scrapePool).sync
	/Users/keithschmitt/go/pkg/mod/github.com/prometheus/prometheus@v0.37.0/scrape/scrape.go:592 +0xa1e
```
</details>

<details>

<summary>Collection Working </summary>

```
Metric #5
Descriptor:
     -> Name: kv_ops
     -> Description:
     -> Unit:
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> bucket: STRING(otelb)
     -> op: STRING(get_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-09-06 18:49:49.693 +0000 UTC
Value: 0.000000
NumberDataPoints #1
Data point attributes:
     -> bucket: STRING(otelb)
     -> op: STRING(set_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-09-06 18:49:49.693 +0000 UTC
Value: 0.000000
NumberDataPoints #2
Data point attributes:
     -> bucket: STRING(otelb)
     -> op: STRING(del_meta)
```

</details>

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
