### PR TITLE
feat(plugin): Updated vCenter log plugin to parse attributes to body

### DIFF
--- a/plugins/vcenter_logs.yaml
+++ b/plugins/vcenter_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: VMware vCenter
 description: Log parser for VMware vCenter
 parameters:
@@ -27,7 +27,10 @@ parameters:
     description: Path to the key file to use for TLS
     type: string
     default: "/opt/key"
-
+  - name: retain_raw_logs
+    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    type: bool
+    default: false
 template: |
   receivers:
     tcplog:
@@ -42,8 +45,14 @@ template: |
         key_file: {{ .key_file }}
       {{ end }}
       operators:
+        {{ if .retain_raw_logs }}
+        - id: save_raw_log
+          type: copy
+          from: body
+          to: attributes.raw_log
+        {{ end }}
         # vcenter will (sometimes) prepend an id to the messages, check
-        # for the id and drop it if it exsits
+        # for the id and drop it if it exists
         # example: '257 <14>1. . . '
         - id: prefix_router
           type: router
@@ -69,9 +78,16 @@ template: |
         - id: vcenter_parser
           type: syslog_parser
           protocol: rfc5424
+          parse_to: body
+        
+        {{ if .retain_raw_logs }}
+        - id: move_raw_log
+          type: move
+          from: attributes.raw_log
+          to: body.raw_log
+        {{ end }}
 
   service:
     pipelines:
       logs:
         receivers: [tcplog]
-

--- a/plugins/vcenter_logs.yaml
+++ b/plugins/vcenter_logs.yaml
@@ -78,15 +78,61 @@ template: |
         - id: vcenter_parser
           type: syslog_parser
           protocol: rfc5424
-          parse_to: body
-        
+
+        # Move syslog fields to body
+        # We do this rather than parsing to body in the syslog_parser as it handles timestamp and severity parsing
+        - id: move_priority
+          if: "attributes.priority != nil"
+          type: move
+          from: attributes.priority
+          to: body.priority
+        - id: move_facility
+          if: "attributes.facility != nil"
+          type: move
+          from: attributes.facility
+          to: body.facility
+        - id: move_hostname
+          if: "attributes.hostname != nil"
+          type: move
+          from: attributes.hostname
+          to: body.hostname
+        - id: move_appname
+          if: "attributes.appname != nil"
+          type: move
+          from: attributes.appname
+          to: body.appname
+        - id: move_proc_id
+          if: "attributes.proc_id != nil"
+          type: move
+          from: attributes.proc_id
+          to: body.proc_id
+        - id: move_msg_id
+          if: "attributes.msg_id != nil"
+          type: move
+          from: attributes.msg_id
+          to: body.msg_id
+        - id: move_message
+          if: "attributes.message != nil"
+          type: move
+          from: attributes.message
+          to: body.message
+        - id: move_structured_data
+          if: "attributes.structured_data != nil"
+          type: move
+          from: attributes.structured_data
+          to: body.structured_data
+        - id: move_version
+          if: "attributes.version != nil"
+          type: move
+          from: attributes.version
+          to: body.version
+
         {{ if .retain_raw_logs }}
         - id: move_raw_log
           type: move
           from: attributes.raw_log
           to: body.raw_log
         {{ end }}
-
   service:
     pipelines:
       logs:


### PR DESCRIPTION
### Proposed Change
- Updated the vCenter Plugin to parse attributes to body.
- Added `retain_raw_logs` parameter that, when enabled, adds the original log as an attribute to the `body`

Example with `retain_raw_logs` enabled:

```
ResourceLog #0
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2022-09-16 14:30:43.095888 +0000 UTC
Timestamp: 2022-09-15 18:01:57.756788 +0000 UTC
Severity: info
Body: {
     -> appname: STRING(content-library)
     -> facility: INT(16)
     -> hostname: STRING(vcsa)
     -> message: STRING(2022-09-15T18:01:57.756Z | DEBUG    | opId-bdfbb34a-1a9c-4d01-9ea3-2a415f97c245 | cls-background-executor-2 | StsTrustChainImpl              | Refreshing cert chain from sso server...)
     -> priority: INT(134)
     -> raw_log: STRING(<134>1 2022-09-15T18:01:57.756788+00:00 vcsa content-library - - - 2022-09-15T18:01:57.756Z | DEBUG    | opId-bdfbb34a-1a9c-4d01-9ea3-2a415f97c245 | cls-background-executor-2 | StsTrustChainImpl              | Refreshing cert chain from sso server...)
     -> version: INT(1)
}
Attributes:
     -> net.peer.name: STRING(localhost)
     -> log_type: STRING(vmware_vcenter)
     -> net.peer.ip: STRING(::1)
     -> net.host.name: STRING(localhost)
     -> net.peer.port: STRING(50461)
     -> net.host.ip: STRING(::1)
     -> net.transport: STRING(IP.TCP)
     -> net.host.port: STRING(5140)
Trace ID: 
Span ID: 
Flags: 0
```


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
