### PR TITLE
feat: OracleDB Metrics Plugin

### DIFF
--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -647,6 +647,7 @@ template: |
     metricstransform:
       transforms:
         - include: .*
+          match_type: regexp
           action: update
           operations:
             - action: update_label

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -643,7 +643,38 @@ template: |
                     )
                   )
                   GROUP BY DATABASE_ID, GLOBAL_NAME, INST_ID
+  processors:
+    metricstransform:
+      transforms:
+        - include: .*
+          action: update
+          operations:
+            - action: update_label
+              label: 'DATABASE_ID'
+              new_label: 'database_id'
+            - action: update_label
+              label: 'GLOBAL_NAME'
+              new_label: 'global_name'
+            - action: update_label
+              label: 'INSTANCE_ID'
+              new_label: 'instance_id'
+            - action: update_label
+              label: 'TABLESPACE_NAME'
+              new_label: 'tablespace_name'
+            - action: update_label
+              label: 'CONTENTS'
+              new_label: 'contents'
+            - action: update_label
+              label: 'STATUS'
+              new_label: 'status'
+            - action: update_label
+              label: 'PROGRAM'
+              new_label: 'program'
+            - action: update_label
+              label: 'WAIT_CLASS'
+              new_label: 'wait_class'
   service:
     pipelines:
       metrics/oracledb:
         receivers: [sqlquery/oracledb]
+        processors: [metricstransform]

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -1,0 +1,650 @@
+version: 0.0.1
+title: OracleDB Metrics
+description: Metrics receiver for OracleDB
+parameters:
+  - name: endpoint
+    description: Address to scrape metrics from
+    type: string
+    default: localhost:1521
+  - name: username
+    description: Username to run metric queries with
+    type: string
+    required: true
+  - name: password
+    description: Password for user
+    type: string
+    required: true
+  - name: scrape_interval
+    description: Time in between every scrape request
+    type: string
+    default: 60s
+  - name: sid
+    description: Site Identifier. sid or service_name must be specified both can be.
+    type: string
+  - name: service_name
+    description: OracleDB Service Name. sid or service_name must be specified both can be.
+    type: string
+  - name: wallet
+    description: OracleDB Wallet file location
+    type: string
+template: |
+  # construct datasource endpoint based on config
+  {{$datasource := "oracle://"}}
+  {{ $datasource = printf "%s%s" $datasource .username }}
+  {{ if .password }}
+    {{ $datasource = printf "%s:%s" $datasource .password }}
+  {{end}}
+  {{ $datasource = printf "%s@%s" $datasource .endpoint }}
+  {{ if .service_name }}
+    {{ $datasource = printf "%s/%s" $datasource .service_name }}
+  {{end}}
+        {{ if and .sid .wallet }}
+    {{ $datasource = printf "%s?SID=%s&WALLET=%s" $datasource .sid .wallet}}
+  {{end}}
+  {{ if and .sid (not .wallet) }}
+    {{ $datasource = printf "%s?SID=%s" $datasource .sid}}
+  {{end}}
+  {{ if and (not .sid) .wallet }}
+    {{ $datasource = printf "%s?WALLET=%s" $datasource .wallet}}
+  {{end}}
+
+  receivers:
+    sqlquery/oracledb:
+      collection_interval: {{ .scrape_interval }}
+      datasource: {{ $datasource }}
+      driver: oracle
+      queries:
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - TABLESPACE_NAME
+                - CONTENTS
+              data_type: sum
+              description: The size of tablespaces in the database.
+              metric_name: oracle.tablespace.size
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+                state: free
+              unit: by
+              value_column: FREE_SPACE
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - TABLESPACE_NAME
+                - CONTENTS
+              data_type: sum
+              description: The size of tablespaces in the database.
+              metric_name: oracle.tablespace.size
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+                state: used
+              unit: by
+              value_column: USED_SPACE
+              value_type: int
+          sql: "SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, ts.TABLESPACE_NAME, ts.CONTENTS,\n\t\t\t\t(select sum(df.bytes) from sys.dba_data_files df where df.tablespace_name=ts.tablespace_name)-(select sum(fs.bytes) from sys.dba_free_space fs where fs.tablespace_name=ts.tablespace_name) AS USED_SPACE,\n\t\t\t\t(select sum(fs.bytes) from sys.dba_free_space fs where fs.tablespace_name=ts.tablespace_name) AS FREE_SPACE\n\t\t\tFROM sys.dba_tablespaces ts \n\t\t\tWHERE ts.contents <> 'TEMPORARY'\n\t\t\tUNION ALL\n\t\t\tSELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, ts.NAME TABLESPACE_NAME, 'TEMPORARY' as CONTENTS,\n\t\t\t\t\tSUM(ss.USED_BLOCKS * t.BLOCK_SIZE) USED_SPACE, \n\t\t\t\t\tSUM(t.BYTES) - SUM(ss.USED_BLOCKS * t.BLOCK_SIZE) FREE_SPACE\n\t\t\tFROM SYS.V_$$sort_segment ss\n\t\t\tJOIN sys.v_$$tablespace ts\n\t\t\tON ss.TABLESPACE_NAME = ts.NAME\n\t\t\tJOIN sys.v_$$tempfile t\n\t\t\tON t.TS# = ss.TS#\n\t\t\tGROUP BY ts.NAME"
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - STATUS
+                - CONTENTS
+              data_type: sum
+              description: The number of tablespaces in the database.
+              metric_name: oracle.tablespace.count
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{tablespaces}"
+              value_column: COUNT
+              value_type: int
+          sql: SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, CONTENTS, STATUS, COUNT(*) COUNT FROM sys.dba_tablespaces GROUP BY STATUS, CONTENTS
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+              data_type: sum
+              description: The number of seconds since the last RMAN backup.
+              metric_name: oracle.backup.latest
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: s
+              value_column: LATEST_BACKUP
+              value_type: int
+          sql: SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, (SELECT round(case when max(start_time) is null then -1 when sysdate - max(start_time) > 0 then (sysdate - max(start_time)) * 86400 else 0 end) FROM SYS.V_$$rman_backup_job_details ) LATEST_BACKUP FROM DUAL
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The current number of processes.
+              metric_name: oracle.process.count
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{processes}"
+              value_column: PROCESSES_UTIL
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The maximum number of processes allowed.
+              metric_name: oracle.process.limit
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{processes}"
+              value_column: PROCESSES_LIMIT_VAL
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The current number of sessions.
+              metric_name: oracle.session.count
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{sessions}"
+              value_column: SESSIONS_UTIL
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The maximum number of sessions allowed.
+              metric_name: oracle.session.limit
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{sessions}"
+              value_column: SESSIONS_LIMIT_VAL
+              value_type: int
+          sql: |-
+            SELECT DATABASE_ID, GLOBAL_NAME, INST_ID INSTANCE_ID, MAX(PROCESSES_UTIL) PROCESSES_UTIL, MAX(PROCESSES_LIMIT_VAL) PROCESSES_LIMIT_VAL, MAX(SESSIONS_UTIL) SESSIONS_UTIL, MAX(SESSIONS_LIMIT_VAL) SESSIONS_LIMIT_VAL
+                  FROM (SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, INST_ID, PROCESSES_UTIL, PROCESSES_LIMIT_VAL, SESSIONS_UTIL, SESSIONS_LIMIT_VAL 
+                  FROM (SELECT * FROM SYS.GV_$$resource_limit
+                    WHERE RESOURCE_NAME IN ('processes', 'sessions'))
+                    PIVOT(
+                      MAX(TRIM(CURRENT_UTILIZATION)) UTIL,
+                      MAX(TRIM(LIMIT_VALUE)) LIMIT_VAL
+                      FOR RESOURCE_NAME
+                      IN (
+                        'processes' PROCESSES,
+                        'sessions' SESSIONS
+                      )
+                    )
+                  )
+                  GROUP BY DATABASE_ID, GLOBAL_NAME, INST_ID
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - PROGRAM
+              data_type: sum
+              description: The programmable global area memory allocated by process.
+              metric_name: oracle.process.pga_memory.size
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+                state: used
+              unit: by
+              value_column: USED_MEM
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - PROGRAM
+              data_type: sum
+              description: The programmable global area memory allocated by process.
+              metric_name: oracle.process.pga_memory.size
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+                state: free
+              unit: by
+              value_column: FREE_MEM
+              value_type: int
+          sql: SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, INST_ID INSTANCE_ID, PROGRAM, SUM(PGA_USED_MEM) USED_MEM, SUM(PGA_ALLOC_MEM) - SUM(PGA_USED_MEM) FREE_MEM FROM SYS.GV_$$PROCESS WHERE PROGRAM <> 'PSEUDO' GROUP BY PROGRAM, INST_ID
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The number of wait events experienced.
+              metric_name: oracle.wait.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: foreground
+              unit: "{events}"
+              value_column: TOTAL_WAITS_FG
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The number of wait events experienced.
+              metric_name: oracle.wait.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: background
+              unit: "{events}"
+              value_column: TOTAL_WAITS_BG
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The amount of time waited for wait events.
+              metric_name: oracle.wait.time
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: foreground
+              unit: cs
+              value_column: TIME_WAITED_FG
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The amount of time waited for wait events.
+              metric_name: oracle.wait.time
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: background
+              unit: cs
+              value_column: TIME_WAITED_BG
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The number of timeouts for wait events.
+              metric_name: oracle.wait.timeouts
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: foreground
+              unit: "{timeouts}"
+              value_column: TOTAL_TIMEOUTS_FG
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+                - WAIT_CLASS
+              data_type: sum
+              description: The number of timeouts for wait events.
+              metric_name: oracle.wait.timeouts
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: background
+              unit: "{timeouts}"
+              value_column: TOTAL_TIMEOUTS_BG
+              value_type: int
+          sql: SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, INST_ID INSTANCE_ID, WAIT_CLASS, SUM(total_waits_fg) AS TOTAL_WAITS_FG, SUM(total_waits)-SUM(total_waits_fg) AS TOTAL_WAITS_BG, SUM(total_timeouts_fg) AS TOTAL_TIMEOUTS_FG, SUM(total_timeouts)-SUM(TOTAL_TIMEOUTS_FG) AS TOTAL_TIMEOUTS_BG, SUM(time_waited_fg) AS TIME_WAITED_FG, SUM(time_waited)-SUM(TIME_WAITED_FG) AS TIME_WAITED_BG FROM SYS.GV_$$system_event WHERE wait_class <> 'Idle' GROUP BY INST_ID, WAIT_CLASS
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: gauge
+              description: The average sql service response time.
+              metric_name: oracle.service.response_time
+              static_attributes:
+                db.system: oracle
+              unit: cs
+              value_column: RESPONSE_TIME
+              value_type: double
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: gauge
+              description: Ratio of buffer cache hits to requests.
+              metric_name: oracle.buffer.cache.ratio
+              static_attributes:
+                db.system: oracle
+              unit: "%"
+              value_column: BUFFER_HIT_RATIO
+              value_type: double
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: gauge
+              description: Ratio of row cache hits to requests.
+              metric_name: oracle.row.cache.ratio
+              static_attributes:
+                db.system: oracle
+              unit: "%"
+              value_column: ROW_HIT_RATIO
+              value_type: double
+          sql: |-
+            SELECT DATABASE_ID, GLOBAL_NAME, INST_ID INSTANCE_ID, MAX(RESPONSE_TIME) RESPONSE_TIME, MAX(BUFFER_HIT_RATIO) BUFFER_HIT_RATIO, MAX(ROW_HIT_RATIO) ROW_HIT_RATIO 
+                  FROM (SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, INST_ID, END_TIME, RESPONSE_TIME, BUFFER_HIT_RATIO, ROW_HIT_RATIO 
+                  FROM (SELECT * FROM SYS.GV_$$sysmetric
+                    WHERE METRIC_NAME IN ('SQL Service Response Time', 'Buffer Cache Hit Ratio', 'Row Cache Hit Ratio')
+                    AND GROUP_ID = 2)
+                    PIVOT(
+                      MAX(VALUE)
+                      FOR METRIC_NAME
+                      IN (
+                        'SQL Service Response Time' RESPONSE_TIME,
+                        'Buffer Cache Hit Ratio' BUFFER_HIT_RATIO,
+                        'Row Cache Hit Ratio' ROW_HIT_RATIO
+                      )
+                    )
+                  )
+                  GROUP BY DATABASE_ID, GLOBAL_NAME, INST_ID
+        - metrics:
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of cursors.
+              metric_name: oracle.cursor.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{cursors}"
+              value_column: CURSORS_CUMULATIVE
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The current number of cursors.
+              metric_name: oracle.cursor.current
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{cursors}"
+              value_column: CURSORS_CURRENT
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of logons.
+              metric_name: oracle.logon.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{logons}"
+              value_column: LOGONS_CUMULATIVE
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The current number of logons.
+              metric_name: oracle.logon.current
+              monotonic: "false"
+              static_attributes:
+                db.system: oracle
+              unit: "{logons}"
+              value_column: LOGONS_CURRENT
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of sorts.
+              metric_name: oracle.sort.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: memory
+              unit: "{sorts}"
+              value_column: SORTS_MEM
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of sorts.
+              metric_name: oracle.sort.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                type: disk
+              unit: "{sorts}"
+              value_column: SORTS_DISK
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of rows sorted.
+              metric_name: oracle.sort.row.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{rows}"
+              value_column: SORTS_ROWS
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The number of physical disk operations.
+              metric_name: oracle.disk.operation.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: read
+              unit: "{operations}"
+              value_column: READ_TOTAL
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The number of bytes affected by physical disk operations.
+              metric_name: oracle.disk.operation.size
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: read
+              unit: by
+              value_column: READ_TOTAL_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The number of physical disk operations.
+              metric_name: oracle.disk.operation.count
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: write
+              unit: "{operations}"
+              value_column: WRITE_TOTAL
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The number of bytes affected by physical disk operations.
+              metric_name: oracle.disk.operation.size
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: write
+              unit: by
+              value_column: WRITE_TOTAL_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of bytes communicated on the network.
+              metric_name: oracle.network.data
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: received
+                target: client
+              unit: by
+              value_column: CLIENT_RECV_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of bytes communicated on the network.
+              metric_name: oracle.network.data
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: sent
+                target: client
+              unit: by
+              value_column: CLIENT_SENT_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of bytes communicated on the network.
+              metric_name: oracle.network.data
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: received
+                target: dblink
+              unit: by
+              value_column: DBLINK_RECV_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of bytes communicated on the network.
+              metric_name: oracle.network.data
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+                direction: sent
+                target: dblink
+              unit: by
+              value_column: DBLINK_SENT_BY
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of user calls such as login, parse, fetch, or execute.
+              metric_name: oracle.user.calls
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{calls}"
+              value_column: USER_CALLS
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of user transaction commits.
+              metric_name: oracle.user.commits
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{commits}"
+              value_column: USER_COMMITS
+              value_type: int
+            - attribute_columns:
+                - DATABASE_ID
+                - GLOBAL_NAME
+                - INSTANCE_ID
+              data_type: sum
+              description: The total number of times users manually issue the ROLLBACK statement or an error occurs during a user's transactions
+              metric_name: oracle.user.rollbacks
+              monotonic: "true"
+              static_attributes:
+                db.system: oracle
+              unit: "{rollbacks}"
+              value_column: USER_ROLLBACKS
+              value_type: int
+          sql: |-
+            SELECT DATABASE_ID, GLOBAL_NAME, INST_ID INSTANCE_ID, MAX(CURSORS_CUMULATIVE) CURSORS_CUMULATIVE, MAX(CURSORS_CURRENT) CURSORS_CURRENT, MAX(SORTS_MEM) SORTS_MEM, MAX(SORTS_DISK) SORTS_DISK, MAX(SORTS_ROWS) SORTS_ROWS, MAX(READ_TOTAL) READ_TOTAL, MAX(WRITE_TOTAL) WRITE_TOTAL, MAX(READ_TOTAL_BY) READ_TOTAL_BY, MAX(WRITE_TOTAL_BY) WRITE_TOTAL_BY, MAX(LOGONS_CURRENT) LOGONS_CURRENT, MAX(CLIENT_RECV_BY) CLIENT_RECV_BY, MAX(DBLINK_RECV_BY) DBLINK_RECV_BY, MAX(CLIENT_SENT_BY) CLIENT_SENT_BY, MAX(DBLINK_SENT_BY) DBLINK_SENT_BY, MAX(LOGONS_CUMULATIVE) LOGONS_CUMULATIVE, MAX(USER_CALLS) USER_CALLS, MAX(USER_COMMITS) USER_COMMITS, MAX(USER_ROLLBACKS) USER_ROLLBACKS 
+                  FROM (SELECT (SELECT DBID FROM SYS.GV_$$DATABASE) DATABASE_ID, (SELECT GLOBAL_NAME FROM sys.GLOBAL_NAME) GLOBAL_NAME, INST_ID, CURSORS_CUMULATIVE, CURSORS_CURRENT, SORTS_MEM, SORTS_DISK, SORTS_ROWS, READ_TOTAL, WRITE_TOTAL, READ_TOTAL_BY, WRITE_TOTAL_BY, LOGONS_CURRENT, CLIENT_RECV_BY, DBLINK_RECV_BY, CLIENT_SENT_BY, DBLINK_SENT_BY, LOGONS_CUMULATIVE, USER_CALLS, USER_COMMITS, USER_ROLLBACKS 
+                  FROM (SELECT * FROM SYS.GV_$$sysstat
+                    WHERE NAME IN ('opened cursors cumulative', 'opened cursors current', 'sorts (memory)', 'sorts (disk)', 'sorts (rows)', 'physical read total IO requests', 'physical write total IO requests', 'physical read total bytes', 'physical write total bytes', 'logons current', 'bytes received via SQL*Net from client', 'bytes received via SQL*Net from dblink', 'bytes sent via SQL*Net to client', 'bytes sent via SQL*Net to dblink', 'logons cumulative', 'user calls', 'user commits', 'user rollbacks')
+                    )
+                    PIVOT(
+                      MAX(VALUE)
+                      FOR NAME
+                      IN (
+                        'opened cursors cumulative' CURSORS_CUMULATIVE,
+                        'opened cursors current' CURSORS_CURRENT,
+                        'logons cumulative' LOGONS_CUMULATIVE,
+                        'logons current' LOGONS_CURRENT,
+                        'sorts (memory)' SORTS_MEM,
+                        'sorts (disk)' SORTS_DISK,
+                        'sorts (rows)' SORTS_ROWS,
+                        'physical read total IO requests' READ_TOTAL,
+                        'physical write total IO requests' WRITE_TOTAL,
+                        'physical read total bytes' READ_TOTAL_BY,
+                        'physical write total bytes' WRITE_TOTAL_BY,
+                        'bytes received via SQL*Net from client' CLIENT_RECV_BY,
+                        'bytes received via SQL*Net from dblink' DBLINK_RECV_BY,
+                        'bytes sent via SQL*Net to client' CLIENT_SENT_BY,
+                        'bytes sent via SQL*Net to dblink' DBLINK_SENT_BY,
+                        'user calls' USER_CALLS,
+                        'user commits' USER_COMMITS,
+                        'user rollbacks' USER_ROLLBACKS
+                      )
+                    )
+                  )
+                  GROUP BY DATABASE_ID, GLOBAL_NAME, INST_ID
+  service:
+    pipelines:
+      metrics/oracledb:
+        receivers: [sqlquery/oracledb]

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -7,26 +7,25 @@ parameters:
     type: string
     default: localhost:1521
   - name: username
-    description: Username to run metric queries with
+    description: Database user to run metric queries with
     type: string
     required: true
   - name: password
     description: Password for user
     type: string
-    required: true
+  - name: sid
+    description: Site Identifier. One of sid or service_name must be specified both can be.
+    type: string
+  - name: service_name
+    description: OracleDB Service Name. One of sid or service_name must be specified both can be.
+    type: string
+  - name: wallet
+    description: OracleDB Wallet file location (must be URL encoded)
+    type: string
   - name: scrape_interval
     description: Time in between every scrape request
     type: string
     default: 60s
-  - name: sid
-    description: Site Identifier. sid or service_name must be specified both can be.
-    type: string
-  - name: service_name
-    description: OracleDB Service Name. sid or service_name must be specified both can be.
-    type: string
-  - name: wallet
-    description: OracleDB Wallet file location
-    type: string
 template: |
   # construct datasource endpoint based on config
   {{$datasource := "oracle://"}}

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -38,13 +38,13 @@ template: |
     {{ $datasource = printf "%s/%s" $datasource .service_name }}
   {{end}}
         {{ if and .sid .wallet }}
-    {{ $datasource = printf "%s?SID=%s&WALLET=%s" $datasource .sid .wallet}}
+    {{ $datasource = printf "%s?SID%%3D%s&WALLET%3D%s" $datasource .sid .wallet}}
   {{end}}
   {{ if and .sid (not .wallet) }}
-    {{ $datasource = printf "%s?SID=%s" $datasource .sid}}
+    {{ $datasource = printf "%s?SID%%3D%s" $datasource .sid}}
   {{end}}
   {{ if and (not .sid) .wallet }}
-    {{ $datasource = printf "%s?WALLET=%s" $datasource .wallet}}
+    {{ $datasource = printf "%s?WALLET%%3D%s" $datasource .wallet}}
   {{end}}
 
   receivers:

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -14,10 +14,10 @@ parameters:
     description: Password for user
     type: string
   - name: sid
-    description: Site Identifier. One of sid or service_name must be specified both can be.
+    description: Site Identifier. One or both of sid or service_name must be specified.
     type: string
   - name: service_name
-    description: OracleDB Service Name. One of sid or service_name must be specified both can be.
+    description: OracleDB Service Name. One or both of sid or service_name must be specified.
     type: string
   - name: wallet
     description: OracleDB Wallet file location (must be URL encoded)
@@ -37,8 +37,8 @@ template: |
   {{ if .service_name }}
     {{ $datasource = printf "%s/%s" $datasource .service_name }}
   {{end}}
-        {{ if and .sid .wallet }}
-    {{ $datasource = printf "%s?SID%%3D%s&WALLET%3D%s" $datasource .sid .wallet}}
+  {{ if and .sid .wallet }}
+    {{ $datasource = printf "%s?SID%%3D%s&WALLET%%3D%s" $datasource .sid .wallet}}
   {{end}}
   {{ if and .sid (not .wallet) }}
     {{ $datasource = printf "%s?SID%%3D%s" $datasource .sid}}


### PR DESCRIPTION
### Proposed Change
Added a plugin for OracleDB Metrics.

Here is a small sample of a metric resulting from the plugin:

```
ResourceMetrics #0
Resource SchemaURL: 
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope  
Metric #0
Descriptor:
     -> Name: oracle.tablespace.size
     -> Description: The size of tablespaces in the database.
     -> Unit: by
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
NumberDataPoints #0
Data point attributes:
     -> db.system: STRING(oracle)
     -> state: STRING(free)
     -> database_id: STRING(1643340059)
     -> global_name: STRING(ORCL.C.OTEL-AGENT-DEV.INTERNAL)
     -> tablespace_name: STRING(SYSTEM)
     -> contents: STRING(PERMANENT)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-10-06 17:50:47.960831095 +0000 UTC
Value: 6225920
Metric #1
Descriptor:
     -> Name: oracle.tablespace.size
     -> Description: The size of tablespaces in the database.
     -> Unit: by
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
NumberDataPoints #0
Data point attributes:
     -> db.system: STRING(oracle)
     -> state: STRING(free)
     -> database_id: STRING(1643340059)
     -> global_name: STRING(ORCL.C.OTEL-AGENT-DEV.INTERNAL)
     -> tablespace_name: STRING(SYSAUX)
     -> contents: STRING(PERMANENT)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-10-06 17:50:47.960831095 +0000 UTC
Value: 69140480
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
