### PR TITLE
feat(plugin):  Add log_driver option to container log plugin

### DIFF
--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -49,6 +49,7 @@ parameters:
       - docker-json-file
       # This format is not well documented: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/logs/logs.go#L125-L169
       - containerd-cri
+    default: auto
 
 
 template: |

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -42,7 +42,7 @@ parameters:
       When set to `auto`, the format will be detected using regex. Format detection
       is convenient but comes with the cost of performing a regex match against every
       log entry read by the filelog receiver.
-    type: "[]string"
+    type: "string"
     supported:
       - auto
       # https://docs.docker.com/config/containers/logging/json-file/

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -35,7 +35,7 @@ parameters:
       - beginning
       - end
     default: end
-  - name: runtime_log_driver
+  - name: log_driver
     description: |
       The container runtime's log driver used to write container logs to disk.
       Valid options include `auto`, `docker-json-file` and `containerd-cri`.
@@ -69,7 +69,7 @@ template: |
           {{end}}
         poll_interval: 500ms
         operators:
-          {{ if eq .runtime_log_driver "auto" }}
+          {{ if eq .log_driver "auto" }}
           - type: router
             routes:
               - expr: 'body matches "^[^{]"'
@@ -77,7 +77,7 @@ template: |
             default: docker_json_file_parser
           {{ end }}
 
-          {{ if or (eq .runtime_log_driver "docker-json-file") (eq .runtime_log_driver "auto") }}
+          {{ if or (eq .log_driver "docker-json-file") (eq .log_driver "auto") }}
           # The raw message looks like this:
           # {"log":"I0618 14:30:29.641678       1 logs.go:59] http: TLS handshake error from 192.168.49.2:56222: EOF\n","stream":"stderr","time":"2022-06-18T14:30:29.641732743Z"}
           - type: json_parser
@@ -88,7 +88,7 @@ template: |
             output: log-to-body
           {{ end }}
 
-          {{ if or (eq .runtime_log_driver "containerd-cri") (eq .runtime_log_driver "auto") }}
+          {{ if or (eq .log_driver "containerd-cri") (eq .log_driver "auto") }}
           # The raw message looks like this:
           # 2022-06-18T16:52:59.639114537Z stdout F {"message":"registered Stackdriver tracing","severity":"info","timestamp":"2022-06-18T16:52:59.639034532Z"}
           - id: containerd_cri_parser

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -76,7 +76,7 @@ template: |
             default: docker_json_file_parser
           {{ end }}
 
-          {{ if or (eq .runtime_log_driver "docker-json-file") (eq eq .runtime_log_driver "auto") }}
+          {{ if or (eq .runtime_log_driver "docker-json-file") (eq .runtime_log_driver "auto") }}
           # The raw message looks like this:
           # {"log":"I0618 14:30:29.641678       1 logs.go:59] http: TLS handshake error from 192.168.49.2:56222: EOF\n","stream":"stderr","time":"2022-06-18T14:30:29.641732743Z"}
           - type: json_parser
@@ -87,7 +87,7 @@ template: |
             output: log-to-body
           {{ end }}
 
-          {{ if or (eq .runtime_log_driver "containerd-cri") (eq eq .runtime_log_driver "auto") }}
+          {{ if or (eq .runtime_log_driver "containerd-cri") (eq .runtime_log_driver "auto") }}
           # The raw message looks like this:
           # 2022-06-18T16:52:59.639114537Z stdout F {"message":"registered Stackdriver tracing","severity":"info","timestamp":"2022-06-18T16:52:59.639034532Z"}
           - id: containerd_cri_parser

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.3.0
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -35,6 +35,21 @@ parameters:
       - beginning
       - end
     default: end
+  - name: runtime_log_driver
+    description: |
+      The container runtime's log driver used to write container logs to disk.
+      Valid options include `auto`, `docker-json-file` and `containerd-cri`.
+      When set to `auto`, the format will be detected using regex. Format detection
+      is convenient but comes with the cost of performing a regex match against every
+      log entry read by the filelog receiver.
+    type: "[]string"
+    supported:
+      - auto
+      # https://docs.docker.com/config/containers/logging/json-file/
+      - docker-json-file
+      # This format is not well documented: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/logs/logs.go#L125-L169
+      - containerd-cri
+
 
 template: |
   receivers:
@@ -53,26 +68,29 @@ template: |
           {{end}}
         poll_interval: 500ms
         operators:
-          # Support docker and containerd runtimes, which have different
-          # logging formats.
+          {{ if eq .runtime_log_driver "auto" }}
           - type: router
             routes:
               - expr: 'body matches "^[^{]"'
-                output: containerd_parser
-            default: docker_parser
+                output: containerd_cri_parser
+            default: docker_json_file_parser
+          {{ end }}
 
+          {{ if or (eq .runtime_log_driver "docker-json-file") (eq eq .runtime_log_driver "auto") }}
           # The raw message looks like this:
           # {"log":"I0618 14:30:29.641678       1 logs.go:59] http: TLS handshake error from 192.168.49.2:56222: EOF\n","stream":"stderr","time":"2022-06-18T14:30:29.641732743Z"}
           - type: json_parser
-            id: docker_parser
+            id: docker_json_file_parser
             timestamp:
               parse_from: attributes.time
               layout: '%Y-%m-%dT%H:%M:%S.%sZ'
             output: log-to-body
+          {{ end }}
 
+          {{ if or (eq .runtime_log_driver "containerd-cri") (eq eq .runtime_log_driver "auto") }}
           # The raw message looks like this:
           # 2022-06-18T16:52:59.639114537Z stdout F {"message":"registered Stackdriver tracing","severity":"info","timestamp":"2022-06-18T16:52:59.639034532Z"}
-          - id: containerd_parser
+          - id: containerd_cri_parser
             type: regex_parser
             regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w)?(?P<log>.*)'
           - type: recombine
@@ -101,6 +119,7 @@ template: |
             parse_from: attributes.time
             layout: '%Y-%m-%dT%H:%M:%S.%sZ'
             output: log-to-body
+          {{ end }}
 
           # The raw body does not contain anything useful considering timestamp has been promotoed to
           # the log entries timestamp, therefore we move attributes.log (the actual container log message)

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -57,7 +57,7 @@ template: |
           # logging formats.
           - type: router
             routes:
-              - expr: 'body matches "^[^\\s]+ \\w+ .*"'
+              - expr: 'body matches "^[^{]"'
                 output: containerd_parser
             default: docker_parser
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

- Added `log_driver` parameter with `auto`, `docker-json-file`, and `containerd-cri` options
  - `auto` is the default value and retains the same behavior (detects log format on every log)
  - By selecting a log driver, the pipeline will skip a regex match on every single log that enters the pipeline
- Fixed the regex used when checking if containerd cri format
  - Previous regex was working for the most part, but I had some application logs match despite coming from docker.
  - This [example](https://regex101.com/r/glMYc3/1) shows the previous containerd incorrectly regex matching a docker log.
- Renamed the parsers to better reflect what format they are processing
  - docker_parser --> docker_json_file_parser
  - containerd_parser --> containerd_cri_parser

These changes are backwards compatible, and do not change behavior unless the `log_driver` option is set to something other than the default `auto` value.

I have tested against the following log_driver options, outputing to Google Cloud Logging:

**docker**
- auto (no parsing failures)
- docker-json-file (no parsing failures)
- containerd-cri (parse failures on every entry, expected)

**containerd**
- auto (no parsing failures)
- docker-json-file (parse failures on every entry, expected)
- containerd-cri (no parsing failures)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
