### PR TITLE
Changed logging exporter loglevel to verbosity in example config

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -42,7 +42,7 @@ exporters:
   # For more information on configuring the logging exporter, refer to the documentation here:
   # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/loggingexporter
   logging:
-    loglevel: debug
+    verbosity: detailed
 
 # 'service' specifies how to construct the data pipelines using the configurations above.
 service:


### PR DESCRIPTION
### Proposed Change
In otel v0.64.0 the `verbosity` parameter was added and the `loglevel` parameter slated for deprecation in the logging exporter. Updated the example base config with the `verbosity` parameter.

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
