### PR TITLE
fix: hotfix issue where GCL logs would get copies of previous log attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -572,4 +572,5 @@ replace github.com/observiq/observiq-otel-collector/internal/expr => ./internal/
 replace github.com/mattn/go-ieproxy v0.0.9 => github.com/mattn/go-ieproxy v0.0.1
 
 // This is a fork of the official opentelemetry-operations-go exporter that removes the credential autodiscovery logic that conflicts with our own custom logic
-replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.34.3-0.20221202192616-0186b89ba914 => github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20221215164112-d92100d9c728
+// Also contains a hotfix for log issue described here: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/572
+replace github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.34.3-0.20221202192616-0186b89ba914 => github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20230124133244-01510a5dd153

--- a/go.sum
+++ b/go.sum
@@ -1393,8 +1393,8 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
-github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20221215164112-d92100d9c728 h1:FAoP0XFEBDTUOpV2Jof0MeITIJWKR4XenCLk/bOFReg=
-github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20221215164112-d92100d9c728/go.mod h1:Ak7usPCI+GqelKZTtbE7Sk4+ci2jjnkfl4X04YH7/ZY=
+github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20230124133244-01510a5dd153 h1:MVqTzny3jhLig1llOp10aWd9OBvMxJS90X+9m1VG1fA=
+github.com/observiq/opentelemetry-operations-go/exporter/collector v0.26.1-0.20230124133244-01510a5dd153/go.mod h1:Ak7usPCI+GqelKZTtbE7Sk4+ci2jjnkfl4X04YH7/ZY=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=


### PR DESCRIPTION
### Proposed Change
Updates our forked version of opentelemetry-operations-go to https://github.com/observIQ/opentelemetry-operations-go/commit/01510a5dd153cb6d89d777e2491a383bc9c195a7 - this fixes a bug where labels of previous logs would be placed on subsequent logs under scenerios with moderate throughput.

Tested against a postgres log that was known to cause the issue.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
