### PR TITLE
fix(container): RHEL UBI logging.yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -245,7 +245,7 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
-    - config/logging.stdout.yaml
+      - config/logging.stdout.yaml
   - id: ubi8-arm64
     goos: linux
     goarch: arm64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -203,6 +203,7 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
+      - config/logging.stdout.yaml
   - id: ubuntu-arm64
     goos: linux
     goarch: arm64
@@ -224,6 +225,7 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
+      - config/logging.stdout.yaml
 
   - id: ubi8-amd64
     goos: linux
@@ -243,6 +245,7 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
+    - config/logging.stdout.yaml
   - id: ubi8-arm64
     goos: linux
     goarch: arm64
@@ -261,6 +264,7 @@ dockers:
     extra_files:
       - plugins
       - config/example.yaml
+      - config/logging.stdout.yaml
 
 docker_manifests:
   - name_template: "observiq/observiq-otel-collector:latest"

--- a/config/logging.stdout.yaml
+++ b/config/logging.stdout.yaml
@@ -1,0 +1,2 @@
+output: stdout
+level: info

--- a/config/logging.stdout.yaml
+++ b/config/logging.stdout.yaml
@@ -1,3 +1,2 @@
 output: stdout
 level: info
-

--- a/config/logging.stdout.yaml
+++ b/config/logging.stdout.yaml
@@ -1,2 +1,3 @@
 output: stdout
 level: info
+

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -66,7 +66,10 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # Default config allows the collector to run without an injected config, which is required
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
-RUN chown otel:otel /etc/otel/config.yaml
+
+RUN chown otel:otel \
+    /etc/otel/config.yaml \
+    /etc/otel/logging.yaml
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -61,8 +61,7 @@ COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
-RUN echo "output: stdout\nlevel: info\n" > /etc/otel/logging.yaml
-ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
+COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 
 # Default config allows the collector to run without an injected config, which is required
 # when connecting to an OpAMP platform.

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -67,7 +67,10 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # Default config allows the collector to run without an injected config, which is required
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
-RUN chown otel:otel /etc/otel/config.yaml
+
+RUN chown otel:otel \
+    /etc/otel/config.yaml \
+    /etc/otel/logging.yaml
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -62,8 +62,7 @@ COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins
 
-RUN echo "output: stdout\nlevel: info\n" > /etc/otel/logging.yaml
-ENV LOGGING_YAML_PATH=/etc/otel/logging.yaml
+COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 
 # Default config allows the collector to run without an injected config, which is required
 # when connecting to an OpAMP platform.


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Seeing some inconsistent behavior between the ubuntu based image and the rhel ubi image. The logging.yaml file is written incorrectly. This PR creates a `config/logging.stdout.yaml` logging config file and uses `COPY` to add it to each container image.

When running the container, I can see that the logging.yaml file is correct:
```
bash-4.4$ ls -la
total 24
drwxr-xr-x 1 otel otel 4096 Nov 18 15:12 .
drwxr-xr-x 1 root root 4096 Nov 18 15:12 ..
-rw-r--r-- 1 otel otel 3184 Nov 18 15:11 config.yaml
-rw-r--r-- 1 otel otel   28 Nov 18 15:11 logging.yaml

drwxr-xr-x 2 root root 4096 Nov 18 15:12 plugins
bash-4.4$ cat logging.yaml
output: stdout
level: info
```

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
