### PR TITLE
fix: Update `awscloudwatchreceiver` to fix partial issue with config validation

### DIFF
--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -10,7 +10,7 @@ Below is a list of supported receivers with links to their documentation pages.
 | Apache Flink Metrics Receiver               | [flinkmetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/flinkmetricsreceiver/README.md) |
 | Apache Web Server Receiver                  | [apachereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/apachereceiver/README.md) |
 | Apache ZooKeeper Receiver                   | [zookeeperreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/zookeeperreceiver/README.md) |
-| AWS CloudWatch Receiver                     | [awscloudwatchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/awscloudwatchreceiver/README.md) |
+| AWS CloudWatch Receiver                     | [awscloudwatchreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/e2f8e76098a2e48b0181dc954bea21176c38368f/receiver/awscloudwatchreceiver/README.md) |
 | AWS CloudWatch Container Insights Receiver  | [awscontainerinsightreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/awscontainerinsightreceiver/README.md) |
 | AWS ECS Container Metrics Receiver          | [awsecscontainermetricsreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/awsecscontainermetricsreceiver/README.md) |
 | AWS Kinesis Data Firehose Receiver          | [awsfirehosereceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.62.0/receiver/awsfirehosereceiver/README.md) |

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver v0.62.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.62.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.62.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.1-0.20221018144113-e2f8e76098a2
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.62.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.62.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.62.0
@@ -506,7 +506,7 @@ require (
 	google.golang.org/api v0.98.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20221010155953-15ba04fc1c0e // indirect
-	google.golang.org/grpc v1.50.0 // indirect
+	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1578,8 +1578,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikerece
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver v0.62.0/go.mod h1:BgrN751a112ZnKAQAiLfF7q7FWRAsSVRRXKGdmKH9rw=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.62.0 h1:HHQ5OdoY5X6/FqaWS2TxbstyaQ3dMrxujaGIl149kis=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver v0.62.0/go.mod h1:GZ7RUzj4ZAYrcokrSR3rbV8vFvl/dkaHepqcJPges8M=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.0 h1:FmCR9e6PTvtW6+uSA4xmpxY700kY+YcDBnQavwGkt0E=
-github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.0/go.mod h1:ze2FjcawwKcNqZgcQYWzTE9xwDYxkT3q2E+gqHulysw=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.1-0.20221018144113-e2f8e76098a2 h1:J8ub5KV+Lo695KRyf7A7fKf+qjs2OZD8Hii1XPBFID4=
+github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscloudwatchreceiver v0.62.1-0.20221018144113-e2f8e76098a2/go.mod h1:MtxykwF6JlbgWG7IDBwPR1B3XOIWNVExZg1dDp95sa4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.62.0 h1:gDFurRY3LQ5Nng8tBo4p9KLWkngn/+hCAgWFt0/6Hl4=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver v0.62.0/go.mod h1:iNoYLlrvzZY4Hu8CTbJEkkCZoFEMdWcU/j39Cucai7s=
 github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver v0.62.0 h1:pkjWmn9UCSiHOjAffY2OPYbsi1fuPJLfaB/EXRNRMHM=
@@ -2955,8 +2955,8 @@ google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.50.0 h1:fPVVDxY9w++VjTZsYvXWqEf9Rqar/e+9zYfxKK+W+YU=
-google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
+google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
+google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=


### PR DESCRIPTION
### Proposed Change

Changes found here https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/14953/

This adds a custom unmarshal step to avoid the default config auto populating the `autodiscover` config when only using the `named` config portions of the `GroupConfig`. 

<details>
<summary>Error received before</summary>

Config: 

```yaml
receivers:
  awscloudwatch:
    profile: 'kschmitt'
    region: us-east-2
    logs:
      poll_interval: 10s
      groups:
        named:
          /aws/eks/dev-eks-0/cluster:
            names: [kube-apiserver-audit-ea9c831555adca1815ae04b884b30566]


exporters:
  logging:
  file:
    path: cloudwatch.json

service:
  pipelines:
    logs:
      receivers:
      - awscloudwatch
      exporters:
      - logging
      - file
```

Error before:

```sh
{"level":"fatal","ts":"2022-10-18T11:21:12.744-0400","caller":"collector/main.go:98","msg":"RunService returned error","error":"failed to start service: failed while starting collector: failed to get config: invalid configuration: receiver \"awscloudwatch\" has invalid configuration: both autodiscover and named configs are configured, Only one or the other is permitted","stacktrace":"main.main\n\t/Users/keithschmitt/go-workspace/src/github.com/observiq/observiq-collector/cmd/collector/main.go:98\nruntime.main\n\t/usr/local/opt/go@1.18/libexec/src/runtime/proc.go:250"}
```

Output after:

```sh
➜ ./dist/collector_darwin_amd64 --config ~/go-workspace/src/github.com/open-telemetry/opentelemetry-collector-contrib/demo/configs/named-prefix-streams.yaml
{"level":"info","ts":"2022-10-18T11:24:15.407-0400","caller":"collector/main.go:89","msg":"Starting Standalone Mode"}
{"level":"info","ts":"2022-10-18T11:24:15.409-0400","caller":"service/telemetry.go:121","msg":"Setting up own telemetry..."}
{"level":"info","ts":"2022-10-18T11:24:15.409-0400","caller":"service/telemetry.go:143","msg":"Serving Prometheus metrics","address":":8888","level":"basic"}
{"level":"info","ts":"2022-10-18T11:24:15.409-0400","caller":"components/components.go:30","msg":"In development component. May change in the future.","kind":"exporter","data_type":"logs","name":"logging","stability":"in development"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"service/service.go:90","msg":"Starting ./dist/collector_darwin_amd64...","Version":"v1.8.0","NumCPU":12}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"extensions/extensions.go:42","msg":"Starting extensions..."}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:74","msg":"Starting exporters..."}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:78","msg":"Exporter is starting...","kind":"exporter","data_type":"logs","name":"logging"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:82","msg":"Exporter started.","kind":"exporter","data_type":"logs","name":"logging"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:78","msg":"Exporter is starting...","kind":"exporter","data_type":"logs","name":"file"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:82","msg":"Exporter started.","kind":"exporter","data_type":"logs","name":"file"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:86","msg":"Starting processors..."}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:98","msg":"Starting receivers..."}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:102","msg":"Receiver is starting...","kind":"receiver","name":"awscloudwatch","pipeline":"logs"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"pipelines/pipelines.go:106","msg":"Receiver started.","kind":"receiver","name":"awscloudwatch","pipeline":"logs"}
{"level":"info","ts":"2022-10-18T11:24:15.410-0400","caller":"service/service.go:107","msg":"Everything is ready. Begin running and processing data."}
^C{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"service/collector.go:199","msg":"Context done, terminating process","error":"context canceled"}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"service/service.go:116","msg":"Starting shutdown..."}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"pipelines/pipelines.go:118","msg":"Stopping receivers..."}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"pipelines/pipelines.go:125","msg":"Stopping processors..."}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"pipelines/pipelines.go:132","msg":"Stopping exporters..."}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"extensions/extensions.go:56","msg":"Stopping extensions..."}
{"level":"info","ts":"2022-10-18T11:24:18.581-0400","caller":"service/service.go:130","msg":"Shutdown complete."}

```
</details>



##### Checklist
- [x] Changes are tested
- [x] CI has passed
