### PR TITLE
fix: Pass through TLS settings to Snapshot Client

### DIFF
--- a/internal/report/agent_client.go
+++ b/internal/report/agent_client.go
@@ -15,6 +15,7 @@
 package report
 
 import (
+	"crypto/tls"
 	"net/http"
 )
 
@@ -29,11 +30,15 @@ type AgentClient struct {
 }
 
 // NewAgentClient creates a new AgentClient
-func NewAgentClient(agentID string, secretKey *string) *AgentClient {
+func NewAgentClient(agentID string, secretKey *string, tlsConfig *tls.Config) *AgentClient {
 	return &AgentClient{
 		agentID:   agentID,
 		secretKey: secretKey,
-		client:    http.DefaultClient,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		},
 	}
 }
 

--- a/internal/report/agent_client_test.go
+++ b/internal/report/agent_client_test.go
@@ -27,7 +27,7 @@ func TestNewAgentClient(t *testing.T) {
 	agentID := "agent_id"
 	secretKey := "secret_key"
 
-	client := NewAgentClient(agentID, &secretKey)
+	client := NewAgentClient(agentID, &secretKey, nil)
 
 	require.Equal(t, agentID, client.agentID)
 	require.Equal(t, &secretKey, client.secretKey)
@@ -69,7 +69,7 @@ func TestAgentClientDo(t *testing.T) {
 			defer s.Close()
 
 			// Create Client
-			client := NewAgentClient(tc.agentID, tc.secretKey)
+			client := NewAgentClient(tc.agentID, tc.secretKey, nil)
 
 			// Format small noop request
 			req, err := http.NewRequest(http.MethodGet, s.URL, http.NoBody)

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -85,8 +85,14 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		return nil, fmt.Errorf("failed to create updaterManager: %w", err)
 	}
 
+	// Propagate TLS config to repoteManager agent
+	tlsCfg, err := args.Config.ToTLS()
+	if err != nil {
+		return nil, fmt.Errorf("failed creating TLS config: %w", err)
+	}
+
 	reportManager := report.GetManager()
-	if err := reportManager.SetClient(report.NewAgentClient(args.Config.AgentID, args.Config.SecretKey)); err != nil {
+	if err := reportManager.SetClient(report.NewAgentClient(args.Config.AgentID, args.Config.SecretKey, tlsCfg)); err != nil {
 		// Error should never happen as we only error if a nil client is sent
 		return nil, fmt.Errorf("failed to set client on report manager: %w", err)
 	}

--- a/opamp/observiq/observiq_client.go
+++ b/opamp/observiq/observiq_client.go
@@ -85,7 +85,7 @@ func NewClient(args *NewClientArgs) (opamp.Client, error) {
 		return nil, fmt.Errorf("failed to create updaterManager: %w", err)
 	}
 
-	// Propagate TLS config to repoteManager agent
+	// Propagate TLS config to reportManager agent
 	tlsCfg, err := args.Config.ToTLS()
 	if err != nil {
 		return nil, fmt.Errorf("failed creating TLS config: %w", err)

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -41,6 +41,7 @@ import (
 
 func TestNewClient(t *testing.T) {
 	secretKey := "136bdd08-2074-40b7-ac1c-6706ac24c4f2"
+	badCAFile := "bad"
 	testCases := []struct {
 		desc        string
 		config      opamp.Config
@@ -61,6 +62,17 @@ func TestNewClient(t *testing.T) {
 				AgentID:  "b24181a8-bc16-4ec1-b3af-ca6f7b669af8",
 			},
 			expectedErr: errors.New("net/url: invalid control character in URL"),
+		},
+		{
+			desc: "Bad TLS Config",
+			config: opamp.Config{
+				Endpoint: "ws://localhost:1234",
+				AgentID:  "b24181a8-bc16-4ec1-b3af-ca6f7b669af8",
+				TLS: &opamp.TLSConfig{
+					CAFile: &badCAFile,
+				},
+			},
+			expectedErr: errors.New("failed creating TLS config"),
 		},
 		{
 			desc: "Valid Config",


### PR DESCRIPTION
### Proposed Change
Fixed TLS issues when using Snapshot feature as TLS config wasn't being passed down to the Client.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
