### PR TITLE
Updated all Windows GH Action Runners to 2022

### DIFF
--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-msi:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -57,7 +57,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-msi:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3


### PR DESCRIPTION
### Proposed Change
Updated GH Action Windows Runners to 2022 as that is the current `latest`. Checked macOS and Ubuntu and verified the current versions are latest.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
