### PR TITLE
feat(plugin): Support parsing container application logs as json

### DIFF
--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -24,6 +24,10 @@ parameters:
     default:
       # Excludes logs for the collector
       - "/var/log/containers/observiq-*-collector-*"
+  - name: body_json_parsing
+    type: bool
+    description: If the application log is detected as json, parse the values into the log entry's body.
+    default: true
   - name: start_at
     description: At startup, where to start reading logs from the file (`beginning` or `end`)
     type: string
@@ -44,7 +48,7 @@ template: |
         attributes:
           log_type: "k8s.container_logs"
         exclude:
-          {{ range $fp := .exclude_log_paths }}
+          {{ range $fp := .exclude_file_log_path }}
             - '{{ $fp }}'
           {{end}}
         poll_interval: 500ms
@@ -105,6 +109,15 @@ template: |
             id: log-to-body
             from: attributes.log
             to: body
+
+          # Parse body as json if the body appears to be json
+          {{ if .body_json_parsing }}
+          - type: json_parser
+            if: body matches "^{.*}\\s*$"
+            parse_from: body
+            parse_to: body
+          {{ end }}
+
           # Detect pod, namespace, and container names from the file name.
           - type: regex_parser
             regex: '^(?P<pod>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container>.+)-'
@@ -161,6 +174,14 @@ template: |
         - type: move
           from: body.MESSAGE
           to: body
+
+        # Parse body as json if the body appears to be json
+        {{ if .body_json_parsing }}
+        - type: json_parser
+          if: body matches "^{.*}\\s*$"
+          parse_from: body
+          parse_to: body
+        {{ end }}
 
         - type: add
           field: attributes.log_type

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Some Kubernetes container application logs are json, and look like this in their unparsed form:
```json
{
    "log":"{\"http.req.id\":\"d2ff7faf-db0b-4a5b-86c6-344eda2c5b8c\",\"http.req.method\":\"GET\",\"http.req.path\":\"/cart\",\"http.resp.bytes\":6650,\"http.resp.status\":200,\"http.resp.took_ms\":5,\"message\":\"request complete\",\"session\":\"bad3edc3-0974-41e0-9e5e-1427b11219d2\",\"severity\":\"debug\",\"timestamp\":\"2022-09-12T20:06:38.079934409Z\"}\n",
    "stream":"stdout",
    "time":"2022-09-12T20:06:38.080008097Z"
}
```

The output entry has `body` as a string, like this:

![Screenshot from 2022-09-12 16-09-16](https://user-images.githubusercontent.com/23043836/189748207-66cdb4a4-d575-4070-8e95-b096cee54a40.png)

This change will parse body as json, and look like this:

![Screenshot from 2022-09-12 16-10-03](https://user-images.githubusercontent.com/23043836/189748407-4e0f05d1-d489-4926-926b-1ce89dc2c66e.png)

Applications logs that are no json are skipped. This change applies to both input options (file and journald).

This change is enabled by default, but I would like some opinions on this.

Also fixed filelog receiver's `exclude` option.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
