### PR TITLE
fix: Force the install script to take old config on debian systems

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -576,7 +576,7 @@ unpack_package()
 {
   case "$package_type" in
     deb)
-      dpkg -i "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
+      dpkg --force-confold -i "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"
       ;;
     rpm)
       rpm -U "$out_file_path" > /dev/null || error_exit "$LINENO" "Failed to unpack package"


### PR DESCRIPTION
### Proposed Change
* Force the install script to use the old config instead of prompting for a user choice on Debian systems.
  * This change makes the script non-interactive if the default config is changed, which it previously was not.

Tested on a Debian 10 VM, upgrading from v1.10.0 to v1.12.0.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
