### PR TITLE
feat: Monitor Collector Status in Managed Mode

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -153,9 +153,12 @@ func (c *collector) Stop() {
 	c.svc = nil
 }
 
-// Restart will restart the collector.
+// Restart will restart the collector. It will also reset the status channel.
+// After calling restart call Status() to get a handle to the new channel.
 func (c *collector) Restart(ctx context.Context) error {
 	c.Stop()
+	// Reset status channel so it's not polluted by the collector shutting down and restarting
+	c.statusChan = make(chan *Status, 10)
 	return c.Run(ctx)
 }
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -120,6 +120,9 @@ func (c *collector) Run(ctx context.Context) error {
 				}
 
 				c.sendStatus(false, true, panicErr)
+
+				// Send error to startup channel so it doesn't wait for a timeout if a panic occurs.
+				startupErr <- panicErr
 			}
 		}()
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -121,9 +121,6 @@ func TestCollectorRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	status = <-collector.Status()
-	require.False(t, status.Running)
-
-	status = <-collector.Status()
 	require.True(t, status.Running)
 
 	collector.Stop()

--- a/internal/service/standalone.go
+++ b/internal/service/standalone.go
@@ -62,6 +62,7 @@ func (s StandaloneCollectorService) monitorStatus() {
 	for {
 		select {
 		case status := <-statusChan:
+			// This will catch panics and errors
 			if status.Err != nil {
 				s.errChan <- status.Err
 			} else if !status.Running {

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -497,10 +497,10 @@ func TestClientDisconnect(t *testing.T) {
 		opampClient:   mockOpAmpClient,
 		collector:     mockCollector,
 		reportManager: report.GetManager(),
+		logger:        zap.NewNop(),
 	}
 
 	// Start collector monitoring to ensure this is shut down properly
-	c.collectorMntrWg.Add(1)
 	c.startCollectorMonitoring(ctx)
 
 	var err error

--- a/opamp/observiq/observiq_client_test.go
+++ b/opamp/observiq/observiq_client_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/observiq/observiq-otel-collector/collector"
 	colmocks "github.com/observiq/observiq-otel-collector/collector/mocks"
 	"github.com/observiq/observiq-otel-collector/internal/report"
 	"github.com/observiq/observiq-otel-collector/internal/version"
@@ -337,8 +338,10 @@ func TestClientConnect(t *testing.T) {
 					assert.Equal(t, protobufs.PackageStatus_InstallFailed, status.Packages[packagestate.CollectorPackageName].Status)
 				})
 
+				statusChannel := make(chan *collector.Status)
 				mockCollector := colmocks.NewMockCollector(t)
 				mockCollector.On("Run", mock.Anything).Return(nil)
+				mockCollector.On("Status").Return((<-chan *collector.Status)(statusChannel))
 
 				c := &Client{
 					opampClient:   mockOpAmpClient,
@@ -355,6 +358,13 @@ func TestClientConnect(t *testing.T) {
 
 				err := c.Connect(context.Background())
 				assert.ErrorIs(t, err, expectedErr)
+
+				// Cleanup
+				c.collectorMntrCancel()
+				assert.Eventually(t, func() bool {
+					c.collectorMntrWg.Wait()
+					return true
+				}, 2*time.Second, 100*time.Millisecond)
 			},
 		},
 		{
@@ -363,8 +373,10 @@ func TestClientConnect(t *testing.T) {
 				mockOpAmpClient := mocks.NewMockOpAMPClient(t)
 				mockOpAmpClient.On("SetAgentDescription", mock.Anything).Return(nil)
 
+				statusChannel := make(chan *collector.Status)
 				mockCollector := colmocks.NewMockCollector(t)
 				mockCollector.On("Run", mock.Anything).Return(nil)
+				mockCollector.On("Status").Return((<-chan *collector.Status)(statusChannel))
 
 				mockPackagesStateProvider := mocks.NewMockPackagesStateProvider(t)
 
@@ -417,6 +429,13 @@ func TestClientConnect(t *testing.T) {
 
 				err := c.Connect(context.Background())
 				assert.NoError(t, err)
+
+				// Cleanup
+				c.collectorMntrCancel()
+				assert.Eventually(t, func() bool {
+					c.collectorMntrWg.Wait()
+					return true
+				}, 2*time.Second, 100*time.Millisecond)
 			},
 		},
 		{
@@ -470,6 +489,8 @@ func TestClientDisconnect(t *testing.T) {
 	mockOpAmpClient := new(mocks.MockOpAMPClient)
 	mockOpAmpClient.On("Stop", ctx).Return(nil)
 	mockCollector := colmocks.NewMockCollector(t)
+	statusChan := make(chan *collector.Status)
+	mockCollector.On("Status").Return((<-chan *collector.Status)(statusChan))
 	mockCollector.On("Stop").Return()
 
 	c := &Client{
@@ -478,7 +499,18 @@ func TestClientDisconnect(t *testing.T) {
 		reportManager: report.GetManager(),
 	}
 
-	c.Disconnect(ctx)
+	// Start collector monitoring to ensure this is shut down properly
+	c.collectorMntrWg.Add(1)
+	c.startCollectorMonitoring(ctx)
+
+	var err error
+	waitFunc := func() bool {
+		err = c.Disconnect(ctx)
+		return true
+	}
+
+	require.Eventually(t, waitFunc, time.Second*2, time.Millisecond*100)
+	assert.NoError(t, err)
 	assert.True(t, c.safeGetDisconnecting())
 	mockOpAmpClient.AssertExpectations(t)
 }

--- a/opamp/observiq/reload_funcs.go
+++ b/opamp/observiq/reload_funcs.go
@@ -125,7 +125,7 @@ func collectorReload(client *Client, collectorConfigPath string) opamp.ReloadFun
 		}
 
 		// Stop collector monitoring as we are going to restart it
-		client.collectorMntrCancel()
+		client.stopCollectorMonitoring()
 
 		// Setup new monitoring after collector has been restarted
 		defer client.startCollectorMonitoring(context.Background())

--- a/opamp/observiq/reload_funcs.go
+++ b/opamp/observiq/reload_funcs.go
@@ -124,6 +124,12 @@ func collectorReload(client *Client, collectorConfigPath string) opamp.ReloadFun
 			return false, err
 		}
 
+		// Stop collector monitoring as we are going to restart it
+		client.collectorMntrCancel()
+
+		// Setup new monitoring after collector has been restarted
+		defer client.startCollectorMonitoring(context.Background())
+
 		// Reload collector
 		if err := client.collector.Restart(context.Background()); err != nil {
 			// Rollback file

--- a/opamp/observiq/reload_funcs_test.go
+++ b/opamp/observiq/reload_funcs_test.go
@@ -221,6 +221,7 @@ func Test_collectorReload(t *testing.T) {
 
 				client := &Client{
 					collector: mockCollector,
+					logger:    zap.NewNop(),
 				}
 
 				// Setup Context to mock out already running collector monitor
@@ -238,9 +239,8 @@ func Test_collectorReload(t *testing.T) {
 				assert.Equal(t, currContents, data)
 
 				// Cleanup
-				client.collectorMntrCancel()
 				assert.Eventually(t, func() bool {
-					client.collectorMntrWg.Wait()
+					client.stopCollectorMonitoring()
 					return true
 				}, 2*time.Second, 100*time.Millisecond)
 			},
@@ -265,6 +265,7 @@ func Test_collectorReload(t *testing.T) {
 
 				client := &Client{
 					collector: mockCollector,
+					logger:    zap.NewNop(),
 				}
 
 				// Setup Context to mock out already running collector monitor
@@ -283,9 +284,8 @@ func Test_collectorReload(t *testing.T) {
 				assert.Equal(t, newContents, data)
 
 				// Cleanup
-				client.collectorMntrCancel()
 				assert.Eventually(t, func() bool {
-					client.collectorMntrWg.Wait()
+					client.stopCollectorMonitoring()
 					return true
 				}, 2*time.Second, 100*time.Millisecond)
 			},


### PR DESCRIPTION
### Proposed Change
- Added `recover` to handle panics from the main collector goroutine
- Added logic to monitor collector status in managed mode

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
