### PR TITLE
feat: Add parse_to parameter to Vcenter

### DIFF
--- a/docs/plugins/vcenter_logs.md
+++ b/docs/plugins/vcenter_logs.md
@@ -12,7 +12,8 @@ Log parser for VMware vCenter
 | enable_tls | Enable TLS for the vCenter listener | bool | `false` | false |  |
 | certificate_file | Path to the x509 PEM certificate or certificate chain to use for TLS | string | `/opt/cert` | false |  |
 | key_file | Path to the key file to use for TLS | string | `/opt/key` | false |  |
-| retain_raw_logs | When enabled will preserve the original log message on the body in a `raw_log` key | bool | `false` | false |  |
+| retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
+| parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
 ## Example Config:
 
@@ -30,4 +31,5 @@ receivers:
       certificate_file: /opt/cert
       key_file: /opt/key
       retain_raw_logs: false
+      parse_to: body
 ```

--- a/plugins/vcenter_logs.yaml
+++ b/plugins/vcenter_logs.yaml
@@ -79,7 +79,7 @@ template: |
         - id: move_syslog_message
           type: move
           from: attributes.syslog_message
-          to: {{ .parse_to }}
+          to: body
           output: vcenter_parser
 
         - id: vcenter_parser
@@ -87,53 +87,53 @@ template: |
           protocol: rfc5424
 
         {{ if eq .parse_to "body" }}
-          # Move syslog fields to body
-          # We do this rather than parsing to body in the syslog_parser as it handles timestamp and severity parsing
-          - id: move_priority
-            if: "attributes.priority != nil"
-            type: move
-            from: attributes.priority
-            to: body.priority
-          - id: move_facility
-            if: "attributes.facility != nil"
-            type: move
-            from: attributes.facility
-            to: body.facility
-          - id: move_hostname
-            if: "attributes.hostname != nil"
-            type: move
-            from: attributes.hostname
-            to: body.hostname
-          - id: move_appname
-            if: "attributes.appname != nil"
-            type: move
-            from: attributes.appname
-            to: body.appname
-          - id: move_proc_id
-            if: "attributes.proc_id != nil"
-            type: move
-            from: attributes.proc_id
-            to: body.proc_id
-          - id: move_msg_id
-            if: "attributes.msg_id != nil"
-            type: move
-            from: attributes.msg_id
-            to: body.msg_id
-          - id: move_message
-            if: "attributes.message != nil"
-            type: move
-            from: attributes.message
-            to: body.message
-          - id: move_structured_data
-            if: "attributes.structured_data != nil"
-            type: move
-            from: attributes.structured_data
-            to: body.structured_data
-          - id: move_version
-            if: "attributes.version != nil"
-            type: move
-            from: attributes.version
-            to: body.version
+        # Move syslog fields to body
+        # We do this rather than parsing to body in the syslog_parser as it handles timestamp and severity parsing
+        - id: move_priority
+          if: "attributes.priority != nil"
+          type: move
+          from: attributes.priority
+          to: body.priority
+        - id: move_facility
+          if: "attributes.facility != nil"
+          type: move
+          from: attributes.facility
+          to: body.facility
+        - id: move_hostname
+          if: "attributes.hostname != nil"
+          type: move
+          from: attributes.hostname
+          to: body.hostname
+        - id: move_appname
+          if: "attributes.appname != nil"
+          type: move
+          from: attributes.appname
+          to: body.appname
+        - id: move_proc_id
+          if: "attributes.proc_id != nil"
+          type: move
+          from: attributes.proc_id
+          to: body.proc_id
+        - id: move_msg_id
+          if: "attributes.msg_id != nil"
+          type: move
+          from: attributes.msg_id
+          to: body.msg_id
+        - id: move_message
+          if: "attributes.message != nil"
+          type: move
+          from: attributes.message
+          to: body.message
+        - id: move_structured_data
+          if: "attributes.structured_data != nil"
+          type: move
+          from: attributes.structured_data
+          to: body.structured_data
+        - id: move_version
+          if: "attributes.version != nil"
+          type: move
+          from: attributes.version
+          to: body.version
         {{ end }}
 
         {{ if and .retain_raw_logs (eq .parse_to "body")}}

--- a/plugins/vcenter_logs.yaml
+++ b/plugins/vcenter_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 title: VMware vCenter
 description: Log parser for VMware vCenter
 parameters:
@@ -28,9 +28,16 @@ parameters:
     type: string
     default: "/opt/key"
   - name: retain_raw_logs
-    description: When enabled will preserve the original log message on the body in a `raw_log` key
+    description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
     default: false
+  - name: parse_to
+    description: Where to parse structured log parts
+    type: string
+    supported:
+      - body
+      - attributes
+    default: body
 template: |
   receivers:
     tcplog:
@@ -72,62 +79,64 @@ template: |
         - id: move_syslog_message
           type: move
           from: attributes.syslog_message
-          to: body
+          to: {{ .parse_to }}
           output: vcenter_parser
 
         - id: vcenter_parser
           type: syslog_parser
           protocol: rfc5424
 
-        # Move syslog fields to body
-        # We do this rather than parsing to body in the syslog_parser as it handles timestamp and severity parsing
-        - id: move_priority
-          if: "attributes.priority != nil"
-          type: move
-          from: attributes.priority
-          to: body.priority
-        - id: move_facility
-          if: "attributes.facility != nil"
-          type: move
-          from: attributes.facility
-          to: body.facility
-        - id: move_hostname
-          if: "attributes.hostname != nil"
-          type: move
-          from: attributes.hostname
-          to: body.hostname
-        - id: move_appname
-          if: "attributes.appname != nil"
-          type: move
-          from: attributes.appname
-          to: body.appname
-        - id: move_proc_id
-          if: "attributes.proc_id != nil"
-          type: move
-          from: attributes.proc_id
-          to: body.proc_id
-        - id: move_msg_id
-          if: "attributes.msg_id != nil"
-          type: move
-          from: attributes.msg_id
-          to: body.msg_id
-        - id: move_message
-          if: "attributes.message != nil"
-          type: move
-          from: attributes.message
-          to: body.message
-        - id: move_structured_data
-          if: "attributes.structured_data != nil"
-          type: move
-          from: attributes.structured_data
-          to: body.structured_data
-        - id: move_version
-          if: "attributes.version != nil"
-          type: move
-          from: attributes.version
-          to: body.version
+        {{ if eq .parse_to "body" }}
+          # Move syslog fields to body
+          # We do this rather than parsing to body in the syslog_parser as it handles timestamp and severity parsing
+          - id: move_priority
+            if: "attributes.priority != nil"
+            type: move
+            from: attributes.priority
+            to: body.priority
+          - id: move_facility
+            if: "attributes.facility != nil"
+            type: move
+            from: attributes.facility
+            to: body.facility
+          - id: move_hostname
+            if: "attributes.hostname != nil"
+            type: move
+            from: attributes.hostname
+            to: body.hostname
+          - id: move_appname
+            if: "attributes.appname != nil"
+            type: move
+            from: attributes.appname
+            to: body.appname
+          - id: move_proc_id
+            if: "attributes.proc_id != nil"
+            type: move
+            from: attributes.proc_id
+            to: body.proc_id
+          - id: move_msg_id
+            if: "attributes.msg_id != nil"
+            type: move
+            from: attributes.msg_id
+            to: body.msg_id
+          - id: move_message
+            if: "attributes.message != nil"
+            type: move
+            from: attributes.message
+            to: body.message
+          - id: move_structured_data
+            if: "attributes.structured_data != nil"
+            type: move
+            from: attributes.structured_data
+            to: body.structured_data
+          - id: move_version
+            if: "attributes.version != nil"
+            type: move
+            from: attributes.version
+            to: body.version
+        {{ end }}
 
-        {{ if .retain_raw_logs }}
+        {{ if and .retain_raw_logs (eq .parse_to "body")}}
         - id: move_raw_log
           type: move
           from: attributes.raw_log


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->
Added a parse_to parameter to Vcenter log plugin to allow choosing where to parse logs to body or attributes.

**Example**

Parse to body
```
LogRecord #0
ObservedTimestamp: 2022-11-15 18:47:57.198006 +0000 UTC
Timestamp: 2022-09-15 18:01:57.734952 +0000 UTC
SeverityText: info
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Map({\"appname\":\"ssoadminserver\",\"facility\":16,\"hostname\":\"vcsa\",\"message\":\"2022-09-15T18:00:42.903Z INFO ssoAdminServer[101:pool-2-thread-5] [OpId=d09ba743-1106-412d-8d83-03512f67560e] [com.vmware.identity.admin.vlsi.ConfigurationManagementServiceImpl] Vmodl method ConfigurationManagementService.getIssuersCertificates return value is []\",\"priority\":134,\"version\":1})
Attributes:
     -> log_type: Str(vmware_vcenter)
     -> net.host.ip: Str(127.0.0.1)
     -> net.host.name: Str(localhost)
     -> net.host.port: Str(5140)
     -> net.peer.ip: Str(127.0.0.1)
     -> net.peer.name: Str(localhost)
     -> net.peer.port: Str(54322)
     -> net.transport: Str(IP.TCP)
Trace ID: 
Span ID: 
Flags: 0
```

Parse to attributes
```
LogRecord #0
ObservedTimestamp: 2022-11-15 18:47:19.067625 +0000 UTC
Timestamp: 2022-09-15 18:01:57.734952 +0000 UTC
SeverityText: info
SeverityNumber: SEVERITY_NUMBER_INFO(9)
Body: Str(<134>1 2022-09-15T18:01:57.734952+00:00 vcsa ssoadminserver - - - 2022-09-15T18:00:42.903Z INFO ssoAdminServer[101:pool-2-thread-5] [OpId=d09ba743-1106-412d-8d83-03512f67560e] [com.vmware.identity.admin.vlsi.ConfigurationManagementServiceImpl] Vmodl method ConfigurationManagementService.getIssuersCertificates return value is [])
Attributes:
     -> appname: Str(ssoadminserver)
     -> facility: Int(16)
     -> hostname: Str(vcsa)
     -> log_type: Str(vmware_vcenter)
     -> message: Str(2022-09-15T18:00:42.903Z INFO ssoAdminServer[101:pool-2-thread-5] [OpId=d09ba743-1106-412d-8d83-03512f67560e] [com.vmware.identity.admin.vlsi.ConfigurationManagementServiceImpl] Vmodl method ConfigurationManagementService.getIssuersCertificates return value is [])
     -> net.host.ip: Str(127.0.0.1)
     -> net.host.name: Str(localhost)
     -> net.host.port: Str(5140)
     -> net.peer.ip: Str(127.0.0.1)
     -> net.peer.name: Str(localhost)
     -> net.peer.port: Str(54308)
     -> net.transport: Str(IP.TCP)
     -> priority: Int(134)
     -> version: Int(1)
Trace ID: 
Span ID: 
Flags: 0
```

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
