### PR TITLE
feat: Added a parse_to field to iis plugin to allow choose how to parse logs

### DIFF
--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -16,7 +16,7 @@ Log parser for IIS
 | include_file_name_resolved | Enable to include file name resolved in logs | bool | `false` | false |  |
 | include_file_path_resolved | Enable to include file path resolved in logs | bool | `false` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:

--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -17,6 +17,7 @@ Log parser for IIS
 | include_file_path_resolved | Enable to include file path resolved in logs | bool | `false` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:
 
@@ -38,4 +39,5 @@ receivers:
       include_file_path_resolved: false
       start_at: end
       retain_raw_logs: false
+      parse_to: body
 ```

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -51,7 +51,7 @@ parameters:
       - end
     default: end
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
   - name: parse_to

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.3.1
+version: 0.4.0
 title: IIS
 description: Log parser for IIS
 parameters:

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -54,6 +54,13 @@ parameters:
     description: When enabled will preserve the original log message on the body in a `raw_log` key
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
 template: |
   receivers:
     # W3C format
@@ -87,13 +94,13 @@ template: |
 
       - type: csv_parser
         header: '{{ .w3c_header }}'
-        parse_to: body
+        parse_to: {{ .parse_to }}
         delimiter: " "
         ignore_quotes: true
 
       - type: severity_parser
-        if: 'body["sc-status"] != nil'
-        parse_from: 'body["sc-status"]'
+        if: '{{ .parse_to }}["sc-status"] != nil'
+        parse_from: '{{ .parse_to }}["sc-status"]'
         mapping:
             info: 2xx
             info2: 3xx
@@ -104,29 +111,29 @@ template: |
       - type: router
         routes:
         - output: add_timestamp
-          expr: 'body.date != nil and body.time != nil'
+          expr: '{{ .parse_to }}.date != nil and {{ .parse_to }}.time != nil'
         default: add_log_type
 
       # Combines data + time fields into timestamp field
       - id: add_timestamp
         type: add
-        field: body.timestamp
-        value: EXPR(body.date + " " + body.time)
+        field: {{ .parse_to }}.timestamp
+        value: EXPR({{ .parse_to }}.date + " " + {{ .parse_to }}.time)
 
       # Remove date field
       - id: remove_date
         type: remove
-        field: body.date
+        field: {{ .parse_to }}.date
 
       # Remove time field
       - id: remove_time
         type: remove
-        field: body.time
+        field: {{ .parse_to }}.time
 
       - id: time_parser
         type: time_parser
-        if: 'body.timestamp != nil'
-        parse_from: body.timestamp
+        if: '{{ .parse_to }}.timestamp != nil'
+        parse_from: {{ .parse_to }}.timestamp
         layout: '%Y-%m-%d %H:%M:%S'
         location: {{.timezone}}
 
@@ -135,7 +142,7 @@ template: |
         field: 'attributes.log_type'
         value: 'microsoft_iis'
 
-      {{ if .retain_raw_logs }}
+      {{ if and .retain_raw_logs (eq .parse_to "body")}}
       - id: move_raw_log
         type: move
         from: attributes.raw_log
@@ -170,9 +177,9 @@ template: |
       {{ end }}
       - type: regex_parser
         regex: '^(?P<c_ip>[^,]+), (?P<cs_username>[^,]+), (?P<date>[^,]+), (?P<time>[^,]+), (?P<s_sitename>[^,]+), (?P<s_computername>[^,]+), (?P<s_ip>[^,]+), (?P<time_taken>[^,]+), (?P<cs_bytes>[^,]+), (?P<sc_bytes>[^,]+), (?P<sc_status>[^,]+), (?P<sc_win32_status>[^,]+), (?P<cs_method>[^,]+), (?P<cs_uri_stem>[^,]+), (?P<cs_uri_query>[^,]+),$'
-        parse_to: body
+        parse_to: {{ .parse_to }}
         severity:
-          parse_from: 'body["sc_status"]'
+          parse_from: '{{ .parse_to }}["sc_status"]'
           mapping:
             info: 2xx
             info2: 3xx
@@ -181,26 +188,26 @@ template: |
 
       - id: add_timestamp
         type: add
-        if: 'body.date != nil and body.time != nil'
-        field: body.timestamp
-        value: EXPR(body.date + " " + body.time)
+        if: '{{ .parse_to }}.date != nil and {{ .parse_to }}.time != nil'
+        field: {{ .parse_to }}.timestamp
+        value: EXPR({{ .parse_to }}.date + " " + {{ .parse_to }}.time)
 
       # Remove date field
       - id: remove_date
         type: remove
-        if: 'body.date != nil'
-        field: body.date
+        if: '{{ .parse_to }}.date != nil'
+        field: {{ .parse_to }}.date
 
       # Remove time field
       - id: remove_time
         type: remove
-        if: 'body.time != nil'
-        field: body.time
+        if: '{{ .parse_to }}.time != nil'
+        field: {{ .parse_to }}.time
 
       - id: time_parser
         type: time_parser
-        if: 'body.timestamp != nil'
-        parse_from: body.timestamp
+        if: '{{ .parse_to }}.timestamp != nil'
+        parse_from: {{ .parse_to }}.timestamp
         layout: '%q/%g/%Y %H:%M:%S'
         location: {{.timezone}}
 
@@ -209,7 +216,7 @@ template: |
         field: 'attributes.log_type'
         value: 'microsoft_iis'
       
-      {{ if .retain_raw_logs }}
+      {{ if and .retain_raw_logs (eq .parse_to "body")}}
       - id: move_raw_log
         type: move
         from: attributes.raw_log
@@ -245,16 +252,16 @@ template: |
       - type: regex_parser
         # Note: The second, uncaptured group here is "Remote log name". This value is always "-" in IIS, so we don't include it
         regex: '^(?P<c_ip>[^\s]+) (?:[^\s]+) (?P<cs_username>[^\s]+) \[(?P<timestamp>[^]]+)\] "(?P<cs_method>[^\s]+) (?P<cs_uri_stem>[^\s?]+)(?:\?(?P<cs_uri_query>[^\s]+))? (?P<cs_version>[^\s]+)" (?P<sc_status>[^\s]+) (?P<sc_bytes>[^\s]+)$'
-        parse_to: body
+        parse_to: {{ .parse_to }}
         severity:
-          parse_from: 'body["sc_status"]'
+          parse_from: '{{ .parse_to }}["sc_status"]'
           mapping:
             info: 2xx
             info2: 3xx
             warn: 4xx
             error: 5xx
         timestamp:
-          parse_from: body.timestamp
+          parse_from: {{ .parse_to }}.timestamp
           layout: '%d/%b/%Y:%H:%M:%S %z'
       
       - id: add_log_type
@@ -262,7 +269,7 @@ template: |
         field: 'attributes.log_type'
         value: 'microsoft_iis'
 
-      {{ if .retain_raw_logs }}
+      {{ if and .retain_raw_logs (eq .parse_to "body")}}
       - id: move_raw_log
         type: move
         from: attributes.raw_log


### PR DESCRIPTION
### Proposed Change
Added a `parse_to` parameter to IIS log plugin to allow choosing where to parse logs to `body` or `attributes`. 

**Examples:**

<details>
  <summary>W3C Format</summary>
  Parse To Body:

  ```
    LogRecord #0
    ObservedTimestamp: 2022-11-09 16:51:35.957338 +0000 UTC
    Timestamp: 2020-11-03 16:13:15 +0000 UTC
    SeverityText: 200
    SeverityNumber: SEVERITY_NUMBER_INFO(9)
    Body: Map({\"c-ip\":\"10.33.121.100\",\"cs(Referer)\":\"-\",\"cs(User-Agent)\":\"Go-http-client/1.1\",\"cs-method\":\"GET\",\"cs-uri-query\":\"-\",\"cs-uri-stem\":\"/\",\"cs-username\":\"-\",\"s-ip\":\"10.33.104.51\",\"s-port\":\"80\",\"sc-status\":\"200\",\"sc-substatus\":\"0\",\"sc-win32-status\":\"0\",\"time-taken\":\"67\",\"timestamp\":\"2020-11-03 16:13:15\"})
    Attributes:
        -> log.file.name: Str(iis_w3c_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_w3c_format.log)
        -> log_type: Str(microsoft_iis)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```

  Parse to Attributes:

  ```
    LogRecord #0
    ObservedTimestamp: 2022-11-09 16:54:22.932403 +0000 UTC
    Timestamp: 2020-11-03 16:13:15 +0000 UTC
    SeverityText: 200
    SeverityNumber: SEVERITY_NUMBER_INFO(9)
    Body: Str(2020-11-03 16:13:15 10.33.104.51 GET / - 80 - 10.33.121.100 Go-http-client/1.1 - 200 0 0 67)
    Attributes:
        -> c-ip: Str(10.33.121.100)
        -> cs(Referer): Str(-)
        -> cs(User-Agent): Str(Go-http-client/1.1)
        -> cs-method: Str(GET)
        -> cs-uri-query: Str(-)
        -> cs-uri-stem: Str(/)
        -> cs-username: Str(-)
        -> log.file.name: Str(iis_w3c_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_w3c_format.log)
        -> log_type: Str(microsoft_iis)
        -> s-ip: Str(10.33.104.51)
        -> s-port: Str(80)
        -> sc-status: Str(200)
        -> sc-substatus: Str(0)
        -> sc-win32-status: Str(0)
        -> time-taken: Str(67)
        -> timestamp: Str(2020-11-03 16:13:15)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```
</details>

<details>
  <summary>IIS Format</summary>
  Parse To Body:

  ```
    Log #0
    Resource SchemaURL: 
    ScopeLogs #0
    ScopeLogs SchemaURL: 
    InstrumentationScope  
    LogRecord #0
    ObservedTimestamp: 2022-11-09 16:58:27.873276 +0000 UTC
    Timestamp: 2022-09-19 17:23:40 +0000 UTC
    SeverityText: 404
    SeverityNumber: SEVERITY_NUMBER_WARN(13)
    Body: Map({\"c_ip\":\"::1\",\"cs_bytes\":\"218\",\"cs_method\":\"GET\",\"cs_uri_query\":\"-\",\"cs_uri_stem\":\"/favicon.ico\",\"cs_username\":\"-\",\"s_computername\":\"windows-iis\",\"s_ip\":\"::1\",\"s_sitename\":\"W3SVC1\",\"sc_bytes\":\"5019\",\"sc_status\":\"404\",\"sc_win32_status\":\"2\",\"time_taken\":\"3\",\"timestamp\":\"9/19/2022 17:23:40\"})
    Attributes:
        -> log.file.name: Str(iis_iis_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_iis_format.log)
        -> log_type: Str(microsoft_iis)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```

  Parse to Attributes:

  ```
    LogRecord #0
    ObservedTimestamp: 2022-11-09 16:59:42.161884 +0000 UTC
    Timestamp: 2022-09-19 17:23:40 +0000 UTC
    SeverityText: 404
    SeverityNumber: SEVERITY_NUMBER_WARN(13)
    Body: Str(::1, -, 9/19/2022, 17:23:40, W3SVC1, windows-iis, ::1, 3, 218, 5019, 404, 2, GET, /favicon.ico, -,)
    Attributes:
        -> c_ip: Str(::1)
        -> cs_bytes: Str(218)
        -> cs_method: Str(GET)
        -> cs_uri_query: Str(-)
        -> cs_uri_stem: Str(/favicon.ico)
        -> cs_username: Str(-)
        -> log.file.name: Str(iis_iis_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_iis_format.log)
        -> log_type: Str(microsoft_iis)
        -> s_computername: Str(windows-iis)
        -> s_ip: Str(::1)
        -> s_sitename: Str(W3SVC1)
        -> sc_bytes: Str(5019)
        -> sc_status: Str(404)
        -> sc_win32_status: Str(2)
        -> time_taken: Str(3)
        -> timestamp: Str(9/19/2022 17:23:40)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```
</details>

<details>
  <summary>NCSA Format</summary>
  Parse To Body:

  ```
    LogRecord #0
    ObservedTimestamp: 2022-11-09 17:01:45.935228 +0000 UTC
    Timestamp: 2022-09-19 17:26:01 +0000 UTC
    SeverityText: 404
    SeverityNumber: SEVERITY_NUMBER_WARN(13)
    Body: Map({\"c_ip\":\"::1\",\"cs_method\":\"GET\",\"cs_uri_query\":\"\",\"cs_uri_stem\":\"/stuff\",\"cs_username\":\"-\",\"cs_version\":\"HTTP/1.1\",\"sc_bytes\":\"5007\",\"sc_status\":\"404\",\"timestamp\":\"19/Sep/2022:17:26:01 +0000\"})
    Attributes:
        -> log.file.name: Str(iis_ncsa_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_ncsa_format.log)
        -> log_type: Str(microsoft_iis)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```

  Parse to Attributes:

  ```
    LogRecord #0
    ObservedTimestamp: 2022-11-09 17:02:41.359628 +0000 UTC
    Timestamp: 2022-09-19 17:26:01 +0000 UTC
    SeverityText: 404
    SeverityNumber: SEVERITY_NUMBER_WARN(13)
    Body: Str(::1 - - [19/Sep/2022:17:26:01 +0000] \"GET /stuff HTTP/1.1\" 404 5007)
    Attributes:
        -> c_ip: Str(::1)
        -> cs_method: Str(GET)
        -> cs_uri_query: Str()
        -> cs_uri_stem: Str(/stuff)
        -> cs_username: Str(-)
        -> cs_version: Str(HTTP/1.1)
        -> log.file.name: Str(iis_ncsa_format.log)
        -> log.file.path: Str(/Users/cphelps/git/log-library/library/msiis/iis_ncsa_format.log)
        -> log_type: Str(microsoft_iis)
        -> sc_bytes: Str(5007)
        -> sc_status: Str(404)
        -> timestamp: Str(19/Sep/2022:17:26:01 +0000)
    Trace ID: 
    Span ID: 
    Flags: 0
  ```
</details>

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
