### PR TITLE
feat: Add parse to parameter for syslog

### DIFF
--- a/docs/plugins/syslog_logs.md
+++ b/docs/plugins/syslog_logs.md
@@ -17,7 +17,8 @@ Log receiver for Syslog
 | tls_min_version | Minimum version of TLS to use, client will negotiate highest possible | string | `1.2` | false | `1.0`, `1.1`, `1.2`, `1.3` |
 | max_log_size | Maximum number of bytes for a single TCP message. Only applicable when connection_type is TCP | string | `1024kib` | false |  |
 | data_flow | High mode keeps all entries, low mode filters out log entries with a debug severity of (7) | string | `high` | false | `high`, `low` |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:
 
@@ -37,4 +38,5 @@ receivers:
       max_log_size: 1024kib
       data_flow: high
       retain_raw_logs: false
+      parse_to: body
 ```

--- a/plugins/syslog_logs.yaml
+++ b/plugins/syslog_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.3.0
 title: Syslog
 description: Log receiver for Syslog
 parameters:
@@ -60,9 +60,16 @@ parameters:
       - low
     default: high
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
 template: |
   receivers:
     syslog:
@@ -88,8 +95,8 @@ template: |
         {{ if .retain_raw_logs }}
         - id: move_raw_log
           type: move
-          from: body
-          to: body.raw_log
+          from: {{ .parse_to }}
+          to: {{ .parse_to }}.raw_log
         {{ end }}
         {{ if eq .data_flow "low" }}
         # Filter entries with debug severity (7); There is no actual severity field left by the syslog parser,
@@ -106,62 +113,64 @@ template: |
             - attributes.version
         {{ end }}
 
-        # Move all retained attributes to the body
-        - id: move_appname
-          type: move
-          if: "attributes.appname != nil"
-          from: attributes.appname
-          to: body.appname
-        - id: move_facility
-          type: move
-          if: "attributes.facility != nil"
-          from: attributes.facility
-          to: body.facility
-        - id: move_hostname
-          type: move
-          if: "attributes.hostname != nil"
-          from: attributes.hostname
-          to: body.hostname
-        - id: move_message
-          type: move
-          if: "attributes.message != nil"
-          from: attributes.message
-          to: body.message
-        - id: move_msg_id
-          type: move
-          if: "attributes.msg_id != nil"
-          from: attributes.msg_id
-          to: body.msg_id
-        - id: move_priority
-          type: move
-          if: "attributes.priority != nil"
-          from: attributes.priority
-          to: body.priority
-        - id: move_proc_id
-          type: move
-          if: "attributes.proc_id != nil"
-          from: attributes.proc_id
-          to: body.proc_id
-        - id: move_severity
-          type: move
-          if: "attributes.severity != nil"
-          from: attributes.severity
-          to: body.severity
-        - id: move_structured_data
-          type: move
-          if: "attributes.structured_data != nil"
-          from: attributes.structured_data
-          to: body.structured_data
-        - id: move_timestamp
-          type: move
-          if: "attributes.timestamp != nil"
-          from: attributes.timestamp
-          to: body.timestamp
-        - id: move_version
-          type: move
-          if: "attributes.version != nil"
-          from: attributes.version
-          to: body.version
+        {{ if eq .parse_to "body" }}
+          # Move all retained attributes to the body
+          - id: move_appname
+            type: move
+            if: "attributes.appname != nil"
+            from: attributes.appname
+            to: body.appname
+          - id: move_facility
+            type: move
+            if: "attributes.facility != nil"
+            from: attributes.facility
+            to: body.facility
+          - id: move_hostname
+            type: move
+            if: "attributes.hostname != nil"
+            from: attributes.hostname
+            to: body.hostname
+          - id: move_message
+            type: move
+            if: "attributes.message != nil"
+            from: attributes.message
+            to: body.message
+          - id: move_msg_id
+            type: move
+            if: "attributes.msg_id != nil"
+            from: attributes.msg_id
+            to: body.msg_id
+          - id: move_priority
+            type: move
+            if: "attributes.priority != nil"
+            from: attributes.priority
+            to: body.priority
+          - id: move_proc_id
+            type: move
+            if: "attributes.proc_id != nil"
+            from: attributes.proc_id
+            to: body.proc_id
+          - id: move_severity
+            type: move
+            if: "attributes.severity != nil"
+            from: attributes.severity
+            to: body.severity
+          - id: move_structured_data
+            type: move
+            if: "attributes.structured_data != nil"
+            from: attributes.structured_data
+            to: body.structured_data
+          - id: move_timestamp
+            type: move
+            if: "attributes.timestamp != nil"
+            from: attributes.timestamp
+            to: body.timestamp
+          - id: move_version
+            type: move
+            if: "attributes.version != nil"
+            from: attributes.version
+            to: body.version
+        {{end}}
 
   service:
     pipelines:

--- a/plugins/syslog_logs.yaml
+++ b/plugins/syslog_logs.yaml
@@ -95,7 +95,7 @@ template: |
         {{ if .retain_raw_logs }}
         - id: move_raw_log
           type: move
-          from: {{ .parse_to }}
+          from: body
           to: {{ .parse_to }}.raw_log
         {{ end }}
         {{ if eq .data_flow "low" }}


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

Added a parse_to parameter to syslog plugin to allow choosing where to parse logs to body or attributes.

** Example
Parse to body
```
LogRecord #0
ObservedTimestamp: 2022-11-15 15:32:17.81204 +0000 UTC
Timestamp: 2022-09-15 18:01:57.756788 +0000 UTC
SeverityText: info
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Map({\"appname\":\"content-library\",\"facility\":16,\"hostname\":\"vcsa\",\"message\":\"2022-09-15T18:01:57.756Z | DEBUG    | opId-bdfbb34a-1a9c-4d01-9ea3-2a415f97c245 | cls-background-executor-2 | StsTrustChainImpl              | Refreshing cert chain from sso server...\",\"priority\":134,\"version\":1})
Trace ID: 
Span ID: 
Flags: 0
```

Parse to attributes
```
LogRecord #0
ObservedTimestamp: 2022-11-15 15:33:13.109556 +0000 UTC
Timestamp: 2022-09-15 18:01:57.756788 +0000 UTC
SeverityText: info
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Str(<134>1 2022-09-15T18:01:57.756788+00:00 vcsa content-library - - - 2022-09-15T18:01:57.756Z | DEBUG    | opId-bdfbb34a-1a9c-4d01-9ea3-2a415f97c245 | cls-background-executor-2 | StsTrustChainImpl              | Refreshing cert chain from sso server...)
Attributes:
     -> appname: Str(content-library)
     -> facility: Int(16)
     -> hostname: Str(vcsa)
     -> message: Str(2022-09-15T18:01:57.756Z | DEBUG    | opId-bdfbb34a-1a9c-4d01-9ea3-2a415f97c245 | cls-background-executor-2 | StsTrustChainImpl              | Refreshing cert chain from sso server...)
     -> priority: Int(134)
     -> version: Int(1)
Trace ID: 
Span ID: 
Flags: 0
```

Added if condition when parse to body since default is attributes but I am not sure if this is the preferable option for the `move` type.

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
