### PR TITLE
feat: Added a parse_to field to Kubelet plugin to allow choose how to parse logs

### DIFF
--- a/docs/plugins/kubelet_logs.md
+++ b/docs/plugins/kubelet_logs.md
@@ -9,7 +9,8 @@ Log parser for Kubelet journald logs
 | journald_directory | Directory containing journal files to read entries from | string |  | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:
 
@@ -23,4 +24,5 @@ receivers:
       start_at: end
       timezone: UTC
       retain_raw_logs: false
+      parse_to: body
 ```

--- a/plugins/kubelet_logs.yaml
+++ b/plugins/kubelet_logs.yaml
@@ -17,9 +17,16 @@ parameters:
     type: timezone
     default: UTC
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
 template: |
   receivers:
     journald:
@@ -47,9 +54,9 @@ template: |
           # Parse kubelet klog formatted message
           - type: regex_parser
             regex: '(?P<severity>\w)(?P<timestamp>\d{4} \d{2}:\d{2}:\d{2}.\d+)\s+(?P<pid>\d+)\s+(?P<src>[^:]*):(?P<src_line>[^\]]*)\] (?P<message>.*)'
-            parse_to: body
+            parse_to: {{ .parse_to }}
             severity:
-              parse_from: body.severity
+              parse_from: {{ .parse_to }}.severity
               mapping:
                 debug: d
                 info: i
@@ -57,13 +64,13 @@ template: |
                 error: e
                 fatal: c
             timestamp:
-              parse_from: body.timestamp
+              parse_from: {{ .parse_to }}.timestamp
               layout: '%m%d %H:%M:%S.%s'
               location: {{ .timezone }}
           - type: add
             field: attributes.log_type
             value: kubelet
-          {{ if .retain_raw_logs }}
+          {{ if and .retain_raw_logs (eq .parse_to "body")}}
           - id: move_raw_log
             type: move
             from: attributes.raw_log

--- a/plugins/kubelet_logs.yaml
+++ b/plugins/kubelet_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.3.0
 title: Kubernetes Kubelet
 description: Log parser for Kubelet journald logs
 parameters:


### PR DESCRIPTION
### Proposed Change
Added a `parse_to` parameter to IIS log plugin to allow choosing where to parse logs to `body` or `attributes`. 

@jsirianni Validated this in GCP:

With body parsing:
![Screenshot from 2022-11-15 10-35-09](https://user-images.githubusercontent.com/11877763/201970745-3aeb997e-d109-4a7c-bec0-c6f9be764263.png)

With attribute parsing
![Screenshot from 2022-11-15 10-34-03](https://user-images.githubusercontent.com/11877763/201970799-6ad72704-e442-4d8e-aea1-cbd3693d1bdc.png)

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
