### PR TITLE
feat(plugin): Updated Apache Combined Plugin to parse attributes to body

### DIFF
--- a/plugins/apache_combined_logs.yaml
+++ b/plugins/apache_combined_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: Apache Combined
 description: Log parser for Apache combined format
 parameters:
@@ -14,7 +14,10 @@ parameters:
       - beginning
       - end
     default: end
-
+  - name: retain_raw_logs
+    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    type: bool
+    default: false
 template: |
   receivers:
     filelog:
@@ -26,19 +29,33 @@ template: |
       attributes:
         log_type: apache_combined
       operators:
+        {{ if .retain_raw_logs }}
+        - id: save_raw_log
+          type: copy
+          from: body
+          to: attributes.raw_log
+        {{ end }}
         - type: regex_parser
           regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*) "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)'
+          parse_to: body
           timestamp:
-            parse_from: attributes.time
+            parse_from: body.time
             layout: '%d/%b/%Y:%H:%M:%S %z'
           severity:
-            parse_from: attributes.status
+            parse_from: body.status
             preset: none
             mapping:
               info: 2xx
               info2: 3xx
               warn: 4xx
               error: 5xx
+        {{ if .retain_raw_logs }}
+        - id: move_raw_log
+          type: move
+          from: attributes.raw_log
+          to: body.raw_log
+        {{ end }}
+
 
   service:
     pipelines:


### PR DESCRIPTION
### Proposed Change
- Updated the Apache Combined Plugin to parse attributes to body.
- Added `retain_raw_logs` parameter that, when enabled, adds the original log as an attribute to the `body`

Example with `retain_raw_logs` enabled:

```
LogRecord #0
ObservedTimestamp: 2022-09-12 12:27:17.915038 +0000 UTC
Timestamp: 2021-06-17 16:06:46 +0000 UTC
Severity: 304
Body: {
     -> body_bytes_sent: STRING(64162)
     -> http_referer: STRING(https://www.seniordisintermediate.biz/models)
     -> http_user_agent: STRING(Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_3) AppleWebKit/5310 (KHTML, like Gecko) Chrome/39.0.854.0 Mobile Safari/5310)
     -> method: STRING(POST)
     -> path: STRING(/v1/login)
     -> protocol: STRING(HTTP)
     -> protocol_version: STRING(2.0)
     -> raw_log: STRING(129.53.82.110 - - [17/Jun/2021:12:06:46 -0400] \"POST /v1/login HTTP/2.0\" 304 64162 \"https://www.seniordisintermediate.biz/models\" \"Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_3) AppleWebKit/5310 (KHTML, like Gecko) Chrome/39.0.854.0 Mobile Safari/5310\")
     -> remote_addr: STRING(129.53.82.110)
     -> remote_host: STRING(-)
     -> remote_user: STRING(-)
     -> status: STRING(304)
     -> time: STRING(17/Jun/2021:12:06:46 -0400)
}
Attributes:
     -> log_type: STRING(apache_combined)
     -> log.file.name: STRING(test.log)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
