### PR TITLE
feat: Redirect stderr to file on Windows

### DIFF
--- a/docs/installation-windows.md
+++ b/docs/installation-windows.md
@@ -31,6 +31,12 @@ By default, the config file for the collector can be found at `C:\Program Files\
 
 For more information on configuring the collector, see the [OpenTelemetry docs](https://opentelemetry.io/docs/collector/configuration/).
 
+**Logging**
+
+Logs from the collector will appear in `<install_dir>/log` (`C:\Program Files\observIQ OpenTelemetry Collector\log` by default). 
+
+Stderr for the collector process can be found at `<install_dir>/log/observiq_collector.err` (`C:\Program Files\observIQ OpenTelemetry Collector\log\observiq_collector.err` by default).
+
 ## Restarting the Collector
 Restarting the collector may be done through the services dialog.
 To access the services dialog, press Win + R, enter `services.msc` into the Run dialog, and press enter.

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -170,13 +171,13 @@ func checkIsService() (bool, error) {
 // instead of it being dropped by Windows services.
 // Most output should go through the zap logger instead of to stderr.
 func redirectStderr() error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working dir: %w", err)
+	homeDir, ok := os.LookupEnv("OIQ_OTEL_COLLECTOR_HOME")
+	if !ok {
+		return errors.New("OIQ_OTEL_COLLECTOR_HOME environment variable not set")
 	}
 
-	path := filepath.Join(wd, "log", "observiq_collector.err")
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
+	path := filepath.Join(homeDir, "log", "observiq_collector.err")
+	f, err := os.OpenFile(filepath.Clean(path), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -57,7 +57,6 @@ func RunService(logger *zap.Logger, rSvc RunnableService) error {
 
 		// Redirect stderr to file, so we can see panic information
 		if err := redirectStderr(); err != nil {
-			// This error is not fatal, so we'll just log this.
 			logger.Error("Failed to redirect stderr", zap.Error(err))
 		}
 

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 )
 
@@ -52,6 +53,12 @@ func RunService(logger *zap.Logger, rSvc RunnableService) error {
 			if err := os.Chdir(execDirPath); err != nil {
 				logger.Warn("Failed to modify current working directory", zap.Error(err))
 			}
+		}
+
+		// Redirect stderr to file, so we can see panic information
+		if err := redirectStderr(); err != nil {
+			// This error is not fatal, so we'll just log this.
+			logger.Error("Failed to redirect stderr", zap.Error(err))
 		}
 
 		// Service name doesn't need to be specified when directly run by the service manager.
@@ -158,4 +165,28 @@ func checkIsService() (bool, error) {
 	}
 
 	return isWindowsService, nil
+}
+
+// redirectStderr redirects stderr so that panic information is output to $INSTALL_DIR/log/observiq_collector.err,
+// instead of it being dropped by Windows services.
+// Most output should go through the zap logger instead of to stderr.
+func redirectStderr() error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working dir: %w", err)
+	}
+
+	path := filepath.Join(wd, "log", "observiq_collector.err")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	if err := windows.SetStdHandle(windows.STD_ERROR_HANDLE, windows.Handle(f.Fd())); err != nil {
+		return fmt.Errorf("failed to set stderr handle: %w (close err: %s)", err, f.Close())
+	} else {
+		os.Stderr = f
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Proposed Change
* Redirect stderr when running as a service on Windows, so that panics will be logged

I tested this on a windows machine using a fake "panic" extension that panics on component startup.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
