### PR TITLE
feat(opamp): Add environment variable options for TLS

### DIFF
--- a/cmd/collector/main_test.go
+++ b/cmd/collector/main_test.go
@@ -129,16 +129,12 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 	testCases := []struct {
 		name        string
 		setupFunc   func()
-		cleanupFunc func()
 		expectFunc  func() *opamp.TLSConfig
 		expectedErr error
 	}{
 		{
 			name: "no-tls",
 			setupFunc: func() {
-				return
-			},
-			cleanupFunc: func() {
 				return
 			},
 			expectFunc: func() *opamp.TLSConfig {
@@ -150,9 +146,6 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 			name: "skip-verify",
 			setupFunc: func() {
 				t.Setenv(tlsSkipVerifyENV, "true")
-			},
-			cleanupFunc: func() {
-				t.Setenv(tlsSkipVerifyENV, "")
 			},
 			expectFunc: func() *opamp.TLSConfig {
 				return &opamp.TLSConfig{
@@ -166,9 +159,6 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 			setupFunc: func() {
 				t.Setenv(tlsSkipVerifyENV, "invalid")
 			},
-			cleanupFunc: func() {
-				t.Setenv(tlsSkipVerifyENV, "")
-			},
 			expectFunc: func() *opamp.TLSConfig {
 				return nil
 			},
@@ -178,9 +168,6 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 			name: "tls",
 			setupFunc: func() {
 				t.Setenv(tlsCaENV, "/tls/ca.crt")
-			},
-			cleanupFunc: func() {
-				t.Setenv(tlsCaENV, "")
 			},
 			expectFunc: func() *opamp.TLSConfig {
 				ca := "/tls/ca.crt"
@@ -195,10 +182,6 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 			setupFunc: func() {
 				t.Setenv(tlsKeyENV, "/tls/tls.key")
 				t.Setenv(tlsCertENV, "/tls/tls.crt")
-			},
-			cleanupFunc: func() {
-				t.Setenv(tlsKeyENV, "")
-				t.Setenv(tlsCertENV, "")
 			},
 			expectFunc: func() *opamp.TLSConfig {
 				key := "/tls/tls.key"
@@ -218,12 +201,6 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 				t.Setenv(tlsKeyENV, "/tls/tls.key")
 				t.Setenv(tlsCertENV, "/tls/tls.crt")
 			},
-			cleanupFunc: func() {
-				t.Setenv(tlsSkipVerifyENV, "")
-				t.Setenv(tlsCaENV, "")
-				t.Setenv(tlsKeyENV, "")
-				t.Setenv(tlsCertENV, "")
-			},
 			expectFunc: func() *opamp.TLSConfig {
 				ca := "/tls/ca.crt"
 				key := "/tls/tls.key"
@@ -242,7 +219,12 @@ func TestCheckManagerConfigNoFileTLS(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupFunc()
-			defer tc.cleanupFunc()
+			defer func() {
+				os.Unsetenv(tlsSkipVerifyENV)
+				os.Unsetenv(tlsCaENV)
+				os.Unsetenv(tlsKeyENV)
+				os.Unsetenv(tlsCertENV)
+			}()
 
 			actual, err := configureTLS()
 			if tc.expectedErr != nil {

--- a/docs/opamp.md
+++ b/docs/opamp.md
@@ -48,12 +48,14 @@ If the collector can not find the specified `manager.yaml` file it will search f
 
 **Note**: Only the `OPAMP_ENDPOINT` is required. If this is not set and there is no `manager.yaml` the collector will start in its normal standalone mode.
 
-| Environment Variable | Required | Description                                                                       |
-| :------------------- | :------: | :-------------------------------------------------------------------------------- |
-| OPAMP_ENDPOINT       | X        | The API endpoint to communicate with the server via websocket                     |
-| OPAMP_SECRET_KEY     |          | The Secret Key defined for the server to be used for authorization                |
-| OPAMP_AGENT_ID       |          | A UUID used to uniquely identify the agent. If not supplied one will be generated |
-| OPAMP_LABELS         |          | A comma separated list of labels in the form `label=value`                        |
-| OPAMP_AGENT_NAME     |          | Human readable name for the agent                                                 |
-
-
+| Environment Variable  | Required | Description                                                                       |
+| :-------------------- | :------: | :-------------------------------------------------------------------------------- |
+| OPAMP_ENDPOINT        | X        | The API endpoint to communicate with the server via websocket                     |
+| OPAMP_SECRET_KEY      |          | The Secret Key defined for the server to be used for authorization                |
+| OPAMP_AGENT_ID        |          | A UUID used to uniquely identify the agent. If not supplied one will be generated |
+| OPAMP_LABELS          |          | A comma separated list of labels in the form `label=value`                        |
+| OPAMP_AGENT_NAME      |          | Human readable name for the agent                                                 |
+| OPAMP_TLS_SKIP_VERIFY |          | Set to `"true"` to skip verification of the OpAMP server's TLS certificate        |
+| OPAMP_TLS_CA          |          | File path to a certificate authority file that should be used to validate the server's TLS certificate |
+| OPAMP_TLS_CERT        |          | File path to a certificate file that will be used for client TLS authentication |
+| OPAMP_TLS_KEY         |          | File path to a private key file that will be used for client TLS authentication |


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

This change adds support for the following OpAMP options using environment variables
- TLS skip verify (skip verifying the server's certificate)
- CA certificate (can be used as an alternative to the underlying operating systems trust store)
- Mutual TLS
  - Private Key
  - Certificate

This solves a container use-case, where the collector's configuration is derived only from environment variables.

##### Checklist
- [x] Changes are tested
- [x] CI has passed
