### PR TITLE
feat(plugin): Add checkpoint storage to container plugin

### DIFF
--- a/docs/plugins/container_logs.md
+++ b/docs/plugins/container_logs.md
@@ -18,6 +18,8 @@ When set to `auto`, the format will be detected using regex. Format detection
 is convenient but comes with the cost of performing a regex match against every
 log entry read by the filelog receiver.
  | string | `auto` | false | `auto`, `docker-json-file`, `containerd-cri` |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_STORAGE` | false |  |
+
 
 ## Example Config:
 

--- a/docs/plugins/container_logs.md
+++ b/docs/plugins/container_logs.md
@@ -18,8 +18,7 @@ When set to `auto`, the format will be detected using regex. Format detection
 is convenient but comes with the cost of performing a regex match against every
 log entry read by the filelog receiver.
  | string | `auto` | false | `auto`, `docker-json-file`, `containerd-cri` |
-| offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_STORAGE` | false |  |
-
+| offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_HOME/storage` | false |  |
 
 ## Example Config:
 
@@ -37,4 +36,5 @@ receivers:
       body_json_parsing: true
       start_at: end
       log_driver: auto
+      offset_storage_dir: $OIQ_OTEL_COLLECTOR_HOME/storage
 ```

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -50,12 +50,20 @@ parameters:
       # This format is not well documented: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/logs/logs.go#L125-L169
       - containerd-cri
     default: auto
-
+  - name: offset_storage_dir
+    description: The directory that the offset storage file will be created
+    type: string
+    default: $OIQ_OTEL_COLLECTOR_STORAGE
 
 template: |
+  extensions:
+    file_storage:
+      directory: {{ .offset_storage_dir }}
+
   receivers:
     {{ if eq .log_source "file" }}
     filelog:
+        storage: file_storage
         include:
           {{ range $fp := .log_paths }}
             - '{{ $fp }}'
@@ -160,6 +168,7 @@ template: |
 
     {{ if eq .log_source "journald" }}
     journald:
+      storage: file_storage
       directory: {{ .journald_path }}
       operators:
         - type: router
@@ -209,6 +218,8 @@ template: |
     {{ end }}
 
   service:
+    extensions:
+      - file_storage
     pipelines:
       logs:
         receivers:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.3.1
+version: 0.4.0
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -53,7 +53,7 @@ parameters:
   - name: offset_storage_dir
     description: The directory that the offset storage file will be created
     type: string
-    default: $OIQ_OTEL_COLLECTOR_STORAGE
+    default: $OIQ_OTEL_COLLECTOR_HOME/storage
 
 template: |
   extensions:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Added the storage extension to the container logs plugin, following the pattern established [here](https://github.com/observIQ/observiq-otel-collector/commit/25abf408990357b4ae7fdf4e92d18c8fdf7b90f5).

The environment variable `OIQ_OTEL_COLLECTOR_STORAGE` is [set by default](https://github.com/observIQ/observiq-otel-collector/blob/main/docker/Dockerfile.ubuntu#L60) to `/etc/otel/storage`. Users will likely modify this to fit their deployment.

The plugin has two possible receivers (filelog and journald), both of which support the storage extension.

I tested by:
1. Deploying 1.17.0 and verifying that logs were flowing correctly
2. Build an image from my branch and updated my container
3. Verified that logs were flowing correctly
4. Deleted my agent
5. Waited two minutes and re-deployed the agent
6. Verified that the collector "caught up" by processing old logs and shipped to my destination w/ correct timestamps.

Log screenshot during collector downtime.

![Screenshot from 2023-02-03 14-07-16](https://user-images.githubusercontent.com/23043836/216686582-1075150c-ae86-4a90-9b37-bdbfc8a4d026.png)

After re-deploying the collector and allowing it to catch up.

![Screenshot from 2023-02-03 14-08-15](https://user-images.githubusercontent.com/23043836/216686737-e2b3c1cf-e9e8-4bb5-bf15-b0da5adea52c.png)

When the collector is re-deployed, you can see that it immediatly performs catch up as it logs batches of 200 right away.

```json
{"level":"info","ts":"2023-02-03T19:07:50.413Z","caller":"service/pipelines.go:118","msg":"Receiver started.","kind":"receiver","name":"plugin/container","pipeline":"logs"}
{"level":"info","ts":"2023-02-03T19:07:50.414Z","caller":"service/service.go:145","msg":"Everything is ready. Begin running and processing data."}
{"level":"info","ts":"2023-02-03T19:07:50.673Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":200}
{"level":"info","ts":"2023-02-03T19:07:50.674Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":200}
{"level":"info","ts":"2023-02-03T19:07:51.900Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":19}
{"level":"info","ts":"2023-02-03T19:07:52.904Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":88}
{"level":"info","ts":"2023-02-03T19:07:53.908Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":35}
{"level":"info","ts":"2023-02-03T19:07:54.309Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:07:54.912Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:07:55.314Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":53}
{"level":"info","ts":"2023-02-03T19:07:55.916Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":21}
{"level":"info","ts":"2023-02-03T19:07:57.925Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":61}
{"level":"info","ts":"2023-02-03T19:07:58.326Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":44}
{"level":"info","ts":"2023-02-03T19:07:58.929Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:07:59.330Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":9}
{"level":"info","ts":"2023-02-03T19:07:59.932Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":27}
{"level":"info","ts":"2023-02-03T19:08:00.333Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":50}
{"level":"info","ts":"2023-02-03T19:08:01.939Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":28}
{"level":"info","ts":"2023-02-03T19:08:02.341Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":30}
{"level":"info","ts":"2023-02-03T19:08:02.944Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:08:03.345Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:08:03.947Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":19}
{"level":"info","ts":"2023-02-03T19:08:04.349Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
{"level":"info","ts":"2023-02-03T19:08:05.353Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":77}
{"level":"info","ts":"2023-02-03T19:08:05.955Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":41}
{"level":"info","ts":"2023-02-03T19:08:06.357Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":7}
{"level":"info","ts":"2023-02-03T19:08:06.960Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":16}
{"level":"info","ts":"2023-02-03T19:08:07.362Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":9}
{"level":"info","ts":"2023-02-03T19:08:07.964Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":19}
{"level":"info","ts":"2023-02-03T19:08:08.968Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":17}
{"level":"info","ts":"2023-02-03T19:08:09.370Z","msg":"LogsExporter","kind":"exporter","data_type":"logs","name":"logging","#logs":8}
```

##### Checklist

- [x] Changes are tested
- [x] CI has passed
