### PR TITLE
fix(oracledb): Don't encode '=' in Oracle DB datasource

### DIFF
--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.1.0
 title: OracleDB Metrics
 description: Metrics receiver for OracleDB
 parameters:

--- a/plugins/oracledb_metrics.yaml
+++ b/plugins/oracledb_metrics.yaml
@@ -38,13 +38,13 @@ template: |
     {{ $datasource = printf "%s/%s" $datasource .service_name }}
   {{end}}
   {{ if and .sid .wallet }}
-    {{ $datasource = printf "%s?SID%%3D%s&WALLET%%3D%s" $datasource .sid .wallet}}
+    {{ $datasource = printf "%s?SID=%s&WALLET=%s" $datasource .sid .wallet}}
   {{end}}
   {{ if and .sid (not .wallet) }}
-    {{ $datasource = printf "%s?SID%%3D%s" $datasource .sid}}
+    {{ $datasource = printf "%s?SID=%s" $datasource .sid}}
   {{end}}
   {{ if and (not .sid) .wallet }}
-    {{ $datasource = printf "%s?WALLET%%3D%s" $datasource .wallet}}
+    {{ $datasource = printf "%s?WALLET=%s" $datasource .wallet}}
   {{end}}
 
   receivers:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
When building `$datasource`, use plain `=` instead of `%3D`

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
