### PR TITLE
feat: Added base_url flag to macOS and Linux installation scripts

### DIFF
--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -173,6 +173,11 @@ Usage:
       Defines the URL that the components will be downloaded from.
       If not provided, this will default to observIQ Distro for OpenTelemetry Collector\'s GitHub releases.
       Example: '-l http://my.domain.org/observiq-otel-collector' will download from there.
+
+  $(fg_yellow '-b, --base-url')
+      Defines the base of the download URL as '{base_url}/download/v{version}/observiq-otel-collector-v{version}-darwin-{os_arch}.tar.gz'.
+      If not provided, this will default to 'https://github.com/observiq/observiq-otel-collector/releases'.
+      Example: '-b http://my.domain.org/observiq-otel-collector/binaries' will be used as the base of the download URL.
    
   $(fg_yellow '-e, --endpoint')
       Defines the endpoint of an OpAMP compatible management server for this collector install.
@@ -373,8 +378,11 @@ set_download_urls()
       error_exit "$LINENO" "Could not determine version to install"
     fi
 
-    url=$DOWNLOAD_BASE
-    collector_download_url="$url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
+    if [ -z "$base_url" ] ; then
+      base_url=$DOWNLOAD_BASE
+    fi
+
+    collector_download_url="$base_url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
   else
     collector_download_url="$url"
   fi
@@ -641,6 +649,8 @@ main()
           opamp_labels=$2 ; shift 2 ;;
         -s|--secret-key)
           opamp_secret_key=$2 ; shift 2 ;;
+        -b|--base-url)
+          base_url=$2 ; shift 2 ;;
       --)
         shift; break ;;
       *)

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -17,7 +17,7 @@ set -e
 
 # Collector Constants
 SERVICE_NAME="com.observiq.collector"
-DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases"
+DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases/download"
 
 # Script Constants
 PREREQS="printf sed uname tr find grep"
@@ -175,7 +175,7 @@ Usage:
       Example: '-l http://my.domain.org/observiq-otel-collector' will download from there.
 
   $(fg_yellow '-b, --base-url')
-      Defines the base of the download URL as '{base_url}/download/v{version}/observiq-otel-collector-v{version}-darwin-{os_arch}.tar.gz'.
+      Defines the base of the download URL as '{base_url}/v{version}/observiq-otel-collector-v{version}-darwin-{os_arch}.tar.gz'.
       If not provided, this will default to 'https://github.com/observiq/observiq-otel-collector/releases'.
       Example: '-b http://my.domain.org/observiq-otel-collector/binaries' will be used as the base of the download URL.
    
@@ -382,7 +382,7 @@ set_download_urls()
       base_url=$DOWNLOAD_BASE
     fi
 
-    collector_download_url="$base_url/download/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
+    collector_download_url="$base_url/v$version/observiq-otel-collector-v${version}-darwin-${os_arch}.tar.gz"
   else
     collector_download_url="$url"
   fi

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -176,7 +176,7 @@ Usage:
 
   $(fg_yellow '-b, --base-url')
       Defines the base of the download URL as '{base_url}/v{version}/observiq-otel-collector-v{version}-darwin-{os_arch}.tar.gz'.
-      If not provided, this will default to 'https://github.com/observiq/observiq-otel-collector/releases'.
+      If not provided, this will default to '$DOWNLOAD_BASE'.
       Example: '-b http://my.domain.org/observiq-otel-collector/binaries' will be used as the base of the download URL.
    
   $(fg_yellow '-e, --endpoint')

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -175,7 +175,7 @@ Usage:
 
   $(fg_yellow '-b, --base-url')
       Defines the base of the download URL as '{base_url}/v{version}/{PACKAGE_NAME}_v{version}_linux_{os_arch}.{package_type}'.
-      If not provided, this will default to 'https://github.com/observiq/observiq-otel-collector/releases'.
+      If not provided, this will default to '$DOWNLOAD_BASE'.
       Example: '-b http://my.domain.org/observiq-otel-collector/binaries' will be used as the base of the download URL.
 
   $(fg_yellow '-f, --file')

--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -17,7 +17,7 @@ set -e
 
 # Collector Constants
 PACKAGE_NAME="observiq-otel-collector"
-DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases"
+DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases/download"
 
 # Script Constants
 COLLECTOR_USER="observiq-otel-collector"
@@ -172,6 +172,11 @@ Usage:
       Defines the URL that the components will be downloaded from.
       If not provided, this will default to observIQ Distro for OpenTelemetry Collector\'s GitHub releases.
       Example: '-l http://my.domain.org/observiq-otel-collector' will download from there.
+
+  $(fg_yellow '-b, --base-url')
+      Defines the base of the download URL as '{base_url}/v{version}/{PACKAGE_NAME}_v{version}_linux_{os_arch}.{package_type}'.
+      If not provided, this will default to 'https://github.com/observiq/observiq-otel-collector/releases'.
+      Example: '-b http://my.domain.org/observiq-otel-collector/binaries' will be used as the base of the download URL.
 
   $(fg_yellow '-f, --file')
       Install Collector from a local file instead of downloading from a URL.
@@ -401,8 +406,11 @@ set_download_urls()
       error_exit "$LINENO" "Could not determine version to install"
     fi
 
-    url=$DOWNLOAD_BASE
-    collector_download_url="$url/download/v$version/${PACKAGE_NAME}_v${version}_linux_${os_arch}.${package_type}"
+    if [ -z "$base_url" ] ; then
+      base_url=$DOWNLOAD_BASE
+    fi
+
+    collector_download_url="$base_url/v$version/${PACKAGE_NAME}_v${version}_linux_${os_arch}.${package_type}"
   else
     collector_download_url="$url"
   fi
@@ -737,6 +745,8 @@ main()
           opamp_labels=$2 ; shift 2 ;;
         -s|--secret-key)
           opamp_secret_key=$2 ; shift 2 ;;
+        -b|--base-url)
+          base_url=$2 ; shift 2 ;;
         -r|--uninstall)
           uninstall
           exit 0


### PR DESCRIPTION
### Proposed Change
Added a `--base_url` flag to the macOS and Linux installation scripts. This allows the script to look at a host other than GitHub for release while still being able to reason about the OS, architecture, and package type needed for the target system.

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
