### PR TITLE
feat(plugin): Parse to body for aerospike_logs

### DIFF
--- a/plugins/aerospike_logs.yaml
+++ b/plugins/aerospike_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: Aerospike
 description: Log parser for Aerospike
 parameters:
@@ -29,48 +29,56 @@ template: |
           to: resource["host.name"]
         - type: move
           from: body.__CURSOR
-          to: attributes.journald_cursor
+          to: body.journald_cursor
         - type: move
           from: body._PID
-          to: attributes.pid
+          to: body.pid
         - type: move
           from: body.PRIORITY
-          to: attributes.priority
+          to: body.priority
         - type: move
           from: body.SYSLOG_FACILITY
-          to: attributes.facility
+          to: body.facility
         - type: move
           from: body._SYSTEMD_UNIT
-          to: attributes.systemd_unit
-
-        # Replce raw journald message with aerospike log body.
+          to: body.systemd_unit
         - type: move
           from: body.MESSAGE
-          to: body
-
+          to: body.message
+        
         # Parse Aerospike's log and update the entry's Timestamp and Severity
         # fields with the values from the Aerospike log.
         - type: regex_parser
           regex: '^(?P<timestamp>[a-zA-z]+ \d{2} \d{4} \d{2}:\d{2}:\d{2} [A-Z]+): (?P<severity>[A-Z]*( [A-Z]*)?) \((?P<context>[^\)]*)\): \((?P<source_file>[^:]*):(?P<source_location>[^:]*)\)\s*({(?P<namespace>[^}]*)} )?.*'
+          parse_from: body.message
+          parse_to: body
           timestamp:
-            parse_from: attributes.timestamp
+            parse_from: body.timestamp
             layout: '%b %d %Y %H:%M:%S %Z'
           severity:
-            parse_from: attributes.severity
+            parse_from: body.severity
             mapping:
               info: detail
               error2: 'failed assertion'
 
-        # Timestamp and severity have been promoted to the entry
-        - type: remove
-          field: attributes.timestamp
-        - type: remove
-          field: attributes.severity
+        # Only retain certain relevant fields
+        - type: retain
+          fields:
+          - body.journald_cursor
+          - body.pid
+          - body.priority
+          - body.facility
+          - body.systemd_unit
+          - body.context
+          - body.source_file
+          - body.source_location
+          - body.namespace
+          - body.message
 
         # Aerospike logs the configuration at startup. This is not something we should
         # capture.
         - type: filter
-          expr: 'attributes.context == "config"'
+          expr: 'body.context == "config"'
 
         - type: add
           field: attributes.log_type


### PR DESCRIPTION
### Proposed Change
* Parse to `body` instead of `attributes` for the `aerospike_logs` plugin.

In this instance, I didn't add the `retain_raw_log` parameter; The original journald line is not present in the output of the journald receiver, so there isn't an original line to retain.

Sample log input:
```
Sep 14 17:55:42 buster asd[2153]: Sep 14 2022 17:55:42 GMT: INFO (info): (ticker.c:499) {bar} memory-usage: total-bytes 0 index-bytes 0 set-index-bytes 0 sindex-bytes 0 data-bytes 0 used-pct 0.00
```

<details>
<summary>As JSON</summary>

```
{
        "PRIORITY" : "6",
        "_SYSTEMD_UNIT" : "aerospike.service",
        "__REALTIME_TIMESTAMP" : "1663178142661261",
        "__CURSOR" : "s=406a98fe116e4556b8a6598e7d6874ff;i=381d;b=9babb220c16742f68ba570481e7466a6;m=2fdd3c8b2;t=5e8a6d6643a8d;x=f216c603b20963d5",
        "_PID" : "2153",
        "_SYSTEMD_CGROUP" : "/system.slice/aerospike.service",
        "_SELINUX_CONTEXT" : "unconfined\n",
        "_HOSTNAME" : "buster",
        "_TRANSPORT" : "stdout",
        "_CAP_EFFECTIVE" : "3fffffffff",
        "_EXE" : "/usr/bin/asd",
        "__MONOTONIC_TIMESTAMP" : "12848449714",
        "_GID" : "0",
        "MESSAGE" : "Sep 14 2022 17:55:42 GMT: INFO (info): (ticker.c:499) {bar} memory-usage: total-bytes 0 index-bytes 0 set-index-bytes 0 sindex-bytes 0 data-bytes 0 used-pct 0.00",
        "_UID" : "0",
        "_CMDLINE" : "/usr/bin/asd --config-file /etc/aerospike/aerospike.conf --fgdaemon",
        "_STREAM_ID" : "f638f1374b8247389953e8dc6520dd29",
        "SYSLOG_IDENTIFIER" : "asd",
        "_COMM" : "asd",
        "SYSLOG_FACILITY" : "3",
        "_MACHINE_ID" : "1d892cd26c9e4f23b4dadd94a5450f87",
        "_SYSTEMD_INVOCATION_ID" : "3757f351c39c4663b34fb2e70d861c98",
        "_SYSTEMD_SLICE" : "system.slice",
        "_BOOT_ID" : "9babb220c16742f68ba570481e7466a6"
}
```
</details>

Sample log output:
```
LogRecord #13
ObservedTimestamp: 2022-09-14 17:55:42.964935901 +0000 UTC
Timestamp: 2022-09-14 17:55:42 +0000 UTC
Severity: 
Body: {
     -> context: STRING(info)
     -> facility: STRING(3)
     -> journald_cursor: STRING(s=406a98fe116e4556b8a6598e7d6874ff;i=381d;b=9babb220c16742f68ba570481e7466a6;m=2fdd3c8b2;t=5e8a6d6643a8d;x=f216c603b20963d5)
     -> message: STRING(Sep 14 2022 17:55:42 GMT: INFO (info): (ticker.c:499) {bar} memory-usage: total-bytes 0 index-bytes 0 set-index-bytes 0 sindex-bytes 0 data-bytes 0 used-pct 0.00)
     -> namespace: STRING(bar)
     -> pid: STRING(2153)
     -> priority: STRING(6)
     -> source_file: STRING(ticker.c)
     -> source_location: STRING(499)
     -> systemd_unit: STRING(aerospike.service)
}
Attributes:
     -> log_type: STRING(aerospike)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
