### PR TITLE
Update Google Cloud Prometheus example config to use `generic_node`

### DIFF
--- a/config/google_cloud_exporter/prometheus/README.md
+++ b/config/google_cloud_exporter/prometheus/README.md
@@ -6,23 +6,95 @@ The Prometheus Receiver can be used to send prometheus style metrics scraped fro
 
 See the [prerequisites](../README.md) doc for Google Cloud prerequisites.
 
-## Configuration
+Ensure your applications support prometheus metrics, or have prometheus exporters configured.
 
-An example configuration is located [here](./config.yaml).
+## Usage
+
+Modify the example configuration's `prometheus` receiver. Update
+the `job_name` value to reflect your environment. Also update the
+`targets` value(s) to point to your application's prometheus exporter(s).
+
+For example, if you have five Nginx systems that need to be
+monitored, your receiver configuration would look like this:
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'nginx'
+        scrape_interval: 60s
+        static_configs:
+        - targets:
+          - 'nginx-0:9113'
+          - 'nginx-1:9113'
+          - 'nginx-2:9113'
+          - 'nginx-3:9113'
+          - 'nginx-4:9113'
+```
+
+You can have multiple scrape configs, for targeting multiple applications.
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'nginx'
+        scrape_interval: 60s
+        static_configs:
+        - targets:
+          - 'nginx-0:9113'
+      - job_name: 'redis'
+        scrape_interval: 60s
+        static_configs:
+        - targets:
+          - 'redis-0:9900'
+```
+
+### Deploy
 
 1. Copy [config.yaml](./config.yaml) to `/opt/observiq-otel-collector/config.yaml`
-2. Restart the collector: `sudo systemctl restart observiq-otel-collector`
+2. Modify the configuration to reflect your environment (See [Usage](./README.md#usage))
+3. Restart the collector: `sudo systemctl restart observiq-otel-collector`
 
-## Setup
+You can search for metrics under the "Generic Node" section
+with the prefix `workload.googleapis.com`.
 
-This example assumes that [node exporter](https://github.com/prometheus/node_exporter) is running on the host system, on port 9100. Generally, all prometheus style exporters are supported, such as the [aerospike exporter](https://github.com/aerospike/aerospike-prometheus-exporter).
+### Metric Labels
 
-If you wish to scrape metrics from external systems, update `config.yaml`'s prometheus scrape config with a list of IP addresses:
+| Label       | Description | Example |
+| ----------- | ----------- | ------- |
+| `node_id`   | The hostname of the collector. Set within the [Google exporter](https://github.com/observIQ/observiq-otel-collector/tree/main/exporter/googlecloudexporter#metric-processing-steps), and required for [generic_node](https://cloud.google.com/monitoring/api/resources#tag_generic_node) monitored resource type. | `collector-0` |
+| `job` | Dervied from the Prometheus receiver's `config.scrape_configs` `job_name` value. This value should represent the applications being scraped by the scrape config. | `nodeexporter` |
+| `instance` | The host / ip and port being scraped by the scrape config. | `node-1:9100` |
+
+For the best experience, ensure that the values for `job_name` and `targets` are descriptive, as the
+`job` and `instance` metric labels are derived from those values.
+
+### Custom Metric Prefix
+
+Generally metric names will contain their software name, however, sometimes
+you might have a metric that is not descriptive, such as `uptime`. In this case, you
+can use a custom metric prefix.
+
 ```yaml
-- targets:
-    - '127.0.0.1:9100'
-    - '10.128.1.30:9100'
-    - '10.128.1.31:9100'
-    - '10.128.1.32:9100'
-    - '10.128.1.33:9100'
+exporters: 
+  googlecloud/mycustomapp:
+    metric:
+      prefix: workload.googleapis.com/mycustomapp
+...
+service:
+  pipelines:
+    metrics:
+      ...
+      exporters:
+      - googlecloud/mycustomapp
 ```
+
+This configuration snipet contains a Google exporter dedicated to `mycustomapp`, which
+has a metric prefix of `workload.googleapis.com/mycustomapp`.
+
+
+
+

--- a/config/google_cloud_exporter/prometheus/config.yaml
+++ b/config/google_cloud_exporter/prometheus/config.yaml
@@ -8,15 +8,36 @@ receivers:
         - targets:
           - '127.0.0.1:9100'
 
+processors:
+  resource:
+    attributes:
+    # Set `job` and `instance` resource attributes
+    # to match up with what you would expect to see
+    # in Prometheus server.
+    - key: job
+      action: upsert
+      from_attribute: service.name
+    - key: instance
+      action: upsert
+      from_attribute: service.instance.id
+    # Google will consider metrics with `service.name` and
+    # `service.instance.id` to be `generic_task` monitored
+    # resource type. To get around this, and use `generic_node`,
+    # delete the resource attributes.
+    - key: service.name
+      action: delete
+    - key: service.instance.id
+      action: delete
+
 exporters: 
   googlecloud:
-    metric:
-      prefix: workload.googleapis.com/nodeexporter
 
 service:
   pipelines:
     metrics:
       receivers:
       - prometheus
+      processors:
+      - resource
       exporters:
       - googlecloud


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The Prometheus example results in two issues:
- Metrics show up in GCP as [generic_task](https://cloud.google.com/monitoring/api/resources#tag_generic_task) when we would prefer [generic_node](https://cloud.google.com/monitoring/api/resources#tag_generic_node).
- Metric labels do not align with Prometheus server. Prometheus server would have `job` and `instance` labels.

Solution: "Rename" `service.name` and `service.instance.id` to `job` and `instance`. This will prevent the `generic_task` mapping while also emitting metrics that look closer to what you would expect when coming from a Prometheus environment.

I also re-wrote the readme to support things like multiple scrape configs and custom metric prefix.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
