### PR TITLE
feat: Changed new agent_id generation to use ULID

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -23,12 +23,12 @@ import (
 	"path/filepath"
 	_ "time/tzdata"
 
-	"github.com/google/uuid"
 	"github.com/observiq/observiq-otel-collector/collector"
 	"github.com/observiq/observiq-otel-collector/internal/logging"
 	"github.com/observiq/observiq-otel-collector/internal/service"
 	"github.com/observiq/observiq-otel-collector/internal/version"
 	"github.com/observiq/observiq-otel-collector/opamp"
+	"github.com/oklog/ulid/v2"
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -158,7 +158,7 @@ func checkManagerConfig(configPath *string) error {
 
 		newConfig.AgentID, ok = os.LookupEnv(agentIDENV)
 		if !ok {
-			newConfig.AgentID = uuid.New().String()
+			newConfig.AgentID = ulid.Make().String()
 		}
 
 		if sk, ok := os.LookupEnv(secretkeyENV); ok {
@@ -204,7 +204,7 @@ func ensureIdentity(configPath string) error {
 		return nil
 	}
 
-	candidateConfig.AgentID = uuid.NewString()
+	candidateConfig.AgentID = ulid.Make().String()
 	newBytes, err := yaml.Marshal(candidateConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal sanitized config: %w", err)

--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/observiq/observiq-otel-collector/opamp"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -137,16 +137,16 @@ func TestManagerConfigNoAgentIDWillSet(t *testing.T) {
 	var config opamp.Config
 	require.NoError(t, yaml.Unmarshal(cfgBytes, &config))
 	require.NotEmpty(t, config.AgentID)
-	uuidv4, err := uuid.Parse(config.AgentID)
+	ulidID, err := ulid.Parse(config.AgentID)
 	require.NoError(t, err)
-	require.NotEmpty(t, uuidv4)
+	require.NotEmpty(t, ulidID)
 }
 
 func TestManagerConfigWillNotOverwriteCurrentAgentID(t *testing.T) {
 	tmpDir := t.TempDir()
 	manager := filepath.Join(tmpDir, "manager.yaml")
 
-	id := uuid.NewString()
+	id := ulid.Make().String()
 	data := []byte(fmt.Sprintf(`
 ---
 agent_id: %s

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.18
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220916145219-4e0913d7c254
-	github.com/google/uuid v1.3.0
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v1.9.0
 	github.com/observiq/observiq-otel-collector/packagestate v1.9.0
 	github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor v1.9.0
 	github.com/observiq/observiq-otel-collector/processor/throughputmeasurementprocessor v1.9.0
 	github.com/observiq/observiq-otel-collector/receiver/pluginreceiver v1.9.0
+	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.2.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter v0.60.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.60.0
@@ -249,6 +249,7 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gophercloud/gophercloud v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -964,7 +964,8 @@ github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eY
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
-github.com/oklog/ulid/v2 v2.0.2 h1:r4fFzBm+bv0wNKNh5eXTwU7i85y5x+uwkxCUTNVQqLc=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1299,6 +1300,7 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pavius/impi v0.0.0-20180302134524-c1cbdcb8df2b/go.mod h1:x/hU0bfdWIhuOT1SKwiJg++yvkk6EuOtJk8WtDZqgr8=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=


### PR DESCRIPTION
### Proposed Change
If a collector does not have an existing `agent_id` and the ENV has not been set the collector will generate itself a a ULID as a new ID rather than a UUID.

I have tested this with the head of BPOP. Since both the collector and BPOP treat this as a string currently collectors can still talk to BPOP.

<img width="1625" alt="Screen Shot 2022-09-23 at 1 26 26 PM" src="https://user-images.githubusercontent.com/11877763/192024571-e57252e3-c5a6-4e03-b56f-0a972f1813f8.png">


##### Checklist
- [x] Changes are tested
- [ ] CI has passed
