### PR TITLE
deps: Update mongodbatlasreceiver to latest

### DIFF
--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -39,7 +39,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Microsoft IIS Receiver                      | [iisreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/iisreceiver/README.md) |
 | Microsoft SQL Server Receiver               | [sqlserverreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/sqlserverreceiver/README.md) |
 | MongoDB Receiver                            | [mongodbreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/mongodbreceiver/README.md) |
-| MongoDB Atlas Receiver                      | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/mongodbatlasreceiver/README.md) |
+| MongoDB Atlas Receiver                      | [mongodbatlasreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/5da63139851a3cbcc329f8c517a2fe02c5b2b30b/receiver/mongodbatlasreceiver/README.md) |
 | MySQL Receiver                              | [mysqlreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/mysqlreceiver/README.md) |
 | NGINX Receiver                              | [nginxreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/nginxreceiver/README.md) |
 | OpenCensus Receiver                         | [opencensusreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.60.0/receiver/opencensusreceiver/README.md) |

--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.60.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.1-0.20220921185933-5da63139851a
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver v0.60.0

--- a/go.sum
+++ b/go.sum
@@ -1213,8 +1213,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsr
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.60.0/go.mod h1:GkkjtnJOREKZLRcwPmvJANrZj+wJe8IagipbQDXw+VQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.60.0 h1:SSVS8sIACgcm5yErTBeXp5H6mPCwm+B1nJNyBVZMvpg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver v0.60.0/go.mod h1:UWxtbgwqbUNlmSevNPpBIRPvAoArFW5NQTRgqyInUhU=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.0 h1:2DzuzH3uUzizJsY4gCE+L9OweoXRL2nDHSAyyWPxuqY=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.0/go.mod h1:AZfxmlPCsov4LlQJYvivTogrOkb+cAx9tU+gsqZ0Mt4=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.1-0.20220921185933-5da63139851a h1:znBiVwhDJrEEwn808WG9MDOilU8gWzYskQZoUECw59s=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.60.1-0.20220921185933-5da63139851a/go.mod h1:2G6Sj/fFvw10GgRlD2F47RpMQNm8iPdDDo3z6tJ4Dxc=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.60.0 h1:seGdTe2KcIy+MPyBzt7+FJcisFtfYjr+qLhPIFsoDQg=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver v0.60.0/go.mod h1:CmDjyGPg12G7A6U5LnVP8x4C5qFFzzg+D1+tr7lAg+4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver v0.60.0 h1:N9RG6Z+A4aonWYXa4x9oKYhWJukxSAcGczt+ME5GrVU=


### PR DESCRIPTION
### Proposed Change
* Update mongodbatlasreceiver to https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/5da63139851a3cbcc329f8c517a2fe02c5b2b30b

This update includes the following fixes:
* Include some missing fields on audit logs to make them complete
* Retain the actual log record as the Body on both audit and process logs
* Fix potential infinite loop when parsing audit logs

Manually tested scraping mongodbatlas logs.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
