### PR TITLE
feat: Added forward porting of legacy agent IDs to ULIDs

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -199,8 +199,8 @@ func ensureIdentity(configPath string) error {
 		return fmt.Errorf("unable to interpret config file: %w", err)
 	}
 
-	// if they already have an AgentID, don't generate it
-	if candidateConfig.AgentID != "" {
+	// If the AgentID is not a ULID (legacy ID or empty) then we need to generate a ULID as the AgentID.
+	if _, err := ulid.Parse(candidateConfig.AgentID); err == nil {
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220916145219-4e0913d7c254
+	github.com/google/uuid v1.3.0
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v1.9.0
 	github.com/observiq/observiq-otel-collector/packagestate v1.9.0
 	github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor v1.9.0
@@ -249,7 +250,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/gophercloud/gophercloud v0.25.0 // indirect


### PR DESCRIPTION
### Proposed Change
Added logic so that if an agent currently has an `agent_id` in the `manager.yaml` that is not a ULID the collector will generate a ULID and save that as its new `agent_id`.

This ID change does make BPOP think the collector is a new agent. All labels and config files are preserved so the agent will behave the same in BPOP it will just be a new entity. I plan to discuss with the BPOP team to see if they have any plan to auto clean up this legacy porting.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
