### PR TITLE
feat: Add a new default resource filter to the Google exporter

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -39,3 +39,6 @@ When trace data is received by the Google Cloud Exporter, it is processed in the
 1. **Hostname Detection**: Hostname is appended as an attribute on traces if not already present.
 2. **Batch Processor**: Traces are batched to decrease the number of requests.
 3. **Google Cloud Exporter**: Traces are exported to GCP.
+
+## Metric Labels
+Unlike the official Google Cloud Exporter, this extension transforms all resource attributes into metric labels by default. Users may still use the `resource_filters` field in the metric config to overwrite this behavior.

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -17,6 +17,7 @@ package googlecloudexporter
 import (
 	"os"
 
+	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	gcp "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/processor/batchprocessor"
@@ -86,6 +87,10 @@ func createDefaultGCPConfig() *gcp.Config {
 	config.UserAgent = defaultUserAgent
 	config.MetricConfig.Prefix = defaultMetricPrefix
 	config.LogConfig.DefaultLogName, _ = os.Hostname()
+
+	// Overwrites the default resource filter to match all resource attributes
+	defaultResourceFilter := collector.ResourceFilter{Prefix: ""}
+	config.MetricConfig.ResourceFilters = []collector.ResourceFilter{defaultResourceFilter}
 	return config
 }
 

--- a/exporter/googlecloudexporter/config_test.go
+++ b/exporter/googlecloudexporter/config_test.go
@@ -31,6 +31,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	require.Equal(t, config.NewComponentID(typeStr), googleCfg.ID())
 	require.Equal(t, defaultMetricPrefix, googleCfg.GCPConfig.MetricConfig.Prefix)
 	require.Equal(t, defaultUserAgent, googleCfg.GCPConfig.UserAgent)
+	require.Len(t, googleCfg.GCPConfig.MetricConfig.ResourceFilters, 1)
+	require.Equal(t, googleCfg.GCPConfig.MetricConfig.ResourceFilters[0].Prefix, "")
 	require.Nil(t, googleCfg.Validate())
 }
 


### PR DESCRIPTION
### Proposed Change
- Updates the Google exporter to use a new default resource filter.
  - Prior to this change, the exporter used an empty array as the default. If the user did not configure this field, the exporter would ignore all resource attributes.
  - After this change, the exporter will use an array of one item as the default. This item has an empty string as the prefix. If the user does not configure this field, the exporter will now include all resource attributes by default.
  - Users can still restrict all resource attributes by setting the field manually to an empty array. Or they can still configure the field as before.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
