### PR TITLE
deps: Removed github.com/pkg/errors in sap receiver in favor of stdlib errors

### DIFF
--- a/receiver/sapnetweaverreceiver/client_test.go
+++ b/receiver/sapnetweaverreceiver/client_test.go
@@ -15,9 +15,9 @@
 package sapnetweaverreceiver // import "github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver"
 
 import (
+	"errors"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/sapnetweaverreceiver/config.go
+++ b/receiver/sapnetweaverreceiver/config.go
@@ -15,10 +15,10 @@
 package sapnetweaverreceiver // import "github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver"
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
@@ -28,11 +28,11 @@ import (
 )
 
 // Errors for missing required config parameters.
-const (
-	ErrNoUsername      = "invalid config: missing username"
-	ErrNoPwd           = "invalid config: missing password"
-	ErrInvalidHostname = "invalid config: invalid hostname"
-	ErrInvalidEndpoint = "invalid config: invalid endpoint"
+var (
+	ErrNoUsername      = errors.New("invalid config: missing username")
+	ErrNoPwd           = errors.New("invalid config: missing password")
+	ErrInvalidHostname = errors.New("invalid config: invalid hostname")
+	ErrInvalidEndpoint = errors.New("invalid config: invalid endpoint")
 )
 
 var (
@@ -59,20 +59,20 @@ type Config struct {
 func (cfg *Config) Validate() error {
 	var errs error
 	if cfg.Username == "" {
-		errs = multierr.Append(errs, errors.New(ErrNoUsername))
+		errs = multierr.Append(errs, ErrNoUsername)
 	}
 
 	if cfg.Password == "" {
-		errs = multierr.Append(errs, errors.New(ErrNoPwd))
+		errs = multierr.Append(errs, ErrNoPwd)
 	}
 
 	u, err := url.Parse(cfg.Endpoint)
 	if err != nil {
-		errs = multierr.Append(errs, errors.Wrap(err, ErrInvalidEndpoint))
+		errs = multierr.Append(errs, ErrInvalidEndpoint)
 	}
 
 	if u.Hostname() == "" {
-		errs = multierr.Append(errs, errors.New(ErrInvalidHostname))
+		errs = multierr.Append(errs, ErrInvalidHostname)
 	}
 
 	return errs

--- a/receiver/sapnetweaverreceiver/config_test.go
+++ b/receiver/sapnetweaverreceiver/config_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
@@ -39,41 +38,41 @@ func TestValidate(t *testing.T) {
 			desc:        "Missing username and password and invalid hostname",
 			endpoint:    "localhost:50013",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoUsername), errors.New(ErrNoPwd), errors.New(ErrInvalidHostname)).Error(),
+			errText:     multierr.Combine(ErrNoUsername, ErrNoPwd, ErrInvalidHostname).Error(),
 		},
 		{
 			desc:        "Missing username and password",
 			endpoint:    "http://localhost:50013",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoUsername), errors.New(ErrNoPwd)).Error(),
+			errText:     multierr.Combine(ErrNoUsername, ErrNoPwd).Error(),
 		},
 		{
 			desc:        "Missing username and invalid hostname, no protocol",
 			endpoint:    "localhost:50013",
 			password:    "password",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoUsername), errors.New(ErrInvalidHostname)).Error(),
+			errText:     multierr.Combine(ErrNoUsername, ErrInvalidHostname).Error(),
 		},
 		{
 			desc:        "Missing password and invalid hostname, no protocol",
 			endpoint:    "localhost:50013",
 			username:    "root",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoPwd), errors.New(ErrInvalidHostname)).Error(),
+			errText:     multierr.Combine(ErrNoPwd, ErrInvalidHostname).Error(),
 		},
 		{
 			desc:        "Missing username",
 			endpoint:    "http://localhost:50013",
 			password:    "password",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoUsername)).Error(),
+			errText:     multierr.Combine(ErrNoUsername).Error(),
 		},
 		{
 			desc:        "Missing password",
 			endpoint:    "http://localhost:50013",
 			username:    "root",
 			errExpected: true,
-			errText:     multierr.Combine(errors.New(ErrNoPwd)).Error(),
+			errText:     multierr.Combine(ErrNoPwd).Error(),
 		},
 		{
 			desc:        "custom_host",

--- a/receiver/sapnetweaverreceiver/factory.go
+++ b/receiver/sapnetweaverreceiver/factory.go
@@ -15,9 +15,9 @@
 package sapnetweaverreceiver // import "github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver"
 import (
 	"context"
+	"errors"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"

--- a/receiver/sapnetweaverreceiver/go.mod
+++ b/receiver/sapnetweaverreceiver/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/hooklift/gowsdl v0.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/collector v0.69.0
 	go.opentelemetry.io/collector/component v0.69.0

--- a/receiver/sapnetweaverreceiver/metrics.go
+++ b/receiver/sapnetweaverreceiver/metrics.go
@@ -15,11 +15,11 @@
 package sapnetweaverreceiver // import "github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver"
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 


### PR DESCRIPTION
### Proposed Change
I think this was missed in the original SAP PR but the receiver was using the `github.com/pkg/errors` package in place of the stdlib `errors` package. I switched it to using the stdlib package to reduce the dependencies of the receiver.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
