### PR TITLE
feat(plugin): Add max_concurrent_files parameter to the IIS plugin

### DIFF
--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -15,7 +15,7 @@ Log parser for IIS
 | include_file_path | Enable to include file path in logs | bool | `true` | false |  |
 | include_file_name_resolved | Enable to include file name resolved in logs | bool | `false` | false |  |
 | include_file_path_resolved | Enable to include file path resolved in logs | bool | `false` | false |  |
-| max_concurrent_files | Max number of W3C files that will be open during a polling cycle | int | `512` | false |  |
+| max_concurrent_files | Max number of W3C files that will be open during a batch | int | `1024` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`). | string | `beginning` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
@@ -38,7 +38,7 @@ receivers:
       include_file_path: true
       include_file_name_resolved: false
       include_file_path_resolved: false
-      max_concurrent_files: 512
+      max_concurrent_files: 1024
       start_at: beginning
       retain_raw_logs: false
       parse_to: body

--- a/docs/plugins/iis_logs.md
+++ b/docs/plugins/iis_logs.md
@@ -15,6 +15,7 @@ Log parser for IIS
 | include_file_path | Enable to include file path in logs | bool | `true` | false |  |
 | include_file_name_resolved | Enable to include file name resolved in logs | bool | `false` | false |  |
 | include_file_path_resolved | Enable to include file path resolved in logs | bool | `false` | false |  |
+| max_concurrent_files | Max number of W3C files that will be open during a polling cycle | int | `512` | false |  |
 | start_at | At startup, where to start reading logs from the file (`beginning` or `end`). | string | `beginning` | false | `beginning`, `end` |
 | retain_raw_logs | When enabled will preserve the original log message in a `raw_log` key. This will either be in the `body` or `attributes` depending on how `parse_to` is configured. | bool | `false` | false |  |
 | parse_to | Where to parse structured log parts | string | `body` | false | `body`, `attributes` |
@@ -37,6 +38,7 @@ receivers:
       include_file_path: true
       include_file_name_resolved: false
       include_file_path_resolved: false
+      max_concurrent_files: 512
       start_at: beginning
       retain_raw_logs: false
       parse_to: body

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -42,6 +42,10 @@ parameters:
     description: Enable to include file path resolved in logs
     type: bool
     default: false
+  - name: max_concurrent_files
+    description: Max number of W3C files that will be open during a polling cycle
+    type: int
+    default: 512
   - name: start_at
     description: At startup, where to start reading logs from the file (`beginning` or `end`).
     type: string
@@ -96,6 +100,7 @@ template: |
       include_file_name_resolved: {{ .include_file_name_resolved }}
       include_file_path_resolved: {{ .include_file_path_resolved }}
       start_at: {{ .start_at }}
+      max_concurrent_files: {{ .max_concurrent_files }}
       operators: 
       - type: filter
         expr: 'body matches "^#"'
@@ -193,6 +198,7 @@ template: |
       include_file_name_resolved: {{ .include_file_name_resolved }}
       include_file_path_resolved: {{ .include_file_path_resolved }}
       start_at: {{ .start_at }}
+      max_concurrent_files: {{ .max_concurrent_files }}
       operators: 
       {{ if .retain_raw_logs }}
       - id: save_raw_log
@@ -268,6 +274,7 @@ template: |
       include_file_name_resolved: {{ .include_file_name_resolved }}
       include_file_path_resolved: {{ .include_file_path_resolved }}
       start_at: {{ .start_at }}
+      max_concurrent_files: {{ .max_concurrent_files }}
       operators: 
       {{ if .retain_raw_logs }}
       - id: save_raw_log

--- a/plugins/iis_logs.yaml
+++ b/plugins/iis_logs.yaml
@@ -43,9 +43,9 @@ parameters:
     type: bool
     default: false
   - name: max_concurrent_files
-    description: Max number of W3C files that will be open during a polling cycle
+    description: Max number of W3C files that will be open during a batch
     type: int
-    default: 512
+    default: 1024
   - name: start_at
     description: At startup, where to start reading logs from the file (`beginning` or `end`).
     type: string


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat:` = Add max_concurrent_files parameter to the IIS plugin
-->


### Proposed Change
A request from a POC customer getting ready to move to production is to be able to specify max_concurrent_files for IIS logs. Since this makes sense, I've added it to the plugin.
[cdn_httpaccess-testfile.log](https://github.com/observIQ/observiq-otel-collector/files/11028621/cdn_httpaccess-testfile.log)
[iis-collector.log](https://github.com/observIQ/observiq-otel-collector/files/11028632/iis-collector.log)
[config-iis.yaml.txt](https://github.com/observIQ/observiq-otel-collector/files/11028633/config-iis.yaml.txt)

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
