### PR TITLE
feat: Add parse_to parameter to tomcat

### DIFF
--- a/docs/plugins/tomcat_logs.md
+++ b/docs/plugins/tomcat_logs.md
@@ -8,12 +8,13 @@ Log parser for Apache Tomcat
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | enable_access_log | Enable to collect Apache Tomcat access logs | bool | `true` | false |  |
 | access_log_path | Path to access log file | []string | `[/usr/local/tomcat/logs/localhost_access_log.*.txt]` | false |  |
-| access_retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| access_retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | enable_catalina_log | Enable to collect Apache Tomcat catalina logs | bool | `true` | false |  |
 | catalina_log_path | Path to catalina log file | []string | `[/usr/local/tomcat/logs/catalina.out]` | false |  |
 | catalina_retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
 | timezone | Timezone to use when parsing the timestamp. | timezone | `UTC` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 | offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_HOME/storage` | false |  |
 
 ## Example Config:
@@ -33,5 +34,6 @@ receivers:
       catalina_retain_raw_logs: false
       start_at: end
       timezone: UTC
+      parse_to: body
       offset_storage_dir: $OIQ_OTEL_COLLECTOR_HOME/storage
 ```

--- a/plugins/tomcat_logs.yaml
+++ b/plugins/tomcat_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.2.0
+version: 0.3.0
 title: Apache Tomcat
 description: Log parser for Apache Tomcat
 parameters:
@@ -12,7 +12,7 @@ parameters:
     default:
       - "/usr/local/tomcat/logs/localhost_access_log.*.txt"
   - name: access_retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
   - name: enable_catalina_log
@@ -39,6 +39,13 @@ parameters:
     description: Timezone to use when parsing the timestamp.
     type: timezone
     default: UTC
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
@@ -67,19 +74,19 @@ template: |
         {{ end }}
         - type: regex_parser
           regex: '(?P<remote_host>[^\s]+) - (?P<remote_user>[^\s]+) \[(?P<timestamp>[^\]]+)\] "(?P<method>[A-Z]+) (?P<path>[^\s]+)[^"]+" (?P<status>\d+) (?P<bytes_sent>[^\s]+)'
-          parse_to: body
+          parse_to: {{ .parse_to }}
           timestamp:
-            parse_from: body.timestamp
+            parse_from: {{ .parse_to }}.timestamp
             location: {{ .timezone }}
             layout: '%d/%b/%Y:%H:%M:%S %z'
           severity:
-            parse_from: body.status
+            parse_from: {{ .parse_to }}.status
             mapping:
               info: 2xx
               info2: 3xx
               warn: 4xx
               error: 5xx
-        {{ if .access_retain_raw_logs }}
+        {{ if and .access_retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
           from: attributes.raw_log
@@ -108,13 +115,13 @@ template: |
         {{ end }}
         - type: regex_parser
           regex: '(?P<timestamp>[0-9]{2}-[A-Za-z]{3}-[0-9]{4} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3})\s(?P<tomcat_severity>[A-Z]*)\s\[(?P<thread>[\w-]*)\]\s(?P<tc_source>[^ ]*)\s(?P<message>[\s\S]+)'
-          parse_to: body
+          parse_to: {{ .parse_to }}
           timestamp:
-            parse_from: body.timestamp
+            parse_from: {{ .parse_to }}.timestamp
             location: {{ .timezone }}
             layout: '%d-%b-%Y %H:%M:%S.%L'
           severity:
-            parse_from: body.tomcat_severity
+            parse_from: {{ .parse_to }}.tomcat_severity
             mapping:
               info: config
               fatal2: severe
@@ -122,7 +129,7 @@ template: |
                 - fine
                 - finer
                 - finest
-        {{ if .catalina_retain_raw_logs }}
+        {{ if and .catalina_retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
           from: attributes.raw_log


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

Added a parse_to parameter to tomcat log plugin to allow choosing where to parse logs to body or attributes.

**Examples

Parse to body with access log
```
LogRecord #0
ObservedTimestamp: 2022-11-15 16:21:47.113723 +0000 UTC
Timestamp: 2021-01-21 04:26:02 +0000 UTC
SeverityText: 200
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Map({\"bytes_sent\":\"11216\",\"method\":\"GET\",\"path\":\"/\",\"remote_host\":\"10.33.104.26\",\"remote_user\":\"-\",\"status\":\"200\",\"timestamp\":\"20/Jan/2021:23:26:02 -0500\"})
Attributes:
     -> log.file.name: Str(tomcat_access_log.log)
     -> log_type: Str(tomcat.access)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to body catalina log
```
LogRecord #0
ObservedTimestamp: 2022-11-15 16:22:36.314092 +0000 UTC
Timestamp: 2021-01-20 12:51:42.078 +0000 UTC
SeverityText: INFO
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Map({\"message\":\"Server version name:   Apache Tomcat/9.0.41\",\"tc_source\":\"org.apache.catalina.startup.VersionLoggerListener.log\",\"thread\":\"main\",\"timestamp\":\"20-Jan-2021 12:51:42.078\",\"tomcat_severity\":\"INFO\"})
Attributes:
     -> log.file.name: Str(tomcat_catalina.log)
     -> log_type: Str(tomcat.catalina)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to attributes access log
```
LogRecord #0
ObservedTimestamp: 2022-11-15 16:23:37.288339 +0000 UTC
Timestamp: 2021-01-21 04:26:02 +0000 UTC
SeverityText: 200
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Str(10.33.104.26 - - [20/Jan/2021:23:26:02 -0500] \"GET / HTTP/1.1\" 200 11216)
Attributes:
     -> bytes_sent: Str(11216)
     -> log.file.name: Str(tomcat_access_log.log)
     -> log_type: Str(tomcat.access)
     -> method: Str(GET)
     -> path: Str(/)
     -> remote_host: Str(10.33.104.26)
     -> remote_user: Str(-)
     -> status: Str(200)
     -> timestamp: Str(20/Jan/2021:23:26:02 -0500)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to attributes catalina log
```
LogRecord #0
ObservedTimestamp: 2022-11-15 16:23:14.288002 +0000 UTC
Timestamp: 2021-01-20 12:51:42.078 +0000 UTC
SeverityText: INFO
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Str(20-Jan-2021 12:51:42.078 INFO [main] org.apache.catalina.startup.VersionLoggerListener.log Server version name:   Apache Tomcat/9.0.41)
Attributes:
     -> log.file.name: Str(tomcat_catalina.log)
     -> log_type: Str(tomcat.catalina)
     -> message: Str(Server version name:   Apache Tomcat/9.0.41)
     -> tc_source: Str(org.apache.catalina.startup.VersionLoggerListener.log)
     -> thread: Str(main)
     -> timestamp: Str(20-Jan-2021 12:51:42.078)
     -> tomcat_severity: Str(INFO)
Trace ID: 
Span ID: 
Flags: 0
```

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
