### PR TITLE
fix(plugin): Hadoop filter expression

### DIFF
--- a/plugins/hadoop_logs.yaml
+++ b/plugins/hadoop_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: Apache Hadoop
 description: Log parser for Apache Hadoop
 parameters:

--- a/plugins/hadoop_logs.yaml
+++ b/plugins/hadoop_logs.yaml
@@ -76,7 +76,7 @@ template: |
               output: regex_parser  
             - attributes:
                 log_type: hadoop
-              expr: true
+              expr: 'true'
               output: regex_parser          
 
         - type: regex_parser


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

I stumbled upon this in the wild. At some point between v1.9.0 and v1.9.2, the `expr` language changed. We now need to quote `true` when doing `expr: true`. I did verify that this is backwards compatible and is working as expected with v1.9.0 and v1.9.2.

The hadoop plugin is the only place we do this.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
