### PR TITLE
Copy collector license into container image (RHEL certification)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -204,6 +204,7 @@ dockers:
       - plugins
       - config/example.yaml
       - config/logging.stdout.yaml
+      - LICENSE
   - id: ubuntu-arm64
     goos: linux
     goarch: arm64
@@ -226,6 +227,7 @@ dockers:
       - plugins
       - config/example.yaml
       - config/logging.stdout.yaml
+      - LICENSE
 
   - id: ubi8-amd64
     goos: linux
@@ -246,6 +248,7 @@ dockers:
       - plugins
       - config/example.yaml
       - config/logging.stdout.yaml
+      - LICENSE
   - id: ubi8-arm64
     goos: linux
     goarch: arm64
@@ -265,6 +268,7 @@ dockers:
       - plugins
       - config/example.yaml
       - config/logging.stdout.yaml
+      - LICENSE
 
 docker_manifests:
   - name_template: "observiq/observiq-otel-collector:latest"

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -57,6 +57,9 @@ COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
 ENV PATH=$PATH:/usr/local/openjdk-8/bin
 
+RUN mkdir /licenses
+COPY LICENSE /licenses/observiq-otel-collector.license
+
 COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -58,6 +58,9 @@ COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
 ENV PATH=$PATH:/usr/local/openjdk-8/bin
 
+RUN mkdir /licenses
+COPY LICENSE /licenses/observiq-otel-collector.license
+
 COPY observiq-otel-collector /collector/observiq-otel-collector
 COPY --from=jmxjar /opentelemetry-java-contrib-jmx-metrics.jar /opt/opentelemetry-java-contrib-jmx-metrics.jar
 COPY plugins /etc/otel/plugins


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

For RHEL certificatation, we need to include the collector's license at `/licenses` within the container image. When running the RHEL [preflight tool](https://github.com/redhat-openshift-ecosystem/openshift-preflight), I see
```json
        "failed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
                "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/8.45/html/red_hat_openshift_software_certification_policy_guide/assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
```

After bundling the license file, preflight passes.

To test, I built and pushed the images to our `bmedora` dockerhub account, because preflight pulls the image instead of using your local copy.

You can test this yourself with [preflight]()
```bash
preflight check container bmedora/observiq-otel-collector-amd64:1.12.0-ubi8
```

I included this change in the ubuntu based image in order to stay consistent.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
