### PR TITLE
feat: Add parse_to parameter field to file_logs plugin

### DIFF
--- a/docs/plugins/file_logs.md
+++ b/docs/plugins/file_logs.md
@@ -16,7 +16,8 @@ Log parser for generic files
 | include_file_name | Whether to add the file name as the attribute log.file.name. | bool | `true` | false |  |
 | include_file_path | Whether to add the file path as the attribute log.file.path. | bool | `false` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 | offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_HOME/storage` | false |  |
 
 ## Example Config:
@@ -37,5 +38,6 @@ receivers:
       include_file_path: false
       start_at: end
       retain_raw_logs: false
+      parse_to: body
       offset_storage_dir: $OIQ_OTEL_COLLECTOR_HOME/storage
 ```

--- a/plugins/file_logs.yaml
+++ b/plugins/file_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.3.0
 title: File
 description: Log parser for generic files
 parameters:
@@ -59,9 +59,16 @@ parameters:
       - end
     default: end
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
@@ -97,13 +104,13 @@ template: |
         {{ end }}
         {{ if (eq .parse_format "json")}}
         - type: json_parser
-          parse_to: body
+          parse_to: {{ .parse_to }}
         {{ end }}
 
         {{ if (eq .parse_format "regex")}}
         - type: regex_parser
           regex: {{ .regex_pattern }}
-          parse_to: body
+          parse_to: {{ .parse_to }}
         {{ end }}
 
         - id: add_type
@@ -111,7 +118,7 @@ template: |
           field: attributes.log_type
           value: {{ .log_type }}
 
-        {{ if .retain_raw_logs }}
+        {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
           from: attributes.raw_log


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

Added a parse_to parameter to file_logs plugin to allow choosing where to parse logs to body or attributes.

**Examples**

Using regex
```bash
regex_pattern: ^(?P<date>[^ ]*) (?P<something>[^ ]*) (?P<something2>[^ ]*)  (?P<rest>.*)$
```
for log
```log
2019-02-06T09:22:27.347-0500 I CONTROL  [initandlisten] db version v3.6.2
```

parse to Body:
```LogRecord #0
ObservedTimestamp: 2022-11-14 20:31:48.093544 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
SeverityText: 
SeverityNumber: SEVERITY_NUMBER_UNSPECIFIED(0)
Body: Map({\"date\":\"2019-02-06T09:22:27.347-0500\",\"rest\":\"[initandlisten] db version v3.6.2\",\"something\":\"I\",\"something2\":\"CONTROL\"})
Attributes:
     -> log.file.name: Str(mongodb.log)
     -> log_type: Str(file)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to Attributes:
```
LogRecord #0
ObservedTimestamp: 2022-11-14 20:32:40.528533 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
SeverityText: 
SeverityNumber: SEVERITY_NUMBER_UNSPECIFIED(0)
Body: Str(2019-02-06T09:22:27.347-0500 I CONTROL  [initandlisten] db version v3.6.2)
Attributes:
     -> date: Str(2019-02-06T09:22:27.347-0500)
     -> log.file.name: Str(mongodb.log)
     -> log_type: Str(file)
     -> rest: Str([initandlisten] db version v3.6.2)
     -> something: Str(I)
     -> something2: Str(CONTROL)
Trace ID: 
Span ID: 
Flags: 0
```

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
