### PR TITLE
fix(container): Remove --config flag from entrypoint command

### DIFF
--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -85,4 +85,3 @@ WORKDIR /etc/otel
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
 # connecting to an OpAMP platform.
 ENTRYPOINT [ "/collector/observiq-otel-collector" ]
-CMD ["--config", "/etc/otel/config.yaml"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -86,4 +86,3 @@ WORKDIR /etc/otel
 # User should mount /etc/otel/config.yaml at runtime using docker volumes / k8s configmap unless
 # connecting to an OpAMP platform.
 ENTRYPOINT [ "/collector/observiq-otel-collector" ]
-CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The `--config` flag is redundant with `WORKDIR /etc/otel`. The config, `/etc/otel/config.yaml` will get used by default if no flag or environment variable are specified.

This resolves an issue where a user might set `CONFIG_YAML_PATH` only to have it overwritten by the `--config` flag which is set in the Dockerfile.

I verified that the container image runs without issue, and uses `/etc/otel/config.yaml` by default, of nothing is specified.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
