### PR TITLE
update to parse_to field to allow to parse to body or attributes

### DIFF
--- a/docs/plugins/apache_combined_logs.md
+++ b/docs/plugins/apache_combined_logs.md
@@ -8,7 +8,8 @@ Log parser for Apache combined format
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_path | Paths to Apache combined formatted log files | []string | `[/var/log/apache_combined.log]` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:
 
@@ -22,4 +23,5 @@ receivers:
       file_path: [/var/log/apache_combined.log]
       start_at: end
       retain_raw_logs: false
+      parse_to: body
 ```

--- a/plugins/apache_combined_logs.yaml
+++ b/plugins/apache_combined_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 title: Apache Combined
 description: Log parser for Apache combined format
 parameters:
@@ -15,9 +15,16 @@ parameters:
       - end
     default: end
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
 template: |
   receivers:
     filelog:
@@ -29,31 +36,31 @@ template: |
       attributes:
         log_type: apache_combined
       operators:
-        {{ if .retain_raw_logs }}
+        {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: save_raw_log
           type: copy
-          from: body
+          from: { .parse_to }}.
           to: attributes.raw_log
         {{ end }}
         - type: regex_parser
           regex: '^(?P<remote_addr>[^ ]*) (?P<remote_host>[^ ]*) (?P<remote_user>[^ ]*) \[(?P<time>[^\]]*)\] "(?P<method>\S+) +(?P<path>[^ ]*)( (?P<protocol>[^/]*)/(?P<protocol_version>[^\"]*)|[^\"]*)?" (?P<status>[^ ]*) (?P<body_bytes_sent>[^ ]*) "(?P<http_referer>[^\"]*)" "(?P<http_user_agent>[^\"]*)'
-          parse_to: body
+          parse_to: {{ .parse_to }}
           timestamp:
-            parse_from: body.time
+            parse_from: {{ .parse_to }}.time
             layout: '%d/%b/%Y:%H:%M:%S %z'
           severity:
-            parse_from: body.status
+            parse_from: {{ .parse_to }}.status
             preset: none
             mapping:
               info: 2xx
               info2: 3xx
               warn: 4xx
               error: 5xx
-        {{ if .retain_raw_logs }}
+        {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
           from: attributes.raw_log
-          to: body.raw_log
+          to: {{ .parse_to }}.raw_log
         {{ end }}
 
 

--- a/plugins/apache_combined_logs.yaml
+++ b/plugins/apache_combined_logs.yaml
@@ -36,10 +36,10 @@ template: |
       attributes:
         log_type: apache_combined
       operators:
-        {{ if and .retain_raw_logs (eq .parse_to "body")}}
+        {{ if .retain_raw_logs }}
         - id: save_raw_log
           type: copy
-          from: { .parse_to }}.
+          from: body
           to: attributes.raw_log
         {{ end }}
         - type: regex_parser
@@ -60,7 +60,7 @@ template: |
         - id: move_raw_log
           type: move
           from: attributes.raw_log
-          to: {{ .parse_to }}.raw_log
+          to: body.raw_log
         {{ end }}
 
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->
Added a parse_to parameter to apache combined log plugin to allow choosing where to parse logs to body or attributes.

**Examples:**
Parse to body:

```
LogRecord #0
ObservedTimestamp: 2022-11-14 18:50:33.744205 +0000 UTC
Timestamp: 2021-06-17 16:06:46 +0000 UTC
SeverityText: 304
SeverityNumber: SEVERITY_NUMBER_INFO2(10)
Body: Map({\"body_bytes_sent\":\"64162\",\"http_referer\":\"https://www.seniordisintermediate.biz/models\",\"http_user_agent\":\"Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_3) AppleWebKit/5310 (KHTML, like Gecko) Chrome/39.0.854.0 Mobile Safari/5310\",\"method\":\"POST\",\"path\":\"/v1/login\",\"protocol\":\"HTTP\",\"protocol_version\":\"2.0\",\"remote_addr\":\"129.53.82.110\",\"remote_host\":\"-\",\"remote_user\":\"-\",\"status\":\"304\",\"time\":\"17/Jun/2021:12:06:46 -0400\"})
Attributes:
     -> log.file.name: Str(apache-combined.log)
     -> log_type: Str(apache_combined)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to Attributes:
```
LogRecord #0
ObservedTimestamp: 2022-11-14 18:51:26.282263 +0000 UTC
Timestamp: 2021-06-17 16:06:46 +0000 UTC
SeverityText: 304
SeverityNumber: SEVERITY_NUMBER_INFO2(10)
Body: Str(129.53.82.110 - - [17/Jun/2021:12:06:46 -0400] \"POST /v1/login HTTP/2.0\" 304 64162 \"https://www.seniordisintermediate.biz/models\" \"Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_3) AppleWebKit/5310 (KHTML, like Gecko) Chrome/39.0.854.0 Mobile Safari/5310\")
Attributes:
     -> body_bytes_sent: Str(64162)
     -> http_referer: Str(https://www.seniordisintermediate.biz/models)
     -> http_user_agent: Str(Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_6_3) AppleWebKit/5310 (KHTML, like Gecko) Chrome/39.0.854.0 Mobile Safari/5310)
     -> log.file.name: Str(apache-combined.log)
     -> log_type: Str(apache_combined)
     -> method: Str(POST)
     -> path: Str(/v1/login)
     -> protocol: Str(HTTP)
     -> protocol_version: Str(2.0)
     -> remote_addr: Str(129.53.82.110)
     -> remote_host: Str(-)
     -> remote_user: Str(-)
     -> status: Str(304)
     -> time: Str(17/Jun/2021:12:06:46 -0400)
Trace ID: 
Span ID: 
Flags: 0
```

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
