### PR TITLE
fix(makefile): Fix the release-test make target to work with module tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ release:
 # Build and sign, skip release and ignore dirty git tree
 .PHONY: release-test
 release-test:
-	goreleaser release --parallelism 4 --skip-validate --skip-publish --skip-sign --rm-dist --snapshot
+	GORELEASER_CURRENT_TAG=$(shell git tag | grep -E -i '^v[0-9]+\.[0-9]+\.[0-9]+' | sort -r --version-sort | head -n1) goreleaser release --parallelism 4 --skip-validate --skip-publish --skip-sign --rm-dist --snapshot
 
 .PHONY: for-all
 for-all:


### PR DESCRIPTION
### Proposed Change
The free version of GoReleaser does not handle multiple module tags in a single repo. Setting the `GORELEASER_CURRENT_TAG` fixes this. Added setting this in the `release-test` target to the last semantic versioned tag.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
