### PR TITLE
fix(plugin): Container logs cri-o regex

### DIFF
--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.3.0
+version: 0.3.1
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -93,7 +93,7 @@ template: |
           # 2022-06-18T16:52:59.639114537Z stdout F {"message":"registered Stackdriver tracing","severity":"info","timestamp":"2022-06-18T16:52:59.639034532Z"}
           - id: containerd_cri_parser
             type: regex_parser
-            regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w)?(?P<log>.*)'
+            regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w)?\s+?(?P<log>.*)'
           - type: recombine
             source_identifier: attributes["log.file.name"]
             combine_field: attributes.log


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The cri-o regex works, but includes a leading space for the `log` capture groups value. You can see this happening [here](https://regex101.com/r/oMmHS1/1). This causes the json detection (line 134) to fail, meaning containerd logs work great but json message fields are not parsed.

The [updated regex](https://regex101.com/r/sObCdA/1) properly handles the space between the `partial` and `log` capture groups.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
