### PR TITLE
feat: Add flag to Linux Install to specify local package

### DIFF
--- a/docs/installation-linux.md
+++ b/docs/installation-linux.md
@@ -24,6 +24,13 @@ sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/re
 
 To read more about the generated connection configuration file see [OpAMP docs](./opamp.md).
 
+### Installation from local package
+
+To install the collector from a local package use the `-f` with the path to the package.
+
+```sh
+sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_unix.sh)" install_unix.sh -f <path_to_package>
+```
 
 ### RPM Installation
 First download the RPM package for your architecture from the [releases page](https://github.com/observIQ/observiq-otel-collector/releases/latest).

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -357,7 +357,7 @@ set_os_arch()
 # Set the package type before install
 set_package_type()
 {
-  # if package_path is set get the file extension otherwise looks what's avabile on the system
+  # if package_path is set get the file extension otherwise look at what's available on the system
   if [ -n "$package_path" ]; then
     case "$package_path" in
       *.deb)


### PR DESCRIPTION
### Proposed Change
Resolves #934 

Added the `-f`/`--file` flag to the Linux installation script to allow for specifying a file path to a local package to install.

**Screen shot using the `--file` flag:**
<img width="849" alt="Screenshot 2023-02-27 at 9 34 38 AM" src="https://user-images.githubusercontent.com/11877763/221595075-d7ef8c39-1118-41a2-a2b0-49812eca6540.png">



##### Checklist
- [x] Changes are tested
- [ ] CI has passed
