### PR TITLE
feat(plugin): Add Journald log driver support to container log plugin

### DIFF
--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -2,11 +2,22 @@ version: 0.0.1
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:
+  - name: log_source
+    description: Where to read container logs from
+    type: string
+    supported:
+      - file
+      - journald
+    default: file
   - name: log_paths
     type: "[]string"
     description: A list of file glob patterns that match the file paths to be read
     default:
       - "/var/log/containers/*.log"
+  - name: journald_path
+    type: string
+    description:
+    default: /var/log/journal
   - name: exclude_file_log_path
     type: "[]string"
     description: A list of file glob patterns to exclude from reading
@@ -23,6 +34,7 @@ parameters:
 
 template: |
   receivers:
+    {{ if eq .log_source "file" }}
     filelog:
         include:
           {{ range $fp := .log_paths }}
@@ -111,8 +123,56 @@ template: |
           - type: move
             from: attributes.container
             to: resource["k8s.container.name"]
+    {{ end }}
+
+    {{ if eq .log_source "journald" }}
+    journald:
+      directory: {{ .journald_path }}
+      operators:
+        - type: router
+          routes:
+            - expr: 'body._COMM == "dockerd-current" and body.CONTAINER_NAME != nil'
+              output: filter
+
+        - type: filter
+          expr: 'body.CONTAINER_NAME matches "otc-container"'
+          drop_ratio: 1.0
+
+        - type: regex_parser
+          regex: '^k8s_(?P<container>[-a-z0-9_]+)_(?P<pod>[-a-z0-9\.]+)_(?P<namespace>[-a-z0-9]+)_[-a-z0-9]+_\d+'
+          parse_from: body.CONTAINER_NAME
+
+        - type: move
+          from: attributes.container
+          to: resource["k8s.container.name"]
+
+        - type: move
+          from: attributes.pod
+          to: resource["k8s.pod.name"]
+
+        - type: move
+          from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+
+        - type: move
+          from: body._HOSTNAME
+          to: resource["k8s.node.name"]
+
+        - type: move
+          from: body.MESSAGE
+          to: body
+
+        - type: add
+          field: attributes.log_type
+          value: container
+    {{ end }}
 
   service:
     pipelines:
       logs:
-        receivers: [filelog]
+        receivers:
+          {{ if eq .log_source "file" }}
+          - filelog
+          {{ else if eq .log_source "journald" }}
+          - journald
+          {{ end }}

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -16,7 +16,7 @@ parameters:
       - "/var/log/containers/*.log"
   - name: journald_path
     type: string
-    description:
+    description: The path to read journald container logs from
     default: /var/log/journal
   - name: exclude_file_log_path
     type: "[]string"


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Some docker based Kubernetes clusters will use Journald as the log driver (default is `json-file`).  This change adds a parameter, `log_source`, for selecting `Journald` instead of the default `file`. 

This is not a breaking change, as users will need to explicitly enable Journald. Existing users will use the default value `file`.

The Journald directory is defaulted to `/var/log/journal` as that was the Journald directory in use when testing this change against an OpenShift cluster using Journald for the log driver. 

The Journald source maps correctly to Open Telemetry semantic conventions, and shows up in Google mapped to the `k8s_container` monitored resource type.

<img width="1390" alt="Screen Shot 2022-09-09 at 11 00 20 AM" src="https://user-images.githubusercontent.com/23043836/189409651-4e95859d-dfcb-4eb6-a84b-ad09f3ea9a40.png">


##### Checklist
- [x] Changes are tested
- [x] CI has passed
