### PR TITLE
feat(plugin): Changed MongoDB Logs plugin to parse to body

### DIFF
--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: MongoDB
 description: Log parser for MongoDB
 parameters:
@@ -15,6 +15,10 @@ parameters:
       - beginning
       - end
     default: end
+  - name: retain_raw_logs
+    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    type: bool
+    default: false
 template: |
   receivers:
     filelog:
@@ -28,6 +32,12 @@ template: |
         {{end}}
       start_at: {{ .start_at }}
       operators:
+        {{ if .retain_raw_logs }}
+        - id: save_raw_log
+          type: copy
+          from: body
+          to: attributes.raw_log
+        {{ end }}
         - type: router
           default: legacy_parser
           routes:
@@ -37,12 +47,13 @@ template: |
         - id: legacy_parser
           type: regex_parser
           regex: '^(?P<timestamp>\S+)\s+(?P<severity>\w+)\s+(?P<component>[\w-]+)\s+\[(?P<context>\S+)\]\s+(?P<message>.*)$'
+          parse_to: body
           timestamp:
-            parse_from: attributes.timestamp
+            parse_from: body.timestamp
             #2019-02-06T09:22:43.967-0500
             layout: '%Y-%m-%dT%H:%M:%S.%f%z'
           severity:
-            parse_from: attributes.severity
+            parse_from: body.severity
             mapping:
               fatal: F
               error: E
@@ -61,13 +72,13 @@ template: |
         # {"t":{"$date":"2022-04-26T16:15:44.876+00:00"},"s":"I",  "c":"INDEX",    "id":20345,   "ctx":"LogicalSessionCacheRefresh","msg":"Index build: done building","attr":{"buildUUID":null,"namespace":"config.system.sessions","index":"lsidTTLIndex","commitTimestamp":null}}
         - id: 4_4_parser
           type: json_parser
-          parse_from: body
+          parse_to: body
           timestamp:
-            parse_from: attributes.t.$date
+            parse_from: body.t.$date
             #2020-11-03T14:24:07.436-05:00
             layout: '%Y-%m-%dT%H:%M:%S.%f%j'
           severity:
-            parse_from: attributes.s
+            parse_from: body.s
             mapping:
               fatal: F
               error: E
@@ -88,22 +99,22 @@ template: |
 
         # - id: remove_t
         #   type: remove
-        #   field: attributes.t
+        #   field: body.t
 
         - id: move_component
           type: move
-          from: attributes.c
-          to: attributes.component
+          from: body.c
+          to: body.component
 
         - id: move_context
           type: move
-          from: attributes.ctx
-          to: attributes.context
+          from: body.ctx
+          to: body.context
 
         - id: move_message
           type: move
-          from: attributes.msg
-          to: attributes.message
+          from: body.msg
+          to: body.message
 
         # When message is 'WiredTiger message', data.attr.message
         # always exists, and should be promoted to message
@@ -111,25 +122,32 @@ template: |
           type: router
           default: add_log_type
           routes:
-            - expr: 'attributes.message == "WiredTiger message"'
+            - expr: 'body.message == "WiredTiger message"'
               output: move_wiredtiger_type
 
         - id: move_wiredtiger_type
           type: move
-          from: attributes.message
-          to: attributes.message_type
+          from: body.message
+          to: body.message_type
           output: move_wiredtiger_msg
 
         - id: move_wiredtiger_msg
           type: move
-          from: attributes.attr.message
-          to: attributes.message
+          from: body.attr.message
+          to: body.message
           output: add_log_type
           
         - id: add_log_type
           type: add
           field: 'attributes.log_type'
           value: 'mongodb'
+        
+        {{ if .retain_raw_logs }}
+        - id: move_raw_log
+          type: move
+          from: attributes.raw_log
+          to: body.raw_log
+        {{ end }}
 
   service:
     pipelines:

--- a/plugins/mongodb_logs.yaml
+++ b/plugins/mongodb_logs.yaml
@@ -74,7 +74,7 @@ template: |
           type: json_parser
           parse_to: body
           timestamp:
-            parse_from: body.t.$date
+            parse_from: body.t.$$date
             #2020-11-03T14:24:07.436-05:00
             layout: '%Y-%m-%dT%H:%M:%S.%f%j'
           severity:

--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -39,10 +39,6 @@ parameters:
     description: Timezone to use when parsing the timestamp.
     type: timezone
     default: UTC
-  - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
-    type: bool
-    default: false
 template: |
   receivers:
     {{ if .enable_access_log }}


### PR DESCRIPTION
### Proposed Change
- Removed unused parameter `retain_raw_logs` from tomcat plugin
- Added parsing to body to MongoDB logs plugin. 

MongoDB older style logs with `retain_raw_logs` enabled:

```
LogRecord #1
ObservedTimestamp: 2022-09-08 17:37:23.165769 +0000 UTC
Timestamp: 2019-02-06 14:22:27.347 +0000 UTC
Severity: I
Body: {
     -> component: STRING(CONTROL)
     -> context: STRING(initandlisten)
     -> message: STRING(db version v3.6.2)
     -> raw_log: STRING(2019-02-06T09:22:27.347-0500 I CONTROL  [initandlisten] db version v3.6.2)
     -> severity: STRING(I)
     -> timestamp: STRING(2019-02-06T09:22:27.347-0500)
}
Attributes:
     -> log_type: STRING(mongodb)
     -> log.file.name: STRING(old.log)
Trace ID: 
Span ID: 
Flags: 0
```

MongoDB newer json style logs with `retain_raw_logs` enabled:

```
LogRecord #1
ObservedTimestamp: 2022-09-08 18:01:17.044687 +0000 UTC
Timestamp: 2020-11-03 19:24:05.178 +0000 UTC
Severity: W
Body: {
     -> component: STRING(ASIO)
     -> context: STRING(main)
     -> id: DOUBLE(22601)
     -> message: STRING(No TransportLayer configured during NetworkInterface startup)
     -> raw_log: STRING({\"t\":{\"$date\":\"2020-11-03T14:24:05.178-05:00\"},\"s\":\"W\",  \"c\":\"ASIO\",     \"id\":22601,   \"ctx\":\"main\",\"msg\":\"No TransportLayer configured during NetworkInterface startup\"})
     -> s: STRING(W)
     -> t: MAP({\"$date\":\"2020-11-03T14:24:05.178-05:00\"})
}
Attributes:
     -> log.file.name: STRING(new.log)
     -> log_type: STRING(mongodb)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
