### PR TITLE
fix(sapnetweaverreceiver):  Record empty response values correctly

### DIFF
--- a/receiver/sapnetweaverreceiver/metrics.go
+++ b/receiver/sapnetweaverreceiver/metrics.go
@@ -41,7 +41,7 @@ var (
 
 func (s *sapNetweaverScraper) recordSapnetweaverSystemInstanceAvailabilityDataPoint(now pcommon.Timestamp, systemInstanceListResponse *models.GetSystemInstanceListResponse, errs *scrapererror.ScrapeErrors) {
 	metricName := "Service Availability"
-	if systemInstanceListResponse.Instance == nil {
+	if systemInstanceListResponse.Instance.Item == nil {
 		err := formatErrorMsg(metricName, "", errValueNotFound)
 		errs.AddPartial(1, err)
 		return
@@ -72,7 +72,7 @@ func (s *sapNetweaverScraper) recordSapnetweaverSystemInstanceAvailabilityDataPo
 
 func (s *sapNetweaverScraper) recordSapnetweaverProcessAvailabilityDataPoint(now pcommon.Timestamp, processListResponse *models.GetProcessListResponse, errs *scrapererror.ScrapeErrors) {
 	metricName := "Process Availability"
-	if processListResponse.Process == nil {
+	if processListResponse.Process.Item == nil {
 		err := formatErrorMsg(metricName, "", errValueNotFound)
 		errs.AddPartial(1, err)
 		return
@@ -245,7 +245,8 @@ func (s *sapNetweaverScraper) recordSapnetweaverHostMemoryVirtualOverheadDataPoi
 // recordSapnetweaverWorkProcessActiveCountDataPoint
 func (s *sapNetweaverScraper) recordSapnetweaverWorkProcessActiveCountDataPoint(now pcommon.Timestamp, systemWPTableResponse *models.ABAPGetSystemWPTableResponse, errs *scrapererror.ScrapeErrors) {
 	metricName := "Active Work Processes"
-	if systemWPTableResponse.Workprocess == nil {
+
+	if systemWPTableResponse.Workprocess.Item == nil {
 		err := formatErrorMsg(metricName, "", errValueNotFound)
 		errs.AddPartial(1, err)
 		return
@@ -337,7 +338,7 @@ func parseSessionTable(sessionTable string) map[string]int64 {
 
 // recordSapnetweaverQueueCountDataPoint
 func (s *sapNetweaverScraper) recordSapnetweaverQueueDataPoints(now pcommon.Timestamp, queueStatistic *models.GetQueueStatisticResponse, errs *scrapererror.ScrapeErrors) {
-	if queueStatistic.Queue == nil {
+	if queueStatistic.Queue.Item == nil {
 		err := formatErrorMsg("Queue count, peak and max", "", errValueNotFound)
 		errs.AddPartial(1, err)
 		return

--- a/receiver/sapnetweaverreceiver/scraper_test.go
+++ b/receiver/sapnetweaverreceiver/scraper_test.go
@@ -174,14 +174,50 @@ func TestScraperScrape(t *testing.T) {
 }
 
 func TestScraperScrapeEmpty(t *testing.T) {
+
+	alertTreeResponseDataEmpty := loadAPIResponseData(t, "api-responses", "AlertTreeEmptyResponse.xml")
+	var alertTreeResponse *models.GetAlertTreeResponse
+	err := xml.Unmarshal(alertTreeResponseDataEmpty, &alertTreeResponse)
+	require.NoError(t, err)
+
+	abapSystemWpTabledataEmpty := loadAPIResponseData(t, "api-responses", "ABAPSystemWPTableEmptyResponse.xml")
+	var abapSystemWpTableResponse *models.ABAPGetSystemWPTableResponse
+	err = xml.Unmarshal(abapSystemWpTabledataEmpty, &abapSystemWpTableResponse)
+	require.NoError(t, err)
+
+	enqStatisticDataEmpty := loadAPIResponseData(t, "api-responses", "EnqStatisticEmptyResponse.xml")
+	var enqStatisticResponse *models.EnqGetStatisticResponse
+	err = xml.Unmarshal(enqStatisticDataEmpty, &enqStatisticResponse)
+	require.NoError(t, err)
+
+	processListDataEmpty := loadAPIResponseData(t, "api-responses", "ProcessListEmptyResponse.xml")
+	var processListResponse *models.GetProcessListResponse
+	err = xml.Unmarshal(processListDataEmpty, &processListResponse)
+	require.NoError(t, err)
+
+	queueStatisticDataEmpty := loadAPIResponseData(t, "api-responses", "QueueStatisticEmptyResponse.xml")
+	var queueStatisticResponse *models.GetQueueStatisticResponse
+	err = xml.Unmarshal(queueStatisticDataEmpty, &queueStatisticResponse)
+	require.NoError(t, err)
+
+	systemInstanceListDataEmpty := loadAPIResponseData(t, "api-responses", "SystemInstanceListEmptyResponse.xml")
+	var systemInstanceListResponse *models.GetSystemInstanceListResponse
+	err = xml.Unmarshal(systemInstanceListDataEmpty, &systemInstanceListResponse)
+	require.NoError(t, err)
+
+	InstancePropertiesDataEmpty := loadAPIResponseData(t, "api-responses", "InstancePropertiesEmptyResponse.xml")
+	var InstancePropertiesResponse *models.GetInstancePropertiesResponse
+	err = xml.Unmarshal(InstancePropertiesDataEmpty, &InstancePropertiesResponse)
+	require.NoError(t, err)
+
 	mockService := mocks.MockWebService{}
-	mockService.On("GetAlertTree").Return(&models.GetAlertTreeResponse{}, nil)
-	mockService.On("ABAPGetSystemWPTable").Return(&models.ABAPGetSystemWPTableResponse{}, nil)
-	mockService.On("EnqGetStatistic").Return(&models.EnqGetStatisticResponse{}, nil)
-	mockService.On("GetProcessList").Return(&models.GetProcessListResponse{}, nil)
-	mockService.On("GetQueueStatistic").Return(&models.GetQueueStatisticResponse{}, nil)
-	mockService.On("GetSystemInstanceList").Return(&models.GetSystemInstanceListResponse{}, nil)
-	mockService.On("GetInstanceProperties").Return(&models.GetInstancePropertiesResponse{}, nil)
+	mockService.On("GetAlertTree").Return(alertTreeResponse, nil)
+	mockService.On("ABAPGetSystemWPTable").Return(abapSystemWpTableResponse, nil)
+	mockService.On("EnqGetStatistic").Return(enqStatisticResponse, nil)
+	mockService.On("GetProcessList").Return(processListResponse, nil)
+	mockService.On("GetQueueStatistic").Return(queueStatisticResponse, nil)
+	mockService.On("GetSystemInstanceList").Return(systemInstanceListResponse, nil)
+	mockService.On("GetInstanceProperties").Return(InstancePropertiesResponse, nil)
 	mockService.On("FindFile", "-L", "/usr/sap", "-name", "*.pse").Return([]string{""}, nil)
 	mockService.On("FindFile", "-L", "/usr/sap", "-name", "dpmon", "-path", "*/exe/dpmon").Return([]string{"/usr/sap/EPP/D00/exe/dpmon"}, nil)
 	mockService.On("DpmonExecute", "echo q | /usr/sap/EPP/D00/exe/dpmon pf=/sapmnt/EPP/profile/EPP_D00_sap-app-1 c").Return("", nil)

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/ABAPSystemWPTableEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/ABAPSystemWPTableEmptyResponse.xml
@@ -1,0 +1,3 @@
+<ABAPGetSystemWPTableResponse xmlns="urn:SAPControl">
+ <workprocess></workprocess>
+</ABAPGetSystemWPTableResponse>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/AlertTreeEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/AlertTreeEmptyResponse.xml
@@ -1,0 +1,4 @@
+<GetAlertTreeResponse xmlns="urn:SAPControl">
+ <tree>
+ </tree>
+</GetAlertTreeResponse>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/EnqStatisticEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/EnqStatisticEmptyResponse.xml
@@ -1,0 +1,2 @@
+<EnqStatistic xmlns="urn:SAPControl">
+</EnqStatistic>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/InstancePropertiesEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/InstancePropertiesEmptyResponse.xml
@@ -1,0 +1,4 @@
+<GetInstancePropertiesResponse xmlns="urn:SAPControl">
+ <properties>
+ </properties>
+</GetInstancePropertiesResponse>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/ProcessListEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/ProcessListEmptyResponse.xml
@@ -1,0 +1,4 @@
+<GetProcessListResponse xmlns="urn:SAPControl">
+ <process>
+ </process>
+</GetProcessListResponse>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/QueueStatisticEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/QueueStatisticEmptyResponse.xml
@@ -1,0 +1,4 @@
+<GetQueueStatisticResponse xmlns="urn:SAPControl">
+ <queue>
+ </queue>
+</GetQueueStatisticResponse>

--- a/receiver/sapnetweaverreceiver/testdata/api-responses/SystemInstanceListEmptyResponse.xml
+++ b/receiver/sapnetweaverreceiver/testdata/api-responses/SystemInstanceListEmptyResponse.xml
@@ -1,0 +1,4 @@
+<GetSystemInstanceListResponse xmlns="urn:SAPControl">
+ <instance>
+ </instance>
+</GetSystemInstanceListResponse>


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->

An error is occurring when parsing systemWPTableResponse on an empty response.
``` log
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: panic: runtime error: index out of range [-2]
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: goroutine 115 [running]:
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver.(*sapNetweaverScraper).recordSapnetweaverWorkProcessActiveCountDataPoint(0xc00096a3f0, 0x0?, 0xc001286330, 0x0?)
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/work/observiq-otel-collector/observiq-otel-collector/receiver/sapnetweaverreceiver/metrics.go:272 +0x5b4
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver.(*sapNetweaverScraper).collectABAPGetSystemWPTable(0xc00096a3f0, {0xc001311ef0?, 0x6fd46c0?}, 0xc000136000?, 0xc00099dce0)
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/work/observiq-otel-collector/observiq-otel-collector/receiver/sapnetweaverreceiver/scraper.go:129 +0x168
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver.(*sapNetweaverScraper).collectMetrics(0xc00096a3f0, {0x6fd4730, 0xc0006b9f80}, 0xc000b65d48?)
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/work/observiq-otel-collector/observiq-otel-collector/receiver/sapnetweaverreceiver/scraper.go:110 +0xe5
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: github.com/observiq/observiq-otel-collector/receiver/sapnetweaverreceiver.(*sapNetweaverScraper).scrape(0xc00096a3f0, {0x6fd4730, 0xc0006b9f80})
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/work/observiq-otel-collector/observiq-otel-collector/receiver/sapnetweaverreceiver/scraper.go:103 +0x1bf
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: go.opentelemetry.io/collector/receiver/scraperhelper.ScrapeFunc.Scrape(...)
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/go/pkg/mod/go.opentelemetry.io/collector/receiver@v0.73.0/scraperhelper/scraper.go:31
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).scrapeMetricsAndReport(0xc001315320, {0x6fd46c0, 0xc000136000})
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/go/pkg/mod/go.opentelemetry.io/collector/receiver@v0.73.0/scraperhelper/scrapercontroller.go:209 +0x223
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).startScraping.func1()
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/go/pkg/mod/go.opentelemetry.io/collector/receiver@v0.73.0/scraperhelper/scrapercontroller.go:191 +0xd4
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]: created by go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).startScraping
Mar 10 15:25:24 netweaver-7 observiq-otel-collector[11720]:         /home/runner/go/pkg/mod/go.opentelemetry.io/collector/receiver@v0.73.0/scraperhelper/scrapercontroller.go:180 +0x56
```

This check was failed because the empty response is not an empty object in the form of
```xml
<ABAPGetSystemWPTableResponse xmlns="urn:SAPControl">
</ABAPGetSystemWPTableResponse>
```

but instead as
```xml
<ABAPGetSystemWPTableResponse xmlns="urn:SAPControl">
 <workprocess></workprocess>
</ABAPGetSystemWPTableResponse>
```

So the TestScraperScrapeEmpty has been updated to parse examples of empty responses for all responses.


### Proposed Change
<!-- Please provide a description of the change here. -->

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
