### PR TITLE
fix(container): Add storage directory to Dockerfiles

### DIFF
--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -70,9 +70,12 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
 
+RUN mkdir /etc/otel/storage
+
 RUN chown otel:otel \
     /etc/otel/config.yaml \
-    /etc/otel/logging.yaml
+    /etc/otel/logging.yaml \
+    /etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -50,8 +50,12 @@ RUN groupadd --gid 10005 otel && \
     --shell /sbin/nologin \
     otel
 
-RUN mkdir /etc/otel && chown otel:otel /etc/otel
+RUN mkdir \
+    /etc/otel \
+    /etc/otel/storage \
+    && chown -R otel:otel /etc/otel
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
@@ -70,12 +74,9 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
 
-RUN mkdir /etc/otel/storage
-
 RUN chown otel:otel \
     /etc/otel/config.yaml \
-    /etc/otel/logging.yaml \
-    /etc/otel/storage
+    /etc/otel/logging.yaml
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -53,7 +53,8 @@ RUN groupadd --gid 10005 otel && \
 RUN mkdir \
     /etc/otel \
     /etc/otel/storage \
-    && chown -R otel:otel /etc/otel
+    && chown -R otel:otel /etc/otel \
+    && chmod 0750 /etc/otel/storage
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -54,7 +54,8 @@ RUN adduser \
 RUN mkdir \
     /etc/otel \
     /etc/otel/storage \
-    && chown -R otel:otel /etc/otel
+    && chown -R otel:otel /etc/otel \
+    && chmod 0750 /etc/otel/storage
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
 ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -71,9 +71,12 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
 
+RUN mkdir /etc/otel/storage
+
 RUN chown otel:otel \
     /etc/otel/config.yaml \
-    /etc/otel/logging.yaml
+    /etc/otel/logging.yaml \
+    /etc/otel/storage
 
 USER otel
 WORKDIR /etc/otel

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -51,8 +51,12 @@ RUN adduser \
     --shell /sbin/nologin \
     otel
 
-RUN mkdir /etc/otel && chown otel:otel /etc/otel
+RUN mkdir \
+    /etc/otel \
+    /etc/otel/storage \
+    && chown -R otel:otel /etc/otel
 ENV OIQ_OTEL_COLLECTOR_HOME=/etc/otel
+ENV OIQ_OTEL_COLLECTOR_STORAGE=/etc/otel/storage
 
 COPY --from=openjdk /usr/local/openjdk-8 /usr/local/openjdk-8
 ENV JAVA_HOME=/usr/local/openjdk-8
@@ -71,12 +75,9 @@ COPY config/logging.stdout.yaml /etc/otel/logging.yaml
 # when connecting to an OpAMP platform.
 COPY config/example.yaml /etc/otel/config.yaml
 
-RUN mkdir /etc/otel/storage
-
 RUN chown otel:otel \
     /etc/otel/config.yaml \
-    /etc/otel/logging.yaml \
-    /etc/otel/storage
+    /etc/otel/logging.yaml
 
 USER otel
 WORKDIR /etc/otel


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Users expect that [$OIQ_OTEL_COLLECTOR_HOME/storage](https://github.com/observIQ/bindplane-op/blob/main/resources/source-types/file_log.yaml#L137) exists and is read / writable by the collector process.

Also added OIQ_OTEL_COLLECTOR_STORAGE to be consistent w/ [existing services](https://github.com/observIQ/observiq-otel-collector/blob/main/service/observiq-otel-collector.service#L12).

Tested with:

```bash
docker run -it --entrypoint ls observiq/observiq-otel-collector-amd64:latest -la /etc/otel
```
```
-rw-r--r-- 1 otel otel 3184 Jan  9 21:00 config.yaml
-rw-r--r-- 1 otel otel   27 Jan  9 21:00 logging.yaml
drwxr-xr-x 2 root root 4096 Jan  9 21:00 plugins
drwxr-x--- 2 otel otel 4096 Jan  9 21:00 storage
```

For production environments, the /etc/otel/storage directory would be bound to a volume for persistence. By including the directory within the image, users can kick the tires with config that depends on storage despite being ephemeral.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
