### PR TITLE
feat: Enhance IIS plugin with automatic field detection and storage

### DIFF
--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -8,14 +8,14 @@ Log parser for IIS
 |:-- |:-- |:-- |:-- |:-- |:-- |
 | file_path | Specify a single path or multiple paths to read one or many files. You may also use a wildcard (*) to read multiple files within a directory | []string | `[C:/inetpub/logs/LogFiles/W3SVC*/**/*.log]` | false |  |
 | log_format | The format of the IIS logs. For more information on the various log formats, see: https://docs.microsoft.com/en-us/previous-versions/iis/6.0-sdk/ms525807%28v=vs.90%29 | string | `w3c` | false | `w3c`, `iis`, `ncsa` |
-| w3c_header | The W3C header which specifies the field names. Only applicable if log_format is w3c. | string | `date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken` | false |  |
+| w3c_header | The W3C header which specifies the field names. Only applicable if log_format is w3c. Fields are automatically detected if unspecified. 'start_at' must be beginning if unspecified. | string |  | false |  |
 | exclude_file_log_path | Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory | []string | `[]` | false |  |
 | timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
 | include_file_name | Enable to include file name in logs | bool | `true` | false |  |
 | include_file_path | Enable to include file path in logs | bool | `true` | false |  |
 | include_file_name_resolved | Enable to include file name resolved in logs | bool | `false` | false |  |
 | include_file_path_resolved | Enable to include file path resolved in logs | bool | `false` | false |  |
-| start_at | At startup, where to start reading logs from the file (`beginning` or `end`) | string | `end` | false | `beginning`, `end` |
+| start_at | At startup, where to start reading logs from the file (`beginning` or `end`). | string | `beginning` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
 
@@ -30,14 +30,13 @@ receivers:
     parameters:
       file_path: [C:/inetpub/logs/LogFiles/W3SVC*/**/*.log]
       log_format: w3c
-      w3c_header: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken
       exclude_file_log_path: []
       timezone: UTC
       include_file_name: true
       include_file_path: true
       include_file_name_resolved: false
       include_file_path_resolved: false
-      start_at: end
+      start_at: beginning
       retain_raw_logs: false
       parse_to: body
 ```

--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -18,6 +18,7 @@ Log parser for IIS
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`). | string | `beginning` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
+| offset_storage_dir | The directory that the offset storage file will be created | string | `$OIQ_OTEL_COLLECTOR_HOME/storage` | false |  |
 
 ## Example Config:
 
@@ -39,4 +40,5 @@ receivers:
       start_at: beginning
       retain_raw_logs: false
       parse_to: body
+      offset_storage_dir: $OIQ_OTEL_COLLECTOR_HOME/storage
 ```

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -60,11 +60,19 @@ parameters:
       - body
       - attributes
     default: body
+  - name: offset_storage_dir
+    description: The directory that the offset storage file will be created
+    type: string
+    default: $OIQ_OTEL_COLLECTOR_HOME/storage
 template: |
+  extensions:
+    file_storage:
+      directory: {{ .offset_storage_dir }}
   receivers:
     # W3C format
     {{if eq .log_format "w3c"}}
     filelog:
+      storage: file_storage
       include: 
       {{ range $i, $fp := .file_path }}
         - '{{ $fp }}'
@@ -169,6 +177,7 @@ template: |
     # IIS format
     {{if eq .log_format "iis"}}
     filelog:
+      storage: file_storage
       include: 
       {{ range $i, $fp := .file_path }}
         - '{{ $fp }}'
@@ -243,7 +252,8 @@ template: |
     # NCSA format
     {{if eq .log_format "ncsa"}}
     filelog:
-      include: 
+      storage: file_storage
+      include:
       {{ range $i, $fp := .file_path }}
         - '{{ $fp }}'
       {{ end }}
@@ -293,6 +303,7 @@ template: |
       {{ end }}
     {{end}}
   service:
+    extensions: [file_storage]
     pipelines:
       logs:
         receivers:

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.5.0
 title: IIS
 description: Log parser for IIS
 parameters:
@@ -16,9 +16,8 @@ parameters:
       - ncsa
     default: w3c
   - name: w3c_header
-    description: "The W3C header which specifies the field names. Only applicable if log_format is w3c."
+    description: "The W3C header which specifies the field names. Only applicable if log_format is w3c. Fields are automatically detected if unspecified. 'start_at' must be beginning if unspecified."
     type: "string"
-    default: "date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) sc-status sc-substatus sc-win32-status time-taken"
   - name: exclude_file_log_path
     description: Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory
     type: "[]string"
@@ -44,12 +43,12 @@ parameters:
     type: bool
     default: false
   - name: start_at
-    description: At startup, where to start reading logs from the file (`beginning` or `end`)
+    description: At startup, where to start reading logs from the file (`beginning` or `end`).
     type: string
     supported:
       - beginning
       - end
-    default: end
+    default: beginning
   - name: retain_raw_logs
     description: When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured.
     type: bool
@@ -75,7 +74,15 @@ template: |
       {{ range $i, $efp := .exclude_file_log_path }}
         - '{{ $efp }}'
       {{ end }}
-     {{ end }}
+      {{ end }}
+      {{ if not .w3c_header }}
+      header:
+        pattern: "^#"
+        metadata_operators:
+          - type: regex_parser
+            regex: "^#Fields: (?P<header_fields>.*)$"
+            if: 'body startsWith "#Fields: "'
+      {{ end }}
       include_file_name: {{ .include_file_name }}
       include_file_path: {{ .include_file_path }}
       include_file_name_resolved: {{ .include_file_name_resolved }}
@@ -93,10 +100,19 @@ template: |
       {{ end }}
 
       - type: csv_parser
+        {{ if .w3c_header }}
         header: '{{ .w3c_header }}'
+        {{ else }}
+        header_attribute: 'header_fields'
+        {{ end }}
         parse_to: {{ .parse_to }}
         delimiter: " "
         ignore_quotes: true
+
+      {{ if not .w3c_header }}
+      - type: remove
+        field: "attributes.header_fields"
+      {{ end }}
 
       - type: severity_parser
         if: '{{ .parse_to }}["sc-status"] != nil'


### PR DESCRIPTION
### Proposed Change
* Change default for `start_at` to beginning on w3c (this is required if headers are being auto-detected!)
* Mark `w3c_header` parameter as not required (if not specified, automatic field detection is enabled)
* Add storage to the IIS plugin
  * This is needed, otherwise the plugin will always start from the beginning in auto-header mode and re-emit log files that have already been read.


<details>
<summary>Config</summary>

```yaml
receivers:
  plugin:
    path: './plugins/iis_logs.yaml'
    parameters:
      log_format: "w3c"
      file_path:
        - ./tmp/w3c_format_logs.log
 
exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    logs:
      receivers: [plugin]
      exporters: [logging]
  telemetry:
    metrics:
      level: none

```
</details>

<details>
<summary>Log</summary>

```
#Software: Microsoft Internet Information Services 10.0
#Version: 1.0
#Date: 2022-08-09 20:25:26
#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken
2022-08-09 20:25:26 W3SVC1 <Server> 127.0.0.1 GET /query param1=1&parma2=2 80 - 127.0.0.1 HTTP/1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0 - - localhost 404 0 2 5029 464 83
```
</details>


<details>
<summary>Output</summary>

```
ObservedTimestamp: 2023-03-06 18:35:25.309217 +0000 UTC
Timestamp: 2022-08-09 20:25:26 +0000 UTC
SeverityText: 404
SeverityNumber: Warn(13)
Body: Map({\"c-ip\":\"127.0.0.1\",\"cs(Cookie)\":\"-\",\"cs(Referer)\":\"-\",\"cs(User-Agent)\":\"Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64;+rv:103.0)+Gecko/20100101+Firefox/103.0\",\"cs-bytes\":\"464\",\"cs-host\":\"localhost\",\"cs-method\":\"GET\",\"cs-uri-query\":\"param1=1\\u0026parma2=2\",\"cs-uri-stem\":\"/query\",\"cs-username\":\"-\",\"cs-version\":\"HTTP/1.1\",\"s-computername\":\"\\u003cServer\\u003e\",\"s-ip\":\"127.0.0.1\",\"s-port\":\"80\",\"s-sitename\":\"W3SVC1\",\"sc-bytes\":\"5029\",\"sc-status\":\"404\",\"sc-substatus\":\"0\",\"sc-win32-status\":\"2\",\"time-taken\":\"83\",\"timestamp\":\"2022-08-09 20:25:26\"})
Attributes:
     -> log.file.name: Str(w3c_format_logs.log)
     -> log.file.path: Str(tmp/w3c_format_logs.log)
     -> log_type: Str(microsoft_iis)
Trace ID: 
Span ID: 
Flags: 0
```
</details>

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
