### PR TITLE
feat(plugin): W3C Plugin: Added most of the possible fields for filelog receiver and csv_parser operator as plugin parameters

### DIFF
--- a/docs/plugins/w3c_logs.md
+++ b/docs/plugins/w3c_logs.md
@@ -10,8 +10,16 @@ Log Parser for W3C
 | exclude_file_log_path | Specify a single path or multiple paths to exclude one or many files from being read. You may also use a wildcard (*) to exclude multiple files from being read within a directory. | []string | `[]` | false |  |
 | encoding | Specify the encoding of the file(s) being read. In most cases, you can leave the default option selected. | string | `utf-8` | false | `utf-8`, `utf-16le`, `utf-16be`, `ascii`, `big5` |
 | log_type | Adds the specified 'Type' as a label to each log message. | string | `w3c` | false |  |
-| start_at | At startup, where to start reading logs from the file. Must be set to "beginning" if 'header' is not specified. | string | `beginning` | false | `beginning`, `end` |
+| start_at | At startup, where to start reading logs from the file. Must be set to "beginning" if 'header' is not specified or if 'delete_after_read' is being used. | string | `beginning` | false | `beginning`, `end` |
 | max_concurrent_files | Max number of W3C files that will be open during a polling cycle | int | `512` | false |  |
+| timestamp_layout | Optional timestamp layout which will parse a timestamp field | string |  | false |  |
+| timestamp_parse_from | Field to parse the timestamp from, required if 'timestamp_layout' is set | string |  | false |  |
+| timestamp_layout_type | Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set | string |  | false | `strptime`, `gotime`, `epoch` |
+| parse_from | Where to parse the data from | string | `body` | false |  |
+| parse_to | Where the data will parse to | string | `body` | false | `attributes`, `body` |
+| lazy_quotes | If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if 'ignore_quotes' is true. | bool | `false` | false |  |
+| ignore_quotes | If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if 'lazy_quotes' is true. | bool | `false` | false |  |
+| delete_after_read | Will delete static log files once they are completely read. When set, 'start_at' must be set to beginning. | bool | `false` | false |  |
 | include_file_name | Include File Name as a label | bool | `true` | false |  |
 | include_file_path | Include File Path as a label | bool | `false` | false |  |
 | include_file_name_resolved | Same as include_file_name, however, if file name is a symlink, the underlying file's name will be set as a label | bool | `false` | false |  |
@@ -36,6 +44,11 @@ receivers:
       log_type: w3c
       start_at: beginning
       max_concurrent_files: 512
+      parse_from: body
+      parse_to: body
+      lazy_quotes: false
+      ignore_quotes: false
+      delete_after_read: false
       include_file_name: true
       include_file_path: false
       include_file_name_resolved: false

--- a/docs/plugins/w3c_logs.md
+++ b/docs/plugins/w3c_logs.md
@@ -12,14 +12,11 @@ Log Parser for W3C
 | log_type | Adds the specified 'Type' as a label to each log message. | string | `w3c` | false |  |
 | start_at | At startup, where to start reading logs from the file. Must be set to "beginning" if 'header' is not specified or if 'delete_after_read' is being used. | string | `beginning` | false | `beginning`, `end` |
 | max_concurrent_files | Max number of W3C files that will be open during a polling cycle | int | `512` | false |  |
-| timestamp_layout | Optional timestamp layout which will parse a timestamp field | string |  | false |  |
+| timestamp_layout | Optional timestamp layout which will parse a timestamp field | string | `%Y-%m-%d %H:%M:%S` | false |  |
 | timestamp_parse_from | Field to parse the timestamp from, required if 'timestamp_layout' is set | string |  | false |  |
 | timestamp_layout_type | Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set | string | `strptime` | false | `strptime`, `gotime`, `epoch` |
-| timestamp_location | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. | string | `UTC` | false |  |
-| parse_from | Where to parse the data from | string | `body` | false |  |
+| timezone | Timezone to use when parsing the timestamp | timezone | `UTC` | false |  |
 | parse_to | Where the data will parse to | string | `body` | false | `attributes`, `body` |
-| lazy_quotes | If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if 'ignore_quotes' is true. | bool | `false` | false |  |
-| ignore_quotes | If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if 'lazy_quotes' is true. | bool | `false` | false |  |
 | delete_after_read | Will delete static log files once they are completely read. When set, 'start_at' must be set to beginning. | bool | `false` | false |  |
 | include_file_name | Include File Name as a label | bool | `true` | false |  |
 | include_file_path | Include File Path as a label | bool | `false` | false |  |
@@ -45,12 +42,10 @@ receivers:
       log_type: w3c
       start_at: beginning
       max_concurrent_files: 512
+      timestamp_layout: %Y-%m-%d %H:%M:%S
       timestamp_layout_type: strptime
-      timestamp_location: UTC
-      parse_from: body
+      timezone: UTC
       parse_to: body
-      lazy_quotes: false
-      ignore_quotes: false
       delete_after_read: false
       include_file_name: true
       include_file_path: false

--- a/docs/plugins/w3c_logs.md
+++ b/docs/plugins/w3c_logs.md
@@ -14,7 +14,7 @@ Log Parser for W3C
 | max_concurrent_files | Max number of W3C files that will be open during a polling cycle | int | `512` | false |  |
 | timestamp_layout | Optional timestamp layout which will parse a timestamp field | string |  | false |  |
 | timestamp_parse_from | Field to parse the timestamp from, required if 'timestamp_layout' is set | string |  | false |  |
-| timestamp_layout_type | Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set | string |  | false | `strptime`, `gotime`, `epoch` |
+| timestamp_layout_type | Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set | string | `strptime` | false | `strptime`, `gotime`, `epoch` |
 | timestamp_location | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. | string | `UTC` | false |  |
 | parse_from | Where to parse the data from | string | `body` | false |  |
 | parse_to | Where the data will parse to | string | `body` | false | `attributes`, `body` |
@@ -45,6 +45,7 @@ receivers:
       log_type: w3c
       start_at: beginning
       max_concurrent_files: 512
+      timestamp_layout_type: strptime
       timestamp_location: UTC
       parse_from: body
       parse_to: body

--- a/docs/plugins/w3c_logs.md
+++ b/docs/plugins/w3c_logs.md
@@ -15,6 +15,7 @@ Log Parser for W3C
 | timestamp_layout | Optional timestamp layout which will parse a timestamp field | string |  | false |  |
 | timestamp_parse_from | Field to parse the timestamp from, required if 'timestamp_layout' is set | string |  | false |  |
 | timestamp_layout_type | Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set | string |  | false | `strptime`, `gotime`, `epoch` |
+| timestamp_location | The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database. | string | `UTC` | false |  |
 | parse_from | Where to parse the data from | string | `body` | false |  |
 | parse_to | Where the data will parse to | string | `body` | false | `attributes`, `body` |
 | lazy_quotes | If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if 'ignore_quotes' is true. | bool | `false` | false |  |
@@ -44,6 +45,7 @@ receivers:
       log_type: w3c
       start_at: beginning
       max_concurrent_files: 512
+      timestamp_location: UTC
       parse_from: body
       parse_to: body
       lazy_quotes: false

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -44,6 +44,10 @@ parameters:
   - name: timestamp_layout_type
     description: Optional timestamp layout type for parsing the timestamp, suggested if timestamp_layout is set
     type: string
+    supported:
+      - strptime
+      - gotime
+      - epoch
   - name: severity
     description: Optional severity block which will parse a severity field
     type: string

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -48,9 +48,6 @@ parameters:
       - strptime
       - gotime
       - epoch
-  - name: severity
-    description: Optional severity block which will parse a severity field
-    type: string
   - name: parse_from
     description: Where to parse the data from
     type: string

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.2.0
 title: W3C
 description: Log Parser for W3C
 parameters:

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -153,6 +153,13 @@ template: |
           lazy_quotes: {{ .lazy_quotes }}
           ignore_quotes: {{ .ignore_quotes }}
           delimiter: '{{ .delimiter }}'
+          {{ if .timestamp_layout }}
+          timestamp:
+            parse_from: {{ .timestamp_parse_from }}
+            layout: '{{ .timestamp_layout }}'
+            layout_type: {{ .timestamp_layout_type }}
+            location: {{ .timestamp_location }}
+          {{ end }}
 
           {{ if .header_delimiter }} 
           header_delimiter: '{{ .header_delimiter }}'
@@ -166,17 +173,6 @@ template: |
         {{ if not .header }}
         - type: remove
           field: "attributes.header_fields"
-        {{ end }}
-        {{ if .timestamp_layout }}
-        timestamp:
-          parse_from: {{ .timestamp_parse_from }}
-          layout: {{ .timestamp_layout }}
-          {{ if .timestamp_layout_type }}
-          layout_type: .timestamp_layout_type
-          {{ end }}
-          {{ if .timestamp_location }}
-          location: .timestamp_location
-          {{ end }}
         {{ end }}
           
   service:

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -25,7 +25,7 @@ parameters:
     type: string
     default: w3c
   - name: start_at
-    description: At startup, where to start reading logs from the file. Must be set to "beginning" if 'header' is not specified.
+    description: At startup, where to start reading logs from the file. Must be set to "beginning" if 'header' is not specified or if 'delete_after_read' is being used.
     type: string
     supported:
       - beginning
@@ -39,10 +39,10 @@ parameters:
     description: Optional timestamp layout which will parse a timestamp field
     type: string
   - name: timestamp_parse_from
-    description: Field to parse the timestamp from, required if timestamp_layout is set
+    description: Field to parse the timestamp from, required if 'timestamp_layout' is set
     type: string
   - name: timestamp_layout_type
-    description: Optional timestamp layout type for parsing the timestamp, suggested if timestamp_layout is set
+    description: Optional timestamp layout type for parsing the timestamp, suggested if 'timestamp_layout' is set
     type: string
     supported:
       - strptime
@@ -60,15 +60,15 @@ parameters:
       - body
     default: body
   - name: lazy_quotes
-    description: If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if ignore_quotes is true.
+    description: If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if 'ignore_quotes' is true.
     type: bool
     default: false
   - name: ignore_quotes
-    description: If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if lazy_quotes is true.
+    description: If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if 'lazy_quotes' is true.
     type: bool
     default: false
   - name: delete_after_read
-    description: Will delete static log files once they are completely read
+    description: Will delete static log files once they are completely read. When set, 'start_at' must be set to beginning.
     type: bool
     default: false
   - name: include_file_name

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -48,6 +48,7 @@ parameters:
       - strptime
       - gotime
       - epoch
+    default: strptime
   - name: timestamp_location
     description: The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database.
     type: string
@@ -172,6 +173,9 @@ template: |
           layout: {{ .timestamp_layout }}
           {{ if .timestamp_layout_type }}
           layout_type: .timestamp_layout_type
+          {{ end }}
+          {{ if .timestamp_location }}
+          location: .timestamp_location
           {{ end }}
         {{ end }}
           

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -48,6 +48,10 @@ parameters:
       - strptime
       - gotime
       - epoch
+  - name: timestamp_location
+    description: The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database.
+    type: string
+    default: UTC
   - name: parse_from
     description: Where to parse the data from
     type: string

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -38,6 +38,7 @@ parameters:
   - name: timestamp_layout
     description: Optional timestamp layout which will parse a timestamp field
     type: string
+    default: '%Y-%m-%d %H:%M:%S'
   - name: timestamp_parse_from
     description: Field to parse the timestamp from, required if 'timestamp_layout' is set
     type: string
@@ -49,14 +50,10 @@ parameters:
       - gotime
       - epoch
     default: strptime
-  - name: timestamp_location
-    description: The geographic location (timezone) to use when parsing a timestamp that does not include a timezone. The available locations depend on the local IANA Time Zone database.
-    type: string
+  - name: timezone
+    description: Timezone to use when parsing the timestamp
+    type: timezone
     default: UTC
-  - name: parse_from
-    description: Where to parse the data from
-    type: string
-    default: body
   - name: parse_to
     description: Where the data will parse to
     type: string
@@ -64,14 +61,6 @@ parameters:
       - attributes
       - body
     default: body
-  - name: lazy_quotes
-    description: If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if 'ignore_quotes' is true.
-    type: bool
-    default: false
-  - name: ignore_quotes
-    description: If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if 'lazy_quotes' is true.
-    type: bool
-    default: false
   - name: delete_after_read
     description: Will delete static log files once they are completely read. When set, 'start_at' must be set to beginning.
     type: bool
@@ -148,18 +137,7 @@ template: |
           expr: 'body matches "^#"'
         - type: csv_parser
           ignore_quotes: true
-          parse_from: '{{ .parse_from }}'
-          parse_to: {{ .parse_to }}
-          lazy_quotes: {{ .lazy_quotes }}
-          ignore_quotes: {{ .ignore_quotes }}
           delimiter: '{{ .delimiter }}'
-          {{ if .timestamp_layout }}
-          timestamp:
-            parse_from: {{ .timestamp_parse_from }}
-            layout: '{{ .timestamp_layout }}'
-            layout_type: {{ .timestamp_layout_type }}
-            location: {{ .timestamp_location }}
-          {{ end }}
 
           {{ if .header_delimiter }} 
           header_delimiter: '{{ .header_delimiter }}'
@@ -174,6 +152,41 @@ template: |
         - type: remove
           field: "attributes.header_fields"
         {{ end }}
+
+        # If both date & time field exists, parse the timestamp
+        - type: router
+          routes:
+          - output: add_timestamp
+            expr: '{{ .parse_to }}.date != nil and {{ .parse_to }}.time != nil'
+          default: time_parser
+
+        # Combines data + time fields into timestamp field
+        - id: add_timestamp
+          type: add
+          field: {{ .parse_to }}.timestamp
+          value: EXPR({{ .parse_to }}.date + " " + {{ .parse_to }}.time)
+
+        # Remove date field
+        - id: remove_date
+          type: remove
+          field: {{ .parse_to }}.date
+
+        # Remove time field
+        - id: remove_time
+          type: remove
+          field: {{ .parse_to }}.time
+
+        - id: time_parser
+          type: time_parser
+          if: '{{ .parse_to }}.timestamp != nil or {{ .timestamp_parse_from }} != nil'
+          {{ if .timestamp_parse_from }}
+          parse_from: {{ .timestamp_parse_from }}
+          {{ else }}
+          parse_from: {{ .parse_to }}.timestamp
+          {{ end }}
+          layout: '{{ .timestamp_layout }}'
+          layout_type: {{ .timestamp_layout_type }}
+          location: {{.timezone}}
           
   service:
     extensions: [file_storage]

--- a/plugins/w3c_logs.yaml
+++ b/plugins/w3c_logs.yaml
@@ -35,6 +35,41 @@ parameters:
     description: Max number of W3C files that will be open during a polling cycle
     type: int
     default: 512
+  - name: timestamp_layout
+    description: Optional timestamp layout which will parse a timestamp field
+    type: string
+  - name: timestamp_parse_from
+    description: Field to parse the timestamp from, required if timestamp_layout is set
+    type: string
+  - name: timestamp_layout_type
+    description: Optional timestamp layout type for parsing the timestamp, suggested if timestamp_layout is set
+    type: string
+  - name: severity
+    description: Optional severity block which will parse a severity field
+    type: string
+  - name: parse_from
+    description: Where to parse the data from
+    type: string
+    default: body
+  - name: parse_to
+    description: Where the data will parse to
+    type: string
+    supported:
+      - attributes
+      - body
+    default: body
+  - name: lazy_quotes
+    description: If true, a quote may appear in an unquoted field and a non-doubled quote may appear in a quoted field. Cannot be true if ignore_quotes is true.
+    type: bool
+    default: false
+  - name: ignore_quotes
+    description: If true, all quotes are ignored, and fields are simply split on the delimiter. Cannot be true if lazy_quotes is true.
+    type: bool
+    default: false
+  - name: delete_after_read
+    description: Will delete static log files once they are completely read
+    type: bool
+    default: false
   - name: include_file_name
     description: Include File Name as a label
     type: bool
@@ -74,6 +109,7 @@ template: |
       storage: file_storage
       start_at: '{{ .start_at }}'
       max_concurrent_files: {{ .max_concurrent_files }}
+      delete_after_read: {{ .delete_after_read }}
       include_file_name: {{ .include_file_name }}
       include_file_path: {{ .include_file_path }}
       include_file_name_resolved: {{ .include_file_name_resolved }}
@@ -104,10 +140,14 @@ template: |
       operators:
         - type: filter
           expr: 'body matches "^#"'
-
         - type: csv_parser
           ignore_quotes: true
+          parse_from: '{{ .parse_from }}'
+          parse_to: {{ .parse_to }}
+          lazy_quotes: {{ .lazy_quotes }}
+          ignore_quotes: {{ .ignore_quotes }}
           delimiter: '{{ .delimiter }}'
+
           {{ if .header_delimiter }} 
           header_delimiter: '{{ .header_delimiter }}'
           {{ end }}
@@ -120,6 +160,14 @@ template: |
         {{ if not .header }}
         - type: remove
           field: "attributes.header_fields"
+        {{ end }}
+        {{ if .timestamp_layout }}
+        timestamp:
+          parse_from: {{ .timestamp_parse_from }}
+          layout: {{ .timestamp_layout }}
+          {{ if .timestamp_layout_type }}
+          layout_type: .timestamp_layout_type
+          {{ end }}
         {{ end }}
           
   service:


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `fix:` = Delete after read is missing from w3c logs plugin
-->


### Proposed Change
This PR exposes most of the filelog receiver and csv_parser parameters as plugin parameters to give full functionality to the users
[cdn_httpaccess-testfile.log](https://github.com/observIQ/observiq-otel-collector/files/10972800/cdn_httpaccess-testfile.log)
[collector.log](https://github.com/observIQ/observiq-otel-collector/files/10972802/collector.log)

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
