### PR TITLE
feat(container): Red Hat Universal base image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -180,9 +180,10 @@ nfpms:
       preinstall: ./scripts/package/preinstall.sh
       postinstall: ./scripts/package/postinstall.sh
 
-# Build container images with docker buildx (mutli arch builds)
+# Build container images with docker buildx (mutli arch builds).
 dockers:
-  - goos: linux
+  - id: ubuntu-amd64
+    goos: linux
     goarch: amd64
     ids:
       - collector
@@ -191,7 +192,7 @@ dockers:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}"
-    dockerfile: ./Dockerfile
+    dockerfile: ./docker/Dockerfile.ubuntu
     use: buildx
     build_flag_templates:
       - "--label=created={{.Date}}"
@@ -202,7 +203,8 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
-  - goos: linux
+  - id: ubuntu-arm64
+    goos: linux
     goarch: arm64
     ids:
       - collector
@@ -211,7 +213,44 @@ dockers:
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}"
-    dockerfile: ./Dockerfile
+    dockerfile: ./docker/Dockerfile.ubuntu
+    use: buildx
+    build_flag_templates:
+      - "--label=created={{.Date}}"
+      - "--label=title={{.ProjectName}}"
+      - "--label=revision={{.FullCommit}}"
+      - "--label=version={{.Version}}"
+      - "--platform=linux/arm64"
+    extra_files:
+      - plugins
+      - config/example.yaml
+
+  - id: ubi8-amd64
+    goos: linux
+    goarch: amd64
+    ids:
+      - collector
+    image_templates:
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    dockerfile: ./docker/Dockerfile.ubi8
+    use: buildx
+    build_flag_templates:
+      - "--label=created={{.Date}}"
+      - "--label=title={{.ProjectName}}"
+      - "--label=revision={{.FullCommit}}"
+      - "--label=version={{.Version}}"
+      - "--platform=linux/amd64"
+    extra_files:
+      - plugins
+      - config/example.yaml
+  - id: ubi8-arm64
+    goos: linux
+    goarch: arm64
+    ids:
+      - collector
+    image_templates:
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    dockerfile: ./docker/Dockerfile.ubi8
     use: buildx
     build_flag_templates:
       - "--label=created={{.Date}}"
@@ -243,6 +282,11 @@ docker_manifests:
     image_templates:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}"
+    skip_push: false
+  - name_template: "observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    image_templates:
+      - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     skip_push: false
 
 # https://goreleaser.com/customization/checksum/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ALLDOC := $(shell find . \( -name "*.md" -o -name "*.yaml" \) \
 ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort )
 
 # All source code files
-ALL_SRC := $(shell find . -name '*.go' -o -name '*.sh' -o -name 'Dockerfile' -type f | sort)
+ALL_SRC := $(shell find . -name '*.go' -o -name '*.sh' -o -name 'Dockerfile*' -type f | sort)
 
 OUTDIR=./dist
 GOOS ?= $(shell go env GOOS)

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -32,7 +32,7 @@ FROM openjdk:8u312-slim-buster as openjdk
 
 # Final Stage
 #
-FROM registry.access.redhat.com/ubi8-minimal:8.7
+FROM registry.access.redhat.com/ubi8:8.7
 WORKDIR /
 
 RUN dnf install -y \

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -1,0 +1,77 @@
+# Copyright  observIQ, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# JMX stage downloads the opentelemetry-jmx-metrics.jar used by JMX receivers
+#
+FROM curlimages/curl:7.82.0 as jmxjar
+ARG JMX_JAR_VERSION=v1.15.0
+USER root
+RUN curl -L \
+    --output /opentelemetry-java-contrib-jmx-metrics.jar \
+    "https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/${JMX_JAR_VERSION}/opentelemetry-jmx-metrics.jar"
+
+
+# OpenJDK stage provides the Java runtime used by JMX receivers.
+# Contrib's integration tests use openjdk 1.8.0
+# https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/testdata/Dockerfile.cassandra
+#
+FROM openjdk:8u312-slim-buster as openjdk
+
+
+# Final Stage
+#
+FROM registry.access.redhat.com/ubi8-minimal:8.7
+WORKDIR /
+
+RUN dnf install -y \
+        systemd tzdata ca-certificates && \
+  	dnf clean all && \
+  	rm -rf /var/cache/yum
+
+RUN groupadd --gid 10005 otel && \
+    adduser \
+    --system \
+    --no-create-home \
+    --uid 10005 \
+    --gid otel \
+    --shell /sbin/nologin \
+    otel
+
+RUN mkdir /etc/otel && chown otel:otel /etc/otel
+ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+
+COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
+ENV JAVA_HOME=/usr/local/openjdk-8
+ENV PATH=$PATH:/usr/local/openjdk-8/bin
+
+COPY observiq-otel-collector /collector/observiq-otel-collector
+COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
+COPY plugins /etc/otel/plugins
+
+RUN echo "output: stdout\nlevel: info\n" > /etc/otel/logging.yaml
+ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
+
+# Default config allows the collector to run without an injected config, which is required
+# when connecting to an OpAMP platform.
+COPY config/example.yaml /etc/otel/config.yaml
+RUN chown otel:otel /etc/otel/config.yaml
+
+USER otel
+WORKDIR /etc/otel
+
+# User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
+# connecting to an OpAMP platform.
+ENTRYPOINT [ "/collector/observiq-otel-collector" ]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -43,6 +43,7 @@ RUN dnf install -y \
 RUN groupadd --gid 10005 otel && \
     adduser \
     --system \
+    --home /etc/otel \
     --no-create-home \
     --uid 10005 \
     --gid otel \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -45,8 +45,10 @@ RUN apt-get update && \
 RUN adduser \
     --disabled-password \
     --gecos "" \
+    --home /etc/otel \
     --no-create-home \
     --uid 10005 \
+    --shell /sbin/nologin \
     otel
 
 RUN mkdir /etc/otel && chown otel:otel /etc/otel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -32,8 +32,15 @@ FROM openjdk:8u312-slim-buster as openjdk
 
 # Final Stage
 #
-FROM gcr.io/observiq-container-images/stanza-base:v1.2.2
+FROM ubuntu:22.04
 WORKDIR /
+
+RUN apt-get update && \
+    apt-get install -y \
+        --no-install-recommends \
+        systemd tzdata ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN adduser \
     --disabled-password \


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

For OpenShift deployments that require a RHEL certificate image, we will need a container image built on top of Red Hat's Universal base image.

- Moved Dockerfile --> docker/Dockerfile.ubuntu
- Added docker/Dockerfile.ubi8
- Added docker build config to goreleaser, with single `Minor }}.{{ .Patch }}-ubi8` tag
- Replaced `gcr.io/observiq-container-images/stanza-base:v1.2.2` with `ubuntu:22.04`
- Added `shell` and `home` options to `adduser` command

I opted to stop using the `stanza-base` image because I wanted to keep both Dockerfiles as identical as possible. This means the ubuntu image needs the `apt` commands for installing the systemd, tzdata, and ca-certificates packages. Stanza base image is nice because it pins our package versions in a nice way, but it is additional maintenance overhead that we can probably do without, and it does not work for rhel unless we re-work some things (Add a ubi8 base image). We could always do this in the future.

The images are pretty big, 509MB and 630MB (rhel). This is mainly from systemd and java's installation. We could probably justify building a minimal image in the future, which contains only the collector binary and plugins.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
