### PR TITLE
fix: Remove OpAMP setup from MSI on older version of Windows

### DIFF
--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -42,6 +42,8 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+
+         <!-- If we're windows 7 or older don't show OpAMP promtp -->
          <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4"><![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4"><![CDATA[(VersionNT < 603 OR VersionNT64 < 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
 

--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -42,7 +42,8 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">WINMAJORVERSION and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">(NOT WINMAJORVERSION) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
 
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
@@ -51,7 +52,8 @@
          <Publish Dialog="ConfigureManagementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">NOT ENABLEMANAGEMENT OR OPAMPENDPOINT</Publish>
          <Publish Dialog="ConfigureManagementDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">1</Publish>
 
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">WINMAJORVERSION AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">NOT WINMAJORVERSION AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">WIX_UPGRADE_DETECTED</Publish>
 

--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -43,7 +43,7 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
-         <!-- If we're windows 7 or older don't show OpAMP promtp -->
+         <!-- If we're windows 7 or older don't show OpAMP prompt -->
          <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4"><![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4"><![CDATA[(VersionNT < 603 OR VersionNT64 < 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
 

--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -42,8 +42,8 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">(VersionNT >= 603 OR VersionNT64 >= 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">(VersionNT < 603 OR VersionNT64 < 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4"><![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4"><![CDATA[(VersionNT < 603 OR VersionNT64 < 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")]]></Publish>
 
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
@@ -52,8 +52,8 @@
          <Publish Dialog="ConfigureManagementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">NOT ENABLEMANAGEMENT OR OPAMPENDPOINT</Publish>
          <Publish Dialog="ConfigureManagementDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">1</Publish>
 
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">(VersionNT < 603 OR VersionNT64 < 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg"><![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED]]></Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg"><![CDATA[(VersionNT < 603 OR VersionNT64 < 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED]]></Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">WIX_UPGRADE_DETECTED</Publish>
 

--- a/windows/templates/WixUI_HK.wxs
+++ b/windows/templates/WixUI_HK.wxs
@@ -42,8 +42,8 @@
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
          <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">WINMAJORVERSION and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
-         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">(NOT WINMAJORVERSION) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ConfigureManagementDlg" Order="4">(VersionNT >= 603 OR VersionNT64 >= 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
+         <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">(VersionNT < 603 OR VersionNT64 < 603) and (WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1")</Publish>
 
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
          <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
@@ -52,8 +52,8 @@
          <Publish Dialog="ConfigureManagementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">NOT ENABLEMANAGEMENT OR OPAMPENDPOINT</Publish>
          <Publish Dialog="ConfigureManagementDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">1</Publish>
 
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">WINMAJORVERSION AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
-         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">NOT WINMAJORVERSION AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ConfigureManagementDlg">(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
+         <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">(VersionNT < 603 OR VersionNT64 < 603) AND NOT Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg">Installed AND NOT WIX_UPGRADE_DETECTED</Publish>
          <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">WIX_UPGRADE_DETECTED</Publish>
 

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -49,6 +49,11 @@
       <Condition Message="{{$c.Message}}"><![CDATA[{{$c.Condition}}]]></Condition>
       {{end}}
       
+      <!-- Check to see if the CurrentMajorVersionNumber registry key exists. It won't on systems earlier than Windows 10-->
+      <Property Id="WINMAJORVERSION">
+          <RegistrySearch Id="MajorVersionNumberExists" Type="raw"
+            Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentMajorVersionNumber" />
+      </Property>
 
       <!-- Load previous install directory (if it exists); This will populate the install dir with the current install dir
            for upgrades. -->
@@ -222,20 +227,23 @@
          </Custom>
          {{end}}
 
+        <!-- The below custom actions should be skipped if WINMAJORVERSION is not set. 
+            This indicates the targert system is older than Windows 10 and the installation may hang on these steps -->
+
         <!-- Schedule the action that creates the manager.yaml file on initial install -->
         <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[WINMAJORVERSION AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
-            <![CDATA[NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[WINMAJORVERSION AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         
         <!-- Schedule the action that removes the manager.yaml file on final uninstall -->
         <Custom Action="CustomExecRemoveManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+            <![CDATA[WINMAJORVERSION and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
         <Custom Action="CustomExecRemoveManagerYaml" Before="RemoveFiles" >
-            <![CDATA[REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+            <![CDATA[WINMAJORVERSION and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
       </InstallExecuteSequence>
 

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -221,8 +221,9 @@
          </Custom>
          {{end}}
 
-        <!-- The below custom actions should be skipped if VersionNT is set as it's only available on versions of 32bit Windows pre. 
-            This indicates the targert system is older than Windows 10 and the installation may hang on these steps -->
+        <!-- The below custom actions should be skipped if VersionNT (32 bit systems) or VersionNT64 (64 bit systems) is >= 603.
+            This should filter out older versions of Windows where some custom actions get stuck. 
+            Link to windows versions for reference https://learn.microsoft.com/en-us/windows/win32/msi/operating-system-property-values-->
 
         <!-- Schedule the action that creates the manager.yaml file on initial install -->
         <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -49,12 +49,6 @@
       <Condition Message="{{$c.Message}}"><![CDATA[{{$c.Condition}}]]></Condition>
       {{end}}
       
-      <!-- Check to see if the CurrentMajorVersionNumber registry key exists. It won't on systems earlier than Windows 10-->
-      <Property Id="WINMAJORVERSION">
-          <RegistrySearch Id="MajorVersionNumberExists" Type="raw"
-            Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="CurrentMajorVersionNumber" />
-      </Property>
-
       <!-- Load previous install directory (if it exists); This will populate the install dir with the current install dir
            for upgrades. -->
       <Property Id="INSTALLDIR">
@@ -227,23 +221,23 @@
          </Custom>
          {{end}}
 
-        <!-- The below custom actions should be skipped if WINMAJORVERSION is not set. 
+        <!-- The below custom actions should be skipped if VersionNT is set as it's only available on versions of 32bit Windows pre. 
             This indicates the targert system is older than Windows 10 and the installation may hang on these steps -->
 
         <!-- Schedule the action that creates the manager.yaml file on initial install -->
         <Custom Action="CustomExecCreateManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[WINMAJORVERSION AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         <Custom Action="CustomExecCreateManagerYaml" After="InstallFiles" >
-            <![CDATA[WINMAJORVERSION AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) AND NOT Installed AND NOT REMOVE AND ENABLEMANAGEMENT AND NOT WIX_UPGRADE_DETECTED]]>
         </Custom>
         
         <!-- Schedule the action that removes the manager.yaml file on final uninstall -->
         <Custom Action="CustomExecRemoveManagerYaml_set" After="InstallInitialize" >
-            <![CDATA[WINMAJORVERSION and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
         <Custom Action="CustomExecRemoveManagerYaml" Before="RemoveFiles" >
-            <![CDATA[WINMAJORVERSION and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
+            <![CDATA[(VersionNT >= 603 OR VersionNT64 >= 603) and REMOVE="ALL" and not UPGRADINGPRODUCTCODE]]>
         </Custom>
       </InstallExecuteSequence>
 


### PR DESCRIPTION
### Proposed Change
Added logic to MSI to not give the user the option to add the `manager.yaml` on install for Windows 7 or older.

We utilize the [VersionNT](https://learn.microsoft.com/en-us/windows/win32/msi/versionnt) and [VersionNT64](https://learn.microsoft.com/en-us/windows/win32/msi/versionnt64) properties to determine the Windows version and make OpAMP installation logic conditional.

Tested this on Windows 7 32bit and Windows Server 2012 R2 64bit.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
