### PR TITLE
feat(plugin): BindPlane OP Logs

### DIFF
--- a/plugins/bindplane_logs.yaml
+++ b/plugins/bindplane_logs.yaml
@@ -1,6 +1,6 @@
 version: 0.1.0
 title: BindPlane OP Logs
-description: Log parser for BindPlane OP observability pipeline.
+description: Log parser for BindPlane Observability Pipeline.
 parameters:
   - name: log_paths
     type: "[]string"

--- a/plugins/bindplane_logs.yaml
+++ b/plugins/bindplane_logs.yaml
@@ -1,0 +1,61 @@
+version: 0.1.0
+title: BindPlane OP Logs
+description: Log parser for BindPlane OP observability pipeline.
+parameters:
+  - name: log_paths
+    type: "[]string"
+    description: A list of file glob patterns that match the file paths to be read
+    default:
+      - "/var/log/bindplane/bindplane.log"
+  - name: exclude_file_log_path
+    type: "[]string"
+    description: A list of file glob patterns to exclude from reading
+    default:
+      - "/var/log/bindplane/bindplane-*.log.gz"
+  - name: start_at
+    description: At startup, where to start reading logs from the file (`beginning` or `end`)
+    type: string
+    supported:
+      - beginning
+      - end
+    default: end
+template: |
+  receivers:
+    filelog:
+      include:
+        {{ range $fp := .log_paths }}
+          - '{{ $fp }}'
+        {{ end }}
+      exclude:
+        {{ range $fp := .exclude_file_log_path }}
+          - '{{ $fp }}'
+        {{end}}
+      start_at: {{ .start_at }}
+      attributes:
+        log_type: "bindplane"
+      operators:
+        - type: json_parser
+          parse_from: body
+          parse_to: body
+          severity:
+            parse_from: body.level
+          timestamp:
+            parse_from: body.timestamp
+            layout_type: gotime
+            # ISO 8601
+            #       2022-10-18T17:46:17.580Z
+            #       2022-10-21T16:00:32.942-0400
+            layout: 2006-01-02T15:04:05.999Z0700
+        
+        # Cleanup raw severity and time fields after setting
+        # the entry's Severity and Timestamp.
+        - type: remove
+          field: body.level
+        - type: remove
+          field: body.timestamp
+
+  service:
+    pipelines:
+      logs:
+        receivers:
+          - filelog

--- a/plugins/bindplane_logs.yaml
+++ b/plugins/bindplane_logs.yaml
@@ -19,9 +19,17 @@ parameters:
       - beginning
       - end
     default: end
+  - name: offset_storage_dir
+    description: The directory that the offset storage file will be created
+    type: string
+    default: $OIQ_OTEL_COLLECTOR_HOME/storage
 template: |
+  extensions:
+    file_storage:
+      directory: {{ .offset_storage_dir }}
   receivers:
     filelog:
+      storage: file_storage
       include:
         {{ range $fp := .log_paths }}
           - '{{ $fp }}'
@@ -55,6 +63,7 @@ template: |
           field: body.timestamp
 
   service:
+    extensions: [file_storage]
     pipelines:
       logs:
         receivers:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Added plugin for [BindPlane OP](https://github.com/observIQ/bindplane-op/).
- Default path is `/var/log/bindplane/bindplane.log` on a linux system, which is the only supported install path at the moment.
- BindPlane rotates the log into gzip compressed files, which should always be excluded.
- Logs are always json encoded.
- Timestamps are ISO 8601.
- Severity parsing uses the default mapping.

![Screenshot from 2022-10-21 16-53-27](https://user-images.githubusercontent.com/23043836/197286865-011af247-8518-4ca7-b576-0e072635c7a1.png)

##### Checklist
- [x] Changes are tested
- [x] CI has passed
