### PR TITLE
deps: Updated to use latest version of operations-collector

### DIFF
--- a/docs/processors.md
+++ b/docs/processors.md
@@ -16,7 +16,7 @@ Below is a list of supported processors with links to their documentation pages.
 | Memory Limiter Processor                | [memorylimiterprocessor](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.61.0/processor/memorylimiterprocessor/README.md) |
 | Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/processor/metricsgenerationprocessor/README.md) |
 | Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/processor/metricstransformprocessor/README.md) |
-| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/observIQ/opentelemetry-operations-collector/blob/bac5dd221ff681886f289be2d4d8cc5c6b336947/processor/normalizesumsprocessor/README.md) |
+| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/42befa2fc86af6de3be2c97b1503a3e33e72d62f/processor/normalizesumsprocessor/README.md) |
 | Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/processor/probabilisticsamplerprocessor/README.md) |
 | Resource Attribute Transposer Processor | [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md) |
 | Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/processor/resourcedetectionprocessor/README.md) |

--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -59,7 +59,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/syslogreceiver/README.md) |
 | TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/tcplogreceiver/README.md) |
 | UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/udplogreceiver/README.md) |
-| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/observIQ/opentelemetry-operations-collector/blob/bac5dd221ff681886f289be2d4d8cc5c6b336947/receiver/varnishreceiver/README.md) |
+| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/42befa2fc86af6de3be2c97b1503a3e33e72d62f/receiver/varnishreceiver/README.md) |
 | vCenter Receiver                            | [vcenterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/vcenterreceiver/README.md) |
 | Windows Event Log Receiver                  | [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/windowseventlogreceiver/README.md) |
 | Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.61.0/receiver/windowsperfcountersreceiver/README.md) |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/observiq/observiq-otel-collector
 go 1.18
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220916145219-4e0913d7c254
+	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220930133424-42befa2fc86a
 	github.com/google/uuid v1.3.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v1.9.0
@@ -519,6 +519,3 @@ replace github.com/observiq/observiq-otel-collector/processor/throughputmeasurem
 // some dependencies attempt to bring something like v1.8.2-0.20220303173753-edfe657b5405, which is older than v0.38.0
 // at the time of this inclusion, v0.38.0 was the latest version available (also tagged as v2.38.0)
 replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.38.0
-
-// The following replaces are temporary fo the 1.9.1 release, should be able to be removed when operations-collector is updated to otel 0.61.0:
-replace github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220916145219-4e0913d7c254 => github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220929143032-bac5dd221ff6

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220930133424-42befa2fc86a h1:d9lpoMRPZg7RgOKLcnevUapuQA2OwZ5u3nh6FmaUNS0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20220930133424-42befa2fc86a/go.mod h1:SXdKvdesYq92Gv/q6kO2KsB3AqEEOtz8hFASebKM1sw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.8 h1:XV1a1MCXc63vOb2EH+Utbypl1Hmr2mqRLSKx82F2Mh4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.32.8/go.mod h1:s7Gpwj0tk7XnVCm4BQEmx/mbS36SuTCY/vMB2SNxe8o=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.32.8 h1:FtmhPiykEaphXerr83TP1OVH/JIcaN+9fu+Ov1eHkvU=
@@ -1309,8 +1311,6 @@ github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220929143032-bac5dd221ff6 h1:JMAM2iong2oUSXlWE4beEvzR/BuFa0dOaAyyOZsTA7A=
-github.com/observIQ/opentelemetry-operations-collector v0.0.3-0.20220929143032-bac5dd221ff6/go.mod h1:SXdKvdesYq92Gv/q6kO2KsB3AqEEOtz8hFASebKM1sw=
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=


### PR DESCRIPTION
### Proposed Change
Updated to use latest version of GoogleCloudPlatform Operations Collector instead of a fork.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
