### PR TITLE
fix: Added package level functions to reset internal telemetry views

### DIFF
--- a/collector/settings.go
+++ b/collector/settings.go
@@ -15,6 +15,7 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/observiq/observiq-otel-collector/factories"
@@ -30,7 +31,11 @@ const buildDescription = "observIQ's opentelemetry-collector distribution"
 
 // NewSettings returns new settings for the collector with default values.
 func NewSettings(configPaths []string, version string, loggingOpts []zap.Option) (*service.CollectorSettings, error) {
-	factories, _ := factories.DefaultFactories()
+	factories, err := factories.DefaultFactories()
+	if err != nil {
+		return nil, fmt.Errorf("error while setting up default factories: %w", err)
+	}
+
 	buildInfo := component.BuildInfo{
 		Command:     os.Args[0],
 		Description: buildDescription,

--- a/internal/throughputwrapper/receiver_factory_wrapper.go
+++ b/internal/throughputwrapper/receiver_factory_wrapper.go
@@ -17,21 +17,21 @@ package throughputwrapper
 
 import (
 	"context"
-	"sync"
 
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 )
 
-var once sync.Once
+// RegisterMetricViews unregisters old metric views if they exist and registers new ones
+func RegisterMetricViews() error {
+	views := metricViews()
+	view.Unregister(views...)
+	return view.Register(views...)
+}
 
 // WrapReceiverFactory creates a wrapper factory that around the passed in factory. Injecting consumers to measure output from the passed in receiver.
 func WrapReceiverFactory(receiverFactory component.ReceiverFactory) component.ReceiverFactory {
-	once.Do(func() {
-		_ = view.Register(metricViews()...)
-	})
-
 	opts := make([]component.ReceiverFactoryOption, 0, 3)
 
 	// Wrap the metric receiver creation func

--- a/processor/throughputmeasurementprocessor/factory.go
+++ b/processor/throughputmeasurementprocessor/factory.go
@@ -16,7 +16,6 @@ package throughputmeasurementprocessor
 
 import (
 	"context"
-	"sync"
 
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
@@ -35,14 +34,15 @@ var (
 	consumerCapabilities = consumer.Capabilities{MutatesData: false}
 )
 
-var once sync.Once
+// RegisterMetricViews unregisters old metric views if they exist and registers new ones
+func RegisterMetricViews() error {
+	views := metricViews()
+	view.Unregister(views...)
+	return view.Register(views...)
+}
 
 // NewFactory creates a new ProcessorFactory with default configuration
 func NewFactory() component.ProcessorFactory {
-	once.Do(func() {
-		_ = view.Register(metricViews()...)
-	})
-
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,


### PR DESCRIPTION
### Proposed Change
In managed mode during a reconfiguration the throughput internal telemetry counters would not reset their values but rather just change labels. Added logic so when factories are recreated it resets the telemetry counters.

Screen shot showing the reset on a reconfigure:
<img width="1220" alt="Screen Shot 2022-11-16 at 8 35 03 AM" src="https://user-images.githubusercontent.com/11877763/202197318-42d2b1dc-16dc-491d-962c-8354ec6b3d18.png">

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
