### PR TITLE
deps: Removed dependency on opentelemetry-operations-collector

### DIFF
--- a/config/google_managed_prometheus/hostmetrics/config.yaml
+++ b/config/google_managed_prometheus/hostmetrics/config.yaml
@@ -17,7 +17,6 @@ receivers:
       #process:
       #  mute_process_name_error: true
 
-
 processors:
   # Resourcedetection is used to add a unique (host.name)
   # to the metric resource(s), allowing users to filter
@@ -27,11 +26,9 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  normalizesums:
-
   batch:
 
-exporters: 
+exporters:
   # The prometheus exporter exposes a TCP port on the collector, that is then scraped
   # by your Google Prometheus server.
   prometheus:
@@ -46,10 +43,9 @@ service:
   pipelines:
     metrics:
       receivers:
-      - hostmetrics
+        - hostmetrics
       processors:
-      - resourcedetection
-      - normalizesums
-      - batch
+        - resourcedetection
+        - batch
       exporters:
-      - prometheus
+        - prometheus

--- a/config/prometheus/kafka/config.yaml
+++ b/config/prometheus/kafka/config.yaml
@@ -15,8 +15,6 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  normalizesums:
-
   batch:
 
 exporters:
@@ -29,10 +27,9 @@ service:
   pipelines:
     metrics:
       receivers:
-      - kafkametrics
+        - kafkametrics
       processors:
-      - resourcedetection
-      - normalizesums
-      - batch
+        - resourcedetection
+        - batch
       exporters:
-      - prometheus
+        - prometheus

--- a/config/prometheus/mongodb/config.yaml
+++ b/config/prometheus/mongodb/config.yaml
@@ -9,8 +9,6 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  normalizesums:
-
   batch:
 
 exporters:
@@ -23,10 +21,9 @@ service:
   pipelines:
     metrics:
       receivers:
-      - mongodb
+        - mongodb
       processors:
-      - resourcedetection
-      - normalizesums
-      - batch
+        - resourcedetection
+        - batch
       exporters:
-      - prometheus
+        - prometheus

--- a/config/prometheus/mysql/config.yaml
+++ b/config/prometheus/mysql/config.yaml
@@ -13,8 +13,6 @@ processors:
 
   batch:
 
-  normalizesums:
-
 exporters:
   prometheus:
     endpoint: "localhost:9000"
@@ -25,10 +23,9 @@ service:
   pipelines:
     metrics:
       receivers:
-      - mysql
+        - mysql
       processors:
-      - resourcedetection
-      - normalizesums
-      - batch
+        - resourcedetection
+        - batch
       exporters:
-      - prometheus
+        - prometheus

--- a/config/prometheus/redis/config.yaml
+++ b/config/prometheus/redis/config.yaml
@@ -9,8 +9,6 @@ processors:
     system:
       hostname_sources: ["os"]
 
-  normalizesums:
-
   batch:
 
 exporters:
@@ -23,10 +21,9 @@ service:
   pipelines:
     metrics:
       receivers:
-      - redis
+        - redis
       processors:
-      - resourcedetection
-      - normalizesums
-      - batch
+        - resourcedetection
+        - batch
       exporters:
-      - prometheus
+        - prometheus

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -19,7 +19,6 @@ Below is a list of supported processors with links to their documentation pages.
 | Metric Extract Processor                | [metricextract](../processor/metricextractprocessor/README.md) |
 | Metrics Generation Processor            | [metricsgenerationprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/processor/metricsgenerationprocessor/README.md) |
 | Metrics Transform Processor             | [metricstransformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/processor/metricstransformprocessor/README.md) |
-| Normalize Sums Processor                | [normalizesumsprocessor](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/9bfb379327ffc7770ee8d44eeff4c871f4a98d97/processor/normalizesumsprocessor/README.md) |
 | Probabilistic Sampling Processor        | [probabilisticsamplerprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/processor/probabilisticsamplerprocessor/README.md) |
 | Resource Attribute Transposer Processor | [resourceattributetransposerprocessor](../processor/resourceattributetransposerprocessor/README.md) |
 | Resource Detection Processor            | [resourcedetectionprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/processor/resourcedetectionprocessor/README.md) |

--- a/docs/receivers.md
+++ b/docs/receivers.md
@@ -65,7 +65,6 @@ Below is a list of supported receivers with links to their documentation pages.
 | Syslog Receiver                             | [syslogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/syslogreceiver/README.md) |
 | TCP Log Receiver                            | [tcplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/tcplogreceiver/README.md) |
 | UDP Log Receiver                            | [udplogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/udplogreceiver/README.md) |
-| Varnish Cache Receiver                      | [varnishreceiver](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/blob/9bfb379327ffc7770ee8d44eeff4c871f4a98d97/receiver/varnishreceiver/README.md) |
 | vCenter Receiver                            | [vcenterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/vcenterreceiver/README.md) |
 | Windows Event Log Receiver                  | [windowseventlogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/windowseventlogreceiver/README.md) |
 | Windows Performance Counters Receiver       | [windowsperfcountersreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.67.0/receiver/windowsperfcountersreceiver/README.md) |

--- a/factories/processors.go
+++ b/factories/processors.go
@@ -15,7 +15,6 @@
 package factories
 
 import (
-	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/processor/normalizesumsprocessor"
 	"github.com/observiq/observiq-otel-collector/internal/processor/snapshotprocessor"
 	"github.com/observiq/observiq-otel-collector/processor/logcountprocessor"
 	"github.com/observiq/observiq-otel-collector/processor/maskprocessor"
@@ -64,7 +63,6 @@ var defaultProcessors = []component.ProcessorFactory{
 	metricextractprocessor.NewFactory(),
 	metricsgenerationprocessor.NewFactory(),
 	metricstransformprocessor.NewFactory(),
-	normalizesumsprocessor.NewFactory(),
 	probabilisticsamplerprocessor.NewFactory(),
 	resourceattributetransposerprocessor.NewFactory(),
 	resourcedetectionprocessor.NewFactory(),

--- a/factories/receivers.go
+++ b/factories/receivers.go
@@ -15,7 +15,6 @@
 package factories
 
 import (
-	"github.com/GoogleCloudPlatform/opentelemetry-operations-collector/receiver/varnishreceiver"
 	"github.com/observiq/observiq-otel-collector/receiver/pluginreceiver"
 	"github.com/observiq/observiq-otel-collector/receiver/routereceiver"
 	"github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver"
@@ -147,7 +146,6 @@ var defaultReceivers = []receiver.Factory{
 	syslogreceiver.NewFactory(),
 	tcplogreceiver.NewFactory(),
 	udplogreceiver.NewFactory(),
-	varnishreceiver.NewFactory(),
 	vcenterreceiver.NewFactory(),
 	windowseventlogreceiver.NewFactory(),
 	windowsperfcountersreceiver.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/observiq/observiq-otel-collector
 go 1.18
 
 require (
-	github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20221212182416-9bfb379327ff
 	github.com/google/uuid v1.3.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20221212182416-9bfb379327ff h1:+w+BR7mh9dxbbe87RbP2alNkWgO6+nGRSBEM6lzghA4=
-github.com/GoogleCloudPlatform/opentelemetry-operations-collector v0.0.3-0.20221212182416-9bfb379327ff/go.mod h1:iISQXYggD3+tDNgNX+uaf7YcZ8Hl4S+NoHoWSQfApdw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.34.3-0.20221202192616-0186b89ba914 h1:6O6K3r/yzVRpISZuceCF11JekUpIXX467R36db1UtlE=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v0.34.3-0.20221202192616-0186b89ba914/go.mod h1:HpmGbYLf1fsWiqVA0Z2oKh7qi7BroCgOl2NqB2N/TG4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.34.3-0.20221202192616-0186b89ba914 h1:h0CdVDxEefsgv2QQikwKGSKY875o5caWnNbpb7GjwXc=


### PR DESCRIPTION
### Proposed Change
Removing the `github.com/GoogleCloudPlatform/opentelemetry-operations-collector` as a dependency to reduce external dependencies on the collector.

This removes the following components:
- normalizesums processor
- varnish receiver

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
