### PR TITLE
feat(googlecloudexporter): Move attributes -> body for log records

### DIFF
--- a/exporter/googlecloudexporter/attrs_to_body.go
+++ b/exporter/googlecloudexporter/attrs_to_body.go
@@ -1,0 +1,63 @@
+package googlecloudexporter
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func logAttrsToBody(ld plog.Logs, keepAttrs map[string]struct{}, retainRawLog bool) {
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(0)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				lr := sl.LogRecords().At(k)
+				attrsToBody(lr, keepAttrs, retainRawLog)
+			}
+		}
+	}
+}
+
+func attrsToBody(lr plog.LogRecord, keepAttrs map[string]struct{}, keepRaw bool) {
+	if lr.Body().Type() == pcommon.ValueTypeMap {
+		// In this case, the body is already structured.
+		// We will ignore the record in this case, and assume it is already in
+		// an acceptable format for exporting.
+		return
+	}
+
+	newBody := pcommon.NewMap()
+	newBody.EnsureCapacity(lr.Attributes().Len() + 1)
+
+	lr.Attributes().RemoveIf(func(s string, v pcommon.Value) bool {
+		if _, ok := keepAttrs[s]; ok {
+			// We should keep this attribute since it's in our keep set
+			return false
+		}
+
+		if strings.HasPrefix(s, "gcp.") {
+			// These are special attributes that are mapped special by the exporter.
+			// The exporter ignores these attributes during label mapping, so we will too.
+			// https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/de1999d028f2db7630d0cc0306731f6457b6bfae/exporter/collector/logs.go#L415
+			return false
+		}
+
+		// move to new body
+		v.CopyTo(newBody.PutEmpty(s))
+
+		// remove this key from attributes
+		return true
+	})
+
+	// If the new body would be empty, we'll actually prefer to keep whatever the original body is.
+	// This avoids scenarios where the log line gets erased, despite no parsing being applied (e.g. file_logs plugin)
+	if newBody.Len() != 0 {
+		if keepRaw {
+			// retain original log as "raw_log"
+			lr.Body().CopyTo(newBody.PutEmpty("raw_log"))
+		}
+		newBody.CopyTo(lr.Body().SetEmptyMapVal())
+	}
+}

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -20,6 +20,7 @@ import (
 	gcp "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
+	semconv "go.opentelemetry.io/collector/semconv/v1.9.0"
 	"go.uber.org/multierr"
 	"google.golang.org/api/option"
 )
@@ -37,6 +38,10 @@ type Config struct {
 	AppendHost              bool                   `mapstructure:"append_host"`
 	GCPConfig               *gcp.Config            `mapstructure:",squash"`
 	BatchConfig             *batchprocessor.Config `mapstructure:"batch"`
+	// Log specific options
+	MoveAttrsToBody bool     `mapstructure:"move_attrs_to_body"`
+	KeepAttrs       []string `mapstructure:"keep_attrs"`
+	RetainRawLog    bool     `mapstructure:"keep_raw_log"`
 }
 
 // Validate validates the config
@@ -75,6 +80,25 @@ func createDefaultConfig() config.Exporter {
 		GCPConfig:        createDefaultGCPConfig(),
 		BatchConfig:      createDefaultBatchConfig(),
 		AppendHost:       true,
+		MoveAttrsToBody:  true,
+		RetainRawLog:     false,
+		KeepAttrs: []string{
+			// For TCP/UDP receivers
+			semconv.AttributeNetHostIP,
+			semconv.AttributeNetHostPort,
+			semconv.AttributeNetHostName,
+			semconv.AttributeNetPeerIP,
+			semconv.AttributeNetPeerPort,
+			semconv.AttributeNetPeerName,
+			semconv.AttributeNetTransport,
+			// for filelog receiver
+			"log.file.name",
+			"log.file.path",
+			"log.file.name_resolved",
+			"log.file.path_resolved",
+			// for our plugins, included with our distro.
+			"log_type",
+		},
 	}
 }
 

--- a/exporter/googlecloudexporter/exporter.go
+++ b/exporter/googlecloudexporter/exporter.go
@@ -34,6 +34,10 @@ var hostname = getHostname()
 type exporter struct {
 	appendHost bool
 
+	moveAttrsToBody bool
+	retainRawLog    bool
+	keepAttrs       map[string]struct{}
+
 	metricsProcessors []component.MetricsProcessor
 	metricsExporter   component.MetricsExporter
 	metricsConsumer   consumer.Metrics
@@ -77,6 +81,10 @@ func (e *exporter) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 func (e *exporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	if e.appendHost {
 		e.appendLogHost(&ld)
+	}
+
+	if e.moveAttrsToBody {
+		logAttrsToBody(ld, e.keepAttrs, e.retainRawLog)
 	}
 
 	if e.logsConsumer == nil {

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -129,10 +129,13 @@ func createLogsExporter(ctx context.Context, set component.ExporterCreateSetting
 	}
 
 	return &exporter{
-		appendHost:     exporterConfig.AppendHost,
-		logsProcessors: processors,
-		logsExporter:   gcpExporter,
-		logsConsumer:   consumer,
+		appendHost:      exporterConfig.AppendHost,
+		logsProcessors:  processors,
+		logsExporter:    gcpExporter,
+		logsConsumer:    consumer,
+		moveAttrsToBody: exporterConfig.MoveAttrsToBody,
+		retainRawLog:    exporterConfig.RetainRawLog,
+		keepAttrs:       makeStringSet(exporterConfig.KeepAttrs),
 	}, nil
 }
 
@@ -178,4 +181,13 @@ func createTracesExporter(ctx context.Context, set component.ExporterCreateSetti
 		tracesExporter:   gcpExporter,
 		tracesConsumer:   consumer,
 	}, nil
+}
+
+func makeStringSet(s []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(s))
+	for _, k := range s {
+		m[k] = struct{}{}
+	}
+
+	return m
 }

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.60.0
 	go.opentelemetry.io/collector/pdata v0.60.0
+	go.opentelemetry.io/collector/semconv v0.60.0
 	go.uber.org/multierr v1.8.0
 )
 
@@ -66,6 +67,5 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/prometheus/prometheus v0.38.0 // indirect
-	go.opentelemetry.io/collector/semconv v0.60.0 // indirect
 	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 // indirect
 )


### PR DESCRIPTION
### Proposed Change
This is a draft of what this COULD look like. This PR makes it so that the exporter, by default, will map attributes onto the Body.

The main problem is that "Body" in OTel is the original log, while Attributes is the actual parsed data. In the GCP mapping, however, "Body" is used as the main data blob for the record, meaning the log record is often a "textPayload" instead of the expected "jsonPayload".

In this draft, most attributes are mapped to the Body, EXCEPT for known fields that are added by receivers. These fields are fully configurable, but they cover our plugins from what I can tell. This also works well with mongodbatlas.

The original Body is optionally retained by setting the "keep_raw_log" setting on the exporter, just like we've been doing with the plugins.

If the Body is already a map, nothing is done. This is because the log is already "structured", so there is an assumption that the log is already parsed. This keeps the new plugins we've created working as well, and also plays nice with structured logs from e.g. windowseventreceiver.
<details>
<summary>Example from macos_logs plugin:</summary>

```json
{
  "insertId": "1kvy4safkifdvz",
  "jsonPayload": {
    "host": "Brandons-MBP",
    "message": "Entered:__thr_AMMuxedDeviceDisconnected, mux-device:2358",
    "spid": "",
    "pid": "37456",
    "process": "MobileDeviceUpdater",
    "raw_log": "Sep 22 20:09:36 Brandons-MBP MobileDeviceUpdater[37456]: Entered:__thr_AMMuxedDeviceDisconnected, mux-device:2358",
    "timestamp": "Sep 22 20:09:36",
    "subprocess": ""
  },
  "resource": {
    "type": "generic_node",
    "labels": {
      "node_id": "Brandons-MBP",
      "project_id": "otel-agent-dev",
      "location": "global",
      "namespace": ""
    }
  },
  "timestamp": "2022-09-23T00:09:36Z",
  "labels": {
    "log_type": "macos.system",
    "log.file.name": "system.log"
  },
  "logName": "projects/otel-agent-dev/logs/mongodbatlas",
  "receiveTimestamp": "2022-09-23T00:09:37.033573532Z"
}
```
</details>

<details>
<summary>Example mongodbatlas log:</summary>

```json
{
  "insertId": "wr163lfol236e",
  "jsonPayload": {
    "raw_log": "{\"t\":{\"$date\":\"2022-09-22T23:39:24.250+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn121945\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"192.168.248.3:34768\",\"uuid\":\"c08bf1c8-5494-495f-874f-1522caca2e14\",\"connectionId\":121945,\"connectionCount\":49}}",
    "id": 22944,
    "remote": "192.168.248.3:34768",
    "log_name": "mongodb.gz",
    "message": "Connection ended",
    "context": "conn121945",
    "connectionId": 121945,
    "uuid": "c08bf1c8-5494-495f-874f-1522caca2e14",
    "component": "NETWORK",
    "connectionCount": 49
  },
  "resource": {
    "type": "generic_node",
    "labels": {
      "project_id": "otel-agent-dev",
      "node_id": "Brandons-MBP",
      "namespace": "",
      "location": "global"
    }
  },
  "timestamp": "2022-09-22T23:39:24.250Z",
  "severity": "INFO",
  "logName": "projects/otel-agent-dev/logs/mongodbatlas",
  "receiveTimestamp": "2022-09-22T23:41:50.362923021Z"
}
```
</details>

<details>
<summary>Example from file_logs plugin:</summary>

```json
{
  "textPayload": "127.0.0.1, -, 8/9/2022, 17:35:36, W3SVC1, <Server>, 127.0.0.1, 0, 455, 5015, 404, 2, GET, /help, query=yes,",
  "insertId": "1dy2baefkc6k0e",
  "resource": {
    "type": "generic_node",
    "labels": {
      "location": "global",
      "node_id": "Brandons-MBP",
      "namespace": "",
      "project_id": "otel-agent-dev"
    }
  },
  "timestamp": "2022-09-22T23:58:55.784650Z",
  "labels": {
    "log_type": "file",
    "log.file.name": "iis_format_logs.log",
    "log.file.path": "tmp/iis_format_logs.log"
  },
  "logName": "projects/otel-agent-dev/logs/mongodbatlas",
  "receiveTimestamp": "2022-09-22T23:58:56.094716279Z"
}
```
</details>

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
