### PR TITLE
feat(plugin): Update file_logs plugin to parse attributes to body

### DIFF
--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -97,7 +97,7 @@ template: |
 
         - id: add_type
           type: add
-          field: body.log_type
+          field: attributes.log_type
           value: {{ .log_type }}
 
         {{ if .retain_raw_logs }}

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.1.1
 title: File
 description: Log parser for generic files
 parameters:
@@ -58,6 +58,10 @@ parameters:
       - beginning
       - end
     default: end
+  - name: retain_raw_logs
+    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    type: bool
+    default: false
 template: |
   receivers:
     filelog:
@@ -76,6 +80,12 @@ template: |
       include_file_name: {{ .include_file_name }}
       include_file_path: {{ .include_file_path }}
       operators:
+        {{ if .retain_raw_logs }}
+        - id: save_raw_log
+          type: copy
+          from: body
+          to: attributes.raw_log
+        {{ end }}
         {{ if (eq .parse_format "json")}}
         - type: json_parser
         {{ end }}
@@ -89,7 +99,13 @@ template: |
           type: add
           field: attributes.log_type
           value: {{ .log_type }}
-    
+
+        {{ if .retain_raw_logs }}
+        - id: move_raw_log
+          type: move
+          from: attributes.raw_log
+          to: body.raw_log
+        {{ end }}
   service:
     pipelines:
       logs:

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -88,12 +88,13 @@ template: |
         {{ end }}
         {{ if (eq .parse_format "json")}}
         - type: json_parser
-          parse_from: body.message
+          parse_to: body
         {{ end }}
 
         {{ if (eq .parse_format "regex")}}
         - type: regex_parser
           regex: {{ .regex_pattern }}
+          parse_to: body
         {{ end }}
 
         - id: add_type

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.2.0
 title: File
 description: Log parser for generic files
 parameters:

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -44,11 +44,11 @@ parameters:
     type: string
     default: "file"
   - name: include_file_name
-    description: Whether to add the file name as the attribute log.file.name.
+    description: Whether to add the file name as the body log.file.name.
     type: bool
     default: true
   - name: include_file_path
-    description: Whether to add the file path as the attribute log.file.path.
+    description: Whether to add the file path as the body log.file.path.
     type: bool
     default: false
   - name: start_at
@@ -97,7 +97,7 @@ template: |
 
         - id: add_type
           type: add
-          field: attributes.log_type
+          field: body.log_type
           value: {{ .log_type }}
 
         {{ if .retain_raw_logs }}

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -44,11 +44,11 @@ parameters:
     type: string
     default: "file"
   - name: include_file_name
-    description: Whether to add the file name as the body log.file.name.
+    description: Whether to add the file name as the attribute log.file.name.
     type: bool
     default: true
   - name: include_file_path
-    description: Whether to add the file path as the body log.file.path.
+    description: Whether to add the file path as the attribute log.file.path.
     type: bool
     default: false
   - name: start_at
@@ -88,6 +88,7 @@ template: |
         {{ end }}
         {{ if (eq .parse_format "json")}}
         - type: json_parser
+          parse_from: body.message
         {{ end }}
 
         {{ if (eq .parse_format "regex")}}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->
- Update the file_logs plugin to parse attributes to body.
- Added `retain_raw_logs` parameter that, when enabled, adds the original logs as an attribute to body.

### Example with `retain_raw_logs` enabled with mongodb log:
#### config
```yaml
receivers:
  plugin:
    path: ./plugins/file_logs.yaml
    parameters:
       file_path: [./tmp/log-plugins/file-logs/mongodb.log]
       parse_format: regex
       regex_pattern: ^(?P<date>[^ ]*) (?P<something>[^ ]*) (?P<something2>[^ ]*)  (?P<rest>.*)$
       include_file_name: false
       retain_raw_logs: true
exporters:
  # The logging exporter; This exporter logs to stdout.
  # For more information on configuring the logging exporter, refer to the documentation here:
  # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
  logging:
    loglevel: debug

# 'service' specifies how to construct the data pipelines using the configurations above.
service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
```

#### mongodb old style Log
```log
2019-02-06T09:22:27.347-0500 I CONTROL  [initandlisten] db version v3.6.2
```

#### Resulting parsed log
```log
LogRecord #0
ObservedTimestamp: 2022-09-16 18:17:21.449598 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: {
     -> date: STRING(2019-02-06T09:22:27.347-0500)
     -> raw_log: STRING(2019-02-06T09:22:27.347-0500 I CONTROL  [initandlisten] db version v3.6.2)
     -> rest: STRING([initandlisten] db version v3.6.2)
     -> something: STRING(I)
     -> something2: STRING(CONTROL)
}
Attributes:
     -> log_type: STRING(file)
Trace ID: 
Span ID: 
Flags: 0
```


Example with `retain_raw_logs` enabled with mongodb json style log:

#### Config
```yaml
# 'receivers' specify configurations of receivers.
# See the README for more information about the receivers available for configuration.
receivers:
  plugin:
    path: ./plugins/file_logs.yaml
    parameters:
       file_path: [./tmp/log-plugins/file-logs/mongodb44.log]
       include_file_name: false
       retain_raw_logs: true
exporters:
  # The logging exporter; This exporter logs to stdout.
  # For more information on configuring the logging exporter, refer to the documentation here:
  # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
  logging:
    loglevel: debug

# 'service' specifies how to construct the data pipelines using the configurations above.
service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
```

#### Mongodb new style log
```log
{"t":{"$date":"2020-11-03T14:24:05.178-05:00"},"s":"W",  "c":"ASIO",     "id":22601,   "ctx":"main","msg":"No TransportLayer configured during NetworkInterface startup"}
```
#### Resulting parsed log
```log
LogRecord #0
ObservedTimestamp: 2022-09-16 17:57:00.922471 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
Severity: 
Body: {
     -> c: STRING(ASIO)
     -> ctx: STRING(main)
     -> id: DOUBLE(22601)
     -> msg: STRING(No TransportLayer configured during NetworkInterface startup)
     -> raw_log: STRING({\"t\":{\"$date\":\"2020-11-03T14:24:05.178-05:00\"},\"s\":\"W\",  \"c\":\"ASIO\",     \"id\":22601,   \"ctx\":\"main\",\"msg\":\"No TransportLayer configured during NetworkInterface startup\"})
     -> s: STRING(W)
     -> t: MAP({\"$date\":\"2020-11-03T14:24:05.178-05:00\"})
}
Attributes:
     -> log_type: STRING(file)
Trace ID: 
Span ID: 
Flags: 0
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
