### PR TITLE
feat: Removed agent_id generation from installation scripts

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -20,7 +20,7 @@ SERVICE_NAME="com.observiq.collector"
 DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases"
 
 # Script Constants
-PREREQS="printf sed uname uuidgen tr find grep"
+PREREQS="printf sed uname tr find grep"
 TMP_DIR="${TMPDIR:-"/tmp/"}observiq-otel-collector" # Allow this to be overriden by cannonical TMPDIR env var
 INSTALL_DIR="/opt/observiq-otel-collector"
 MANAGEMENT_YML_PATH="$INSTALL_DIR/manager.yaml"
@@ -526,7 +526,6 @@ create_manager_yml()
     command printf 'endpoint: "%s"\n' "$OPAMP_ENDPOINT" > "$manager_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf 'labels: "%s"\n' "$OPAMP_LABELS" >> "$manager_yml_path"
     [ -n "$OPAMP_SECRET_KEY" ] && command printf 'secret_key: "%s"\n' "$OPAMP_SECRET_KEY" >> "$manager_yml_path"
-    command printf 'agent_id: "%s"\n' "$(uuidgen | tr "[:upper:]" "[:lower:]")" >> "$manager_yml_path"
     succeeded
   fi
 }

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -23,7 +23,7 @@ DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases"
 COLLECTOR_USER="observiq-otel-collector"
 TMP_DIR=${TMPDIR:-"/tmp"} # Allow this to be overriden by cannonical TMPDIR env var
 MANAGEMENT_YML_PATH="/opt/observiq-otel-collector/manager.yaml"
-PREREQS="curl printf systemctl sed uname cut uuidgen"
+PREREQS="curl printf systemctl sed uname cut"
 SCRIPT_NAME="$0"
 INDENT_WIDTH='  '
 indent=""
@@ -606,7 +606,6 @@ create_manager_yml()
     command printf 'endpoint: "%s"\n' "$OPAMP_ENDPOINT" > "$manager_yml_path"
     [ -n "$OPAMP_LABELS" ] && command printf 'labels: "%s"\n' "$OPAMP_LABELS" >> "$manager_yml_path"
     [ -n "$OPAMP_SECRET_KEY" ] && command printf 'secret_key: "%s"\n' "$OPAMP_SECRET_KEY" >> "$manager_yml_path"
-    command printf 'agent_id: "%s"\n' "$(uuidgen -r)" >> "$manager_yml_path"
   fi
 }
 

--- a/windows/install/generate-manager-yaml.ps1
+++ b/windows/install/generate-manager-yaml.ps1
@@ -24,6 +24,5 @@ if(![string]::IsNullOrEmpty($secret_key)) {
 if(![string]::IsNullOrEmpty($labels)) {
     $yaml+="labels: `"$labels`"{0}" -f [environment]::NewLine
 }
-$yaml+="agent_id: `"{0}`"" -f [guid]::NewGuid()
 
 Set-Content -Path "${install_dir}manager.yaml" -Value $yaml


### PR DESCRIPTION
### Proposed Change
In preparation for moving Agent IDs to [ULID](https://github.com/ulid/spec), as required in the latest version of OPAMP, I've removed `agent_id` generation in the installation scripts. The collector currently will generate it's own `agent_id` if one isn't found int he `manager.yaml` so this does not break any installation flow.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
