### PR TITLE
fix: Changed to using context notation for GITHUB_REF_NAME in msi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           unzip wix310-binaries.zip
         working-directory: C:/build
       - name: "Build MSI from Tagged Release"
-        run: go-msi.exe make -m observiq-otel-collector.msi --version ${GITHUB_REF_NAME} --arch amd64
+        run: go-msi.exe make -m observiq-otel-collector.msi --version ${{ github.ref_name }} --arch amd64
         working-directory: C:/build
       - name: Install MSI
         run: msiexec.exe /qn /i observiq-otel-collector.msi


### PR DESCRIPTION
### Proposed Change
Changed `GITHUB_REF_NAME` to `github.ref_name` in release MSI build

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
