### PR TITLE
fix: Create storage dir for macOS

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -453,6 +453,10 @@ install_package()
   do
     mkdir -p "$INSTALL_DIR/$d" || error_exit "$LINENO" "Failed to create directory $INSTALL_DIR/$d"
   done
+  
+  # Create the storage dir; This dir is necessary for filelog based plugins
+  mkdir -p "$INSTALL_DIR/storage" || error_exit "$LINENO" "Failed to create directory $INSTALL_DIR/storage"
+
   decrease_indent
   succeeded
 

--- a/service/com.observiq.collector.plist
+++ b/service/com.observiq.collector.plist
@@ -8,6 +8,8 @@
     <dict>
         <key>OIQ_OTEL_COLLECTOR_HOME</key>
         <string>[INSTALLDIR]</string>
+        <key>OIQ_OTEL_COLLECTOR_STORAGE</key>
+        <string>[INSTALLDIR]storage</string>
     </dict>
     <key>ProgramArguments</key>
     <array>


### PR DESCRIPTION
### Proposed Change
* Create storage dir for macOS install script
  * This directory is required for filelog based plugins, otherwise the collector will fail to start. 
* Add `OIQ_OTEL_COLLECTOR_STORAGE` env var to MacOS service file
  * This env is present in other installs, so we should have this here to be consistent.


##### Checklist
- [x] Changes are tested
- [ ] CI has passed
