### PR TITLE
feat: Added temporary manual plugin doc github action check

### DIFF
--- a/.github/workflows/check_plugin_docs.yml
+++ b/.github/workflows/check_plugin_docs.yml
@@ -1,0 +1,27 @@
+name: check_plugin_docs
+on:
+  workflow_dispatch:
+  # pull_request:
+
+jobs:
+  check-fmt:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.18"
+          check-latest: true
+      - name: Plugin Doc Generation
+        run: make create-plugin-docs
+      - name: Check Changed Plugin Docs
+        uses: tj-actions/verify-changed-files@v12
+        id: verify-changed-files
+        with:
+          files: |
+             docs/plugins
+      - name: Verify No Plugin Doc Changes
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: exit 1


### PR DESCRIPTION
### Proposed Change
Adds github action to verify that plugin document generation is up to date. This currently is with a manual trigger, but will change to on pull request once verified.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
