### PR TITLE
feat: Added feature flag for delete after read

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -75,6 +75,11 @@ func main() {
 
 	var runnableService service.RunnableService
 
+	// Set feature flags
+	if err := collector.SetFeatureFlags(); err != nil {
+		log.Fatalf("Failed to set feature flags: %v", err)
+	}
+
 	col := collector.New(*collectorConfigPaths, version.Version(), logOpts)
 
 	// See if manager config file exists. If so run in remote managed mode otherwise standalone mode

--- a/collector/featuregates.go
+++ b/collector/featuregates.go
@@ -1,0 +1,26 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import "go.opentelemetry.io/collector/featuregate"
+
+// SetFeatureFlags sets hardcoded collector feature flags
+func SetFeatureFlags() error {
+	var featuregateMap = map[string]bool{
+		"filelog.allowFileDeletion": true, // Enables delete after read functionality for the filelog receiver
+	}
+
+	return featuregate.GlobalRegistry().Apply(featuregateMap)
+}

--- a/collector/featuregates_test.go
+++ b/collector/featuregates_test.go
@@ -1,0 +1,25 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFeatureFlags(t *testing.T) {
+	require.NoError(t, SetFeatureFlags())
+}

--- a/go.mod
+++ b/go.mod
@@ -142,6 +142,7 @@ require (
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.70.0
 	go.opentelemetry.io/collector/extension/ballastextension v0.70.0
 	go.opentelemetry.io/collector/extension/zpagesextension v0.70.0
+	go.opentelemetry.io/collector/featuregate v0.70.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rc4
 	go.opentelemetry.io/collector/processor/batchprocessor v0.70.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0
@@ -176,8 +177,7 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect; indi70.0
-	go.opentelemetry.io/collector/featuregate v0.70.0 // indir7ct
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,7 @@ require (
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.70.0 // indirect; indi70.0
-	go.opentelemetry.io/collector/featuregate v0.70.0 // indirect; indir7ct
+	go.opentelemetry.io/collector/featuregate v0.70.0 // indir7ct
 )
 
 require (


### PR DESCRIPTION
### Proposed Change
Hard coded `filelog.allowFileDeletion` to `true` to enable `delete_after_read` functionality in filelog receiver.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
