### PR TITLE
Updated all modules to Go 1.19

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Install Tools
         run: make install-tools

--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Install Tools
         run: make install-tools

--- a/.github/workflows/check_plugin_docs.yml
+++ b/.github/workflows/check_plugin_docs.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Plugin Doc Generation
         run: make create-plugin-docs

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: "1.19"
           check-latest: true
-      - name: Install Goec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
+      - name: Install Tools
+        run: make install-tools
       - name: Run Gosec Security Scanner
         run: make gosec

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Install Goec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0

--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Install Tools
         run: make install-tools

--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Build
         run: make build-linux
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Build
         run: make build-darwin
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Build
         run: make build-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
           cache-dependency-path: '**/go.sum'
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
           cache-dependency-path: '**/go.sum'
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
           cache: true
           cache-dependency-path: '**/go.sum'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
           check-latest: true
       - name: Run Tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ fmt:
 
 .PHONY: tidy
 tidy:
-	$(MAKE) for-all CMD="go mod tidy -compat=1.18"
+	$(MAKE) for-all CMD="go mod tidy -compat=1.19"
 
 .PHONY: gosec
 gosec:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ install-tools:
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/sigstore/cosign/cmd/cosign@v1.10.1
 	go install github.com/goreleaser/goreleaser@v1.14.1
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.15.0
 	go install github.com/uw-labs/lichen@v0.1.7
 	go install github.com/vektra/mockery/v2@v2.14.0
 	go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen@latest

--- a/cmd/plugindocgen/go.mod
+++ b/cmd/plugindocgen/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/plugindocgen
 
-go 1.18
+go 1.19
 
 require (
 	github.com/observiq/observiq-otel-collector/receiver/pluginreceiver v1.19.0

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/exporter/googlecloudexporter
 
-go 1.18
+go 1.19
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.35.1

--- a/expr/go.mod
+++ b/expr/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/expr
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0

--- a/opamp/observiq/observiq_downloadable_file_manager.go
+++ b/opamp/observiq/observiq_downloadable_file_manager.go
@@ -89,7 +89,11 @@ func (m DownloadableFileManager) downloadFile(downloadURL string, outPath string
 	if err != nil {
 		return fmt.Errorf("could not GET url: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			m.logger.Warn("Failed to close response body while downloading file", zap.String("URL", downloadURL), zap.Error(err))
+		}
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("got non-200 status code (%d)", resp.StatusCode)

--- a/packagestate/go.mod
+++ b/packagestate/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/packagestate
 
-go 1.18
+go 1.19
 
 require (
 	github.com/open-telemetry/opamp-go v0.2.0

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/logcountprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/observiq/observiq-otel-collector/expr v1.19.0

--- a/processor/logdeduplicationprocessor/go.mod
+++ b/processor/logdeduplicationprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/logdeduplicationprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.71.0

--- a/processor/maskprocessor/go.mod
+++ b/processor/maskprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/maskprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/processor/metricextractprocessor/go.mod
+++ b/processor/metricextractprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/metricextractprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/observiq/observiq-otel-collector/expr v1.19.0

--- a/processor/metricstatsprocessor/go.mod
+++ b/processor/metricstatsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/metricstatsprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.70.0

--- a/processor/resourceattributetransposerprocessor/go.mod
+++ b/processor/resourceattributetransposerprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/resourceattributetransposerprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/processor/samplingprocessor/go.mod
+++ b/processor/samplingprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/samplingprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/processor/throughputmeasurementprocessor/go.mod
+++ b/processor/throughputmeasurementprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/processor/throughputmeasurementprocessor
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/receiver/pluginreceiver/go.mod
+++ b/receiver/pluginreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/receiver/pluginreceiver
 
-go 1.18
+go 1.19
 
 require (
 	github.com/mitchellh/mapstructure v1.5.0

--- a/receiver/routereceiver/go.mod
+++ b/receiver/routereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/receiver/routereceiver
 
-go 1.18
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.1

--- a/receiver/sapnetweaverreceiver/go.mod
+++ b/receiver/sapnetweaverreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver
 
-go 1.18
+go 1.19
 
 require (
 	github.com/hooklift/gowsdl v0.5.0

--- a/updater/go.mod
+++ b/updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/observiq/observiq-otel-collector/updater
 
-go 1.18
+go 1.19
 
 require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51


### PR DESCRIPTION
### Proposed Change
Updated all modules to Go 1.19 as OTel has updated in the [v0.72.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.72.0) release. 

Gosec needed to be updated to v2.15.0 as there was a failure while running on 1.19. The new version of gosec also identified an ignored error on defer so a logging statement was added.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
