### PR TITLE
feat: Support OpAMP when running within a container

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -201,6 +201,7 @@ dockers:
       - "--platform=linux/amd64"
     extra_files:
       - plugins
+      - config/example.yaml
   - goos: linux
     goarch: arm64
     ids:
@@ -220,6 +221,7 @@ dockers:
       - "--platform=linux/arm64"
     extra_files:
       - plugins
+      - config/example.yaml
 
 docker_manifests:
   - name_template: "observiq/observiq-otel-collector:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
 
 # Default config allows the collector to run without an injected config, which is required
 # when connecting to an OpAMP platform.
-RUN echo "receivers:\n  hostmetrics:\n    collection_interval: 1h\n    scrapers:\n      load:\nexporters:\n  logging:\nservice:\n  pipelines:\n    metrics:\n      receivers: [hostmetrics]\n      exporters: [logging]" > /etc/otel/config.yaml
+COPY config/example.yaml /etc/otel/config.yaml
 RUN chown otel:otel /etc/otel/config.yaml
 
 USER otel

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,16 @@ FROM openjdk:8u312-slim-buster as openjdk
 FROM gcr.io/observiq-container-images/stanza-base:v1.2.2
 WORKDIR /
 
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --no-create-home \
+    --uid 10005 \
+    otel
+
+RUN mkdir /etc/otel && chown otel:otel /etc/otel
+ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
 ENV PATH=$PATH:/usr/local/openjdk-8/bin
@@ -43,18 +53,18 @@ COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --no-create-home \
-    --uid 10005 \
-    otel
-
 RUN echo "output: stdout\nlevel: info\n" > /etc/otel/logging.yaml
 ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
 
-USER otel
+# Default config allows the collector to run without an injected config, which is required
+# when connecting to an OpAMP platform.
+RUN echo "receivers:\n  hostmetrics:\n    collection_interval: 1h\n    scrapers:\n      load:\nexporters:\n  logging:\nservice:\n  pipelines:\n    metrics:\n      receivers: [hostmetrics]\n      exporters: [logging]" > /etc/otel/config.yaml
+RUN chown otel:otel /etc/otel/config.yaml
 
-# User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap
+USER otel
+WORKDIR /etc/otel
+
+# User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
+# connecting to an OpAMP platform.
 ENTRYPOINT [ "/collector/observiq-otel-collector" ]
 CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The Dockerfile requires a configuration file to be injected (docker volume / kubernetes configmap) at runtime, otherwise it will fail to start. In order to allow users to use OpAMP, the container needs to function without a configuration.

- Moved user creation toward top
- Created `/etc/otel` and set ownership to the previously created `otel` user
- Added "default" config to container image
- Set `OIQ_OTEL_COLLECTOR_HOME` to `/etc/otel`. We use this variable in the systemd and windows service configurations.
- Added a "default" config to `/etc/otel/config.yaml`, owned by `otel` user
- Set working dir to `/etc/otel`, this allows the `otel` user to write `manager.yaml` to `/etc/otel`

I tested to ensure the collector continues to work without opamp (config injected via configmap).

You can try this out with Docker Compose (assuming `arm64`. If amd64, update the container image tag)
```yaml
version: "3.9"
services:
  bindplane:
    image: observiq/bindplane:latest
    ports:
      - "3001:3001"
    restart: always
    environment:
      - BINDPLANE_CONFIG_LOG_OUTPUT=stdout
      - BINDPLANE_CONFIG_SERVER_URL=http://bindplane:3001
      - BINDPLANE_CONFIG_REMOTE_URL=ws://bindplane:3001
      - BINDPLANE_CONFIG_USERNAME=admin
      - BINDPLANE_CONFIG_PASSWORD=admin
      - BINDPLANE_CONFIG_SECRET_KEY=b0afeee0-3e2d-482e-8332-42a52ce6b720
      - BINDPLANE_CONFIG_SESSIONS_SECRET=b52c0c31-463a-48eb-aebd-93b3360d902a

  collector:
    depends_on:
      - bindplane
    restart: always
    image: bmedora/observiq-otel-collector-arm64:3c918d6
    #image: bmedora/observiq-otel-collector-amd64:3c918d6
    environment:
      - OPAMP_ENDPOINT=ws://bindplane:3001/v1/opamp
      - OPAMP_SECRET_KEY=b0afeee0-3e2d-482e-8332-42a52ce6b720
    deploy:
      replicas: 12
```

Navigate to http://localhost:3001 and login with `admin` / `admin`.

![Screenshot from 2022-10-06 17-08-29](https://user-images.githubusercontent.com/23043836/194419010-8f1e536e-6784-4b97-b776-59c7c8f347a1.png)



##### Checklist
- [x] Changes are tested
- [x] CI has passed
