### PR TITLE
Replaced actions/cache with built-in cache in setup-go for actions

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -13,15 +13,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Install Tools
         run: make install-tools
       - name: Check Formatting

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -13,15 +13,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Install Tools
         run: make install-tools
       - name: Check License Headers

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -18,15 +18,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -85,15 +78,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -13,15 +13,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Install Tools
         run: make install-tools
       - name: Check for Misspelled Words in Doc Files

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -16,15 +16,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Build
         run: make build-linux
       - name: Scan Third Party Dependency Licenses
@@ -41,15 +34,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Build
         run: make build-darwin
       - name: Scan Third Party Dependency Licenses
@@ -66,15 +52,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Build
         run: make build-windows
       - name: Scan Third Party Dependency Licenses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -82,15 +75,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -155,6 +141,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,38 +17,8 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-
-      # Load caches based on OS
-      - name: Linux Cache Go Modules
-        if: matrix.os == 'ubuntu-20.04'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: MacOS Cache Go Modules
-        if: matrix.os == 'macos-11'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Windows Cache Go Modules
-        if: matrix.os == 'windows-2019'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache: true
+          cache-dependency-path: '**/go.sum'
       - name: Run Tests
         run: make test
       - name: Run Updater Integration Tests (non-linux)


### PR DESCRIPTION
### Proposed Change
Replaced `actions/cache` references in CI/CD with built in option for the [setup-go action](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs)

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
