### PR TITLE
bug: attempt hotfix for windows eventlog receiver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -571,5 +571,7 @@ replace github.com/observiq/observiq-otel-collector/internal/expr => ./internal/
 // Relevant issue https://github.com/mattn/go-ieproxy/issues/45
 replace github.com/mattn/go-ieproxy v0.0.9 => github.com/mattn/go-ieproxy v0.0.1
 
+// replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.67.0 => github.com/observiq/opentelemetry-collector-contrib/pkg/stanza v0.0.0-20221228204657-a7bbdcb314a1
+
 // This is a fork of the official opentelemetry-operations-go exporter that removes the credential autodiscovery logic that conflicts with our own custom logic
 replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.34.3-0.20221202192616-0186b89ba914 => github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20221215164112-d92100d9c728


### PR DESCRIPTION
Attempting to never resize a buffer to a size of 0, may not be the best approach so going to keep in draft. Confirmed that this works by exporting to file.

Changes https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...observIQ:opentelemetry-collector-contrib:windows-event-log-panic-pt-3

<details>
<summary> snippet </summary>

```json
{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1672260914889548900","observedTimeUnixNano":"1672260915658423400","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"system_time","value":{"stringValue":"2022-12-28T20:55:14.889548900Z"}},{"key":"channel","value":{"stringValue":"System"}},{"key":"record_id","value":{"intValue":"2022"}},{"key":"level","value":{"stringValue":"Information"}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"observIQ Distro for OpenTelemetry Collector"},{"stringValue":"running"}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"guid","value":{"stringValue":"{555908d1-a6d7-4695-8e1e-26931d2012f4}"}},{"key":"event_source","value":{"stringValue":"Service Control Manager"}},{"key":"name","value":{"stringValue":"Service Control Manager"}}]}}},{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"message","value":{"stringValue":"The observIQ Distro for OpenTelemetry Collector service entered the running state."}},{"key":"task","value":{"stringValue":"0"}},{"key":"opcode","value":{"stringValue":"0"}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"Classic"}]}}},{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"qualifiers","value":{"intValue":"16384"}},{"key":"id","value":{"intValue":"7036"}}]}}}]}},"traceId":"","spanId":""}]}]}]}
{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1672260964860499200","observedTimeUnixNano":"1672260966671984900","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"qualifiers","value":{"intValue":"16384"}},{"key":"id","value":{"intValue":"7040"}}]}}},{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"record_id","value":{"intValue":"2023"}},{"key":"task","value":{"stringValue":"0"}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"Classic"}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"event_source","value":{"stringValue":"Service Control Manager"}},{"key":"name","value":{"stringValue":"Service Control Manager"}},{"key":"guid","value":{"stringValue":"{555908d1-a6d7-4695-8e1e-26931d2012f4}"}}]}}},{"key":"system_time","value":{"stringValue":"2022-12-28T20:56:04.860499200Z"}},{"key":"channel","value":{"stringValue":"System"}},{"key":"level","value":{"stringValue":"Information"}},{"key":"message","value":{"stringValue":"The start type of the Background Intelligent Transfer Service service was changed from auto start to demand start."}},{"key":"opcode","value":{"stringValue":"0"}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"Background Intelligent Transfer Service"},{"stringValue":"auto start"},{"stringValue":"demand start"},{"stringValue":"BITS"}]}}}]}},"traceId":"","spanId":""},{"timeUnixNano":"1672260964918012100","observedTimeUnixNano":"1672260966671984900","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"id","value":{"intValue":"7036"}},{"key":"qualifiers","value":{"intValue":"16384"}}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"name","value":{"stringValue":"Service Control Manager"}},{"key":"guid","value":{"stringValue":"{555908d1-a6d7-4695-8e1e-26931d2012f4}"}},{"key":"event_source","value":{"stringValue":"Service Control Manager"}}]}}},{"key":"message","value":{"stringValue":"The Background Intelligent Transfer Service service entered the stopped state."}},{"key":"task","value":{"stringValue":"0"}},{"key":"opcode","value":{"stringValue":"0"}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"Background Intelligent Transfer Service"},{"stringValue":"stopped"}]}}},{"key":"system_time","value":{"stringValue":"2022-12-28T20:56:04.918012100Z"}},{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"channel","value":{"stringValue":"System"}},{"key":"record_id","value":{"intValue":"2024"}},{"key":"level","value":{"stringValue":"Information"}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"Classic"}]}}}]}},"traceId":"","spanId":""}]}]}]}
{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1672261005578990700","observedTimeUnixNano":"1672261005682803300","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"level","value":{"stringValue":"4"}},{"key":"opcode","value":{"stringValue":""}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"0x80000000000000"}]}}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"Service stopped"}]}}},{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"qualifiers","value":{"intValue":"0"}},{"key":"id","value":{"intValue":"0"}}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"name","value":{"stringValue":"gupdate"}},{"key":"guid","value":{"stringValue":""}},{"key":"event_source","value":{"stringValue":""}}]}}},{"key":"record_id","value":{"intValue":"26185"}},{"key":"message","value":{"stringValue":""}},{"key":"task","value":{"stringValue":"0"}},{"key":"system_time","value":{"stringValue":"2022-12-28T20:56:45.578990700Z"}},{"key":"channel","value":{"stringValue":"Application"}}]}},"traceId":"","spanId":""}]}]}]}
{"resourceLogs":[{"resource":{},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1672261005210359900","observedTimeUnixNano":"1672261006660590400","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"system_time","value":{"stringValue":"2022-12-28T20:56:45.210359900Z"}},{"key":"record_id","value":{"intValue":"2025"}},{"key":"task","value":{"stringValue":"0"}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"Classic"}]}}},{"key":"level","value":{"stringValue":"Information"}},{"key":"message","value":{"stringValue":"The Google Update Service (gupdate) service entered the running state."}},{"key":"opcode","value":{"stringValue":"0"}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"Google Update Service (gupdate)"},{"stringValue":"running"}]}}},{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"qualifiers","value":{"intValue":"16384"}},{"key":"id","value":{"intValue":"7036"}}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"name","value":{"stringValue":"Service Control Manager"}},{"key":"guid","value":{"stringValue":"{555908d1-a6d7-4695-8e1e-26931d2012f4}"}},{"key":"event_source","value":{"stringValue":"Service Control Manager"}}]}}},{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"channel","value":{"stringValue":"System"}}]}},"traceId":"","spanId":""},{"timeUnixNano":"1672261005578990700","observedTimeUnixNano":"1672261006663541500","severityNumber":9,"severityText":"INFO","body":{"kvlistValue":{"values":[{"key":"task","value":{"stringValue":"0"}},{"key":"keywords","value":{"arrayValue":{"values":[{"stringValue":"Classic"}]}}},{"key":"system_time","value":{"stringValue":"2022-12-28T20:56:45.578990700Z"}},{"key":"computer","value":{"stringValue":"keith-windows-panic-box"}},{"key":"channel","value":{"stringValue":"System"}},{"key":"record_id","value":{"intValue":"2026"}},{"key":"level","value":{"stringValue":"Information"}},{"key":"message","value":{"stringValue":"The Google Update Service (gupdate) service entered the stopped state."}},{"key":"event_id","value":{"kvlistValue":{"values":[{"key":"id","value":{"intValue":"7036"}},{"key":"qualifiers","value":{"intValue":"16384"}}]}}},{"key":"provider","value":{"kvlistValue":{"values":[{"key":"name","value":{"stringValue":"Service Control Manager"}},{"key":"guid","value":{"stringValue":"{555908d1-a6d7-4695-8e1e-26931d2012f4}"}},{"key":"event_source","value":{"stringValue":"Service Control Manager"}}]}}},{"key":"opcode","value":{"stringValue":"0"}},{"key":"event_data","value":{"arrayValue":{"values":[{"stringValue":"Google Update Service (gupdate)"},{"stringValue":"stopped"}]}}}]}},"traceId":"","spanId":""}]}]}]}
```
</details>

### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
