### PR TITLE
feat: Added Object Counts to throughputmeasurement Processor

### DIFF
--- a/processor/throughputmeasurementprocessor/README.md
+++ b/processor/throughputmeasurementprocessor/README.md
@@ -2,12 +2,15 @@
 
 Supported pipelines: logs, metrics, traces
 
-This processor samples OTLP payloads and measures the protobuf size. These measurements are added to the following counter metrics that can be accessed via internal telemetry. Units for each counter is in Bytes.
+This processor samples OTLP payloads and measures the protobuf size as well as number of OTLP objects in that payload. These measurements are added to the following counter metrics that can be accessed via internal telemetry. Units for each `data_size` counter are in Bytes.
 
 Counters:
 - `log_data_size`
 - `metric_data_size`
 - `trace_data_size`
+- `log_count`
+- `metric_count`
+- `trace_count`
 
 **NOTE**: This processor can be expensive and time consuming to run, especially at high throughput rates. It is recommended to run only for short periods of time with a modest `sampling_ratio` value.
 

--- a/processor/throughputmeasurementprocessor/metrics.go
+++ b/processor/throughputmeasurementprocessor/metrics.go
@@ -28,9 +28,9 @@ var (
 	logDataSize     = stats.Int64("log_data_size", "Size of the log package passed to the processor", stats.UnitBytes)
 	metricDataSize  = stats.Int64("metric_data_size", "Size of the metric package passed to the processor", stats.UnitBytes)
 	traceDataSize   = stats.Int64("trace_data_size", "Size of the trace package passed to the processor", stats.UnitBytes)
-	logCount        = stats.Int64("log_count", "Count of the number log records passed to the processor", stats.UnitNone)
-	metricCount     = stats.Int64("metric_count", "Count of the number metric data points passed to the processor", stats.UnitNone)
-	traceCount      = stats.Int64("trace_count", "Count of the number trace spans passed to the processor", stats.UnitNone)
+	logCount        = stats.Int64("log_count", "Count of the number log records passed to the processor", stats. UnitDimensionless)
+	metricCount     = stats.Int64("metric_count", "Count of the number metric data points passed to the processor", stats. UnitDimensionless)
+	traceCount      = stats.Int64("trace_count", "Count of the number trace spans passed to the processor", stats. UnitDimensionless)
 )
 
 func metricViews() []*view.View {

--- a/processor/throughputmeasurementprocessor/metrics.go
+++ b/processor/throughputmeasurementprocessor/metrics.go
@@ -28,6 +28,9 @@ var (
 	logDataSize     = stats.Int64("log_data_size", "Size of the log package passed to the processor", stats.UnitBytes)
 	metricDataSize  = stats.Int64("metric_data_size", "Size of the metric package passed to the processor", stats.UnitBytes)
 	traceDataSize   = stats.Int64("trace_data_size", "Size of the trace package passed to the processor", stats.UnitBytes)
+	logCount        = stats.Int64("log_count", "Count of the number log package passed to the processor", stats.UnitNone)
+	metricCount     = stats.Int64("metric_count", "Count of the number metric package passed to the processor", stats.UnitNone)
+	traceCount      = stats.Int64("trace_count", "Count of the number trace package passed to the processor", stats.UnitNone)
 )
 
 func metricViews() []*view.View {
@@ -52,6 +55,27 @@ func metricViews() []*view.View {
 			Name:        obsreport.BuildProcessorCustomMetricName(string(typeStr), traceDataSize.Name()),
 			Description: traceDataSize.Description(),
 			Measure:     traceDataSize,
+			TagKeys:     processorTagKeys,
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        obsreport.BuildProcessorCustomMetricName(string(typeStr), logCount.Name()),
+			Description: logCount.Description(),
+			Measure:     logCount,
+			TagKeys:     processorTagKeys,
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        obsreport.BuildProcessorCustomMetricName(string(typeStr), metricCount.Name()),
+			Description: metricCount.Description(),
+			Measure:     metricCount,
+			TagKeys:     processorTagKeys,
+			Aggregation: view.Sum(),
+		},
+		{
+			Name:        obsreport.BuildProcessorCustomMetricName(string(typeStr), traceCount.Name()),
+			Description: traceCount.Description(),
+			Measure:     traceCount,
 			TagKeys:     processorTagKeys,
 			Aggregation: view.Sum(),
 		},

--- a/processor/throughputmeasurementprocessor/metrics.go
+++ b/processor/throughputmeasurementprocessor/metrics.go
@@ -28,9 +28,9 @@ var (
 	logDataSize     = stats.Int64("log_data_size", "Size of the log package passed to the processor", stats.UnitBytes)
 	metricDataSize  = stats.Int64("metric_data_size", "Size of the metric package passed to the processor", stats.UnitBytes)
 	traceDataSize   = stats.Int64("trace_data_size", "Size of the trace package passed to the processor", stats.UnitBytes)
-	logCount        = stats.Int64("log_count", "Count of the number log package passed to the processor", stats.UnitNone)
-	metricCount     = stats.Int64("metric_count", "Count of the number metric package passed to the processor", stats.UnitNone)
-	traceCount      = stats.Int64("trace_count", "Count of the number trace package passed to the processor", stats.UnitNone)
+	logCount        = stats.Int64("log_count", "Count of the number log records passed to the processor", stats.UnitNone)
+	metricCount     = stats.Int64("metric_count", "Count of the number metric data points passed to the processor", stats.UnitNone)
+	traceCount      = stats.Int64("trace_count", "Count of the number trace spans passed to the processor", stats.UnitNone)
 )
 
 func metricViews() []*view.View {

--- a/processor/throughputmeasurementprocessor/metrics.go
+++ b/processor/throughputmeasurementprocessor/metrics.go
@@ -28,9 +28,9 @@ var (
 	logDataSize     = stats.Int64("log_data_size", "Size of the log package passed to the processor", stats.UnitBytes)
 	metricDataSize  = stats.Int64("metric_data_size", "Size of the metric package passed to the processor", stats.UnitBytes)
 	traceDataSize   = stats.Int64("trace_data_size", "Size of the trace package passed to the processor", stats.UnitBytes)
-	logCount        = stats.Int64("log_count", "Count of the number log records passed to the processor", stats. UnitDimensionless)
-	metricCount     = stats.Int64("metric_count", "Count of the number metric data points passed to the processor", stats. UnitDimensionless)
-	traceCount      = stats.Int64("trace_count", "Count of the number trace spans passed to the processor", stats. UnitDimensionless)
+	logCount        = stats.Int64("log_count", "Count of the number log records passed to the processor", stats.UnitDimensionless)
+	metricCount     = stats.Int64("metric_count", "Count of the number metric data points passed to the processor", stats.UnitDimensionless)
+	traceCount      = stats.Int64("trace_count", "Count of the number trace spans passed to the processor", stats.UnitDimensionless)
 )
 
 func metricViews() []*view.View {

--- a/processor/throughputmeasurementprocessor/metrics_test.go
+++ b/processor/throughputmeasurementprocessor/metrics_test.go
@@ -25,6 +25,9 @@ func TestMetricViews(t *testing.T) {
 		"processor/throughputmeasurement/log_data_size",
 		"processor/throughputmeasurement/metric_data_size",
 		"processor/throughputmeasurement/trace_data_size",
+		"processor/throughputmeasurement/log_count",
+		"processor/throughputmeasurement/metric_count",
+		"processor/throughputmeasurement/trace_count",
 	}
 
 	views := metricViews()

--- a/processor/throughputmeasurementprocessor/processor.go
+++ b/processor/throughputmeasurementprocessor/processor.go
@@ -52,13 +52,18 @@ func (tmp *throughputMeasurementProcessor) processTraces(ctx context.Context, td
 	if tmp.enabled {
 		//#nosec G404 -- randomly generated number is not used for security purposes. It's ok if it's weak
 		if rand.Float64() <= tmp.samplingCutOffRatio {
-			err := stats.RecordWithTags(
+			// Record size
+			if err := stats.RecordWithTags(
 				ctx,
 				tmp.mutators,
 				traceDataSize.M(int64(tmp.tracesSizer.TracesSize(td))),
-			)
+			); err != nil {
 
-			if err != nil {
+				return td, err
+			}
+
+			// Record count
+			if err := stats.RecordWithTags(ctx, tmp.mutators, traceCount.M(int64(td.SpanCount()))); err != nil {
 				return td, err
 			}
 		}
@@ -71,13 +76,17 @@ func (tmp *throughputMeasurementProcessor) processLogs(ctx context.Context, ld p
 	if tmp.enabled {
 		//#nosec G404 -- randomly generated number is not used for security purposes. It's ok if it's weak
 		if rand.Float64() <= tmp.samplingCutOffRatio {
-			err := stats.RecordWithTags(
+			// Record size
+			if err := stats.RecordWithTags(
 				ctx,
 				tmp.mutators,
 				logDataSize.M(int64(tmp.logsSizer.LogsSize(ld))),
-			)
+			); err != nil {
+				return ld, err
+			}
 
-			if err != nil {
+			// Record count
+			if err := stats.RecordWithTags(ctx, tmp.mutators, logCount.M(int64(ld.LogRecordCount()))); err != nil {
 				return ld, err
 			}
 		}
@@ -90,13 +99,16 @@ func (tmp *throughputMeasurementProcessor) processMetrics(ctx context.Context, m
 	if tmp.enabled {
 		//#nosec G404 -- randomly generated number is not used for security purposes. It's ok if it's weak
 		if rand.Float64() <= tmp.samplingCutOffRatio {
-			err := stats.RecordWithTags(
+			if err := stats.RecordWithTags(
 				ctx,
 				tmp.mutators,
 				metricDataSize.M(int64(tmp.metricsSizer.MetricsSize(md))),
-			)
+			); err != nil {
+				return md, err
+			}
 
-			if err != nil {
+			// Record count
+			if err := stats.RecordWithTags(ctx, tmp.mutators, metricCount.M(int64(md.DataPointCount()))); err != nil {
 				return md, err
 			}
 		}


### PR DESCRIPTION
### Proposed Change
Added the following count metrics to `throughputmeasurement` processor:
- `log_count`
- `metric_count`
- `trace_count`

While most receivers inherently count their object throughput via the OTel framework some don't. Also, most processors do not count their throughput either. Adding counts to the `throughputmeasurement` processor adds a way to get counts of throughput for components that don't count on their own.

Example of metric count prometheus metric:

```
# HELP otelcol_processor_throughputmeasurement_metric_count Count of the number metric data points passed to the processor
# TYPE otelcol_processor_throughputmeasurement_metric_count counter
otelcol_processor_throughputmeasurement_metric_count{processor="throughputmeasurement/batch",service_instance_id="4addcd83-9156-4f03-9c4a-0bd93c133359",service_version="v1.9.1"} 6
otelcol_processor_throughputmeasurement_metric_count{processor="throughputmeasurement/receiver",service_instance_id="4addcd83-9156-4f03-9c4a-0bd93c133359",service_version="v1.9.1"} 6
```

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
