### PR TITLE
feat(container): Push images to Github container registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
       - name: Retrieve Windows 64-bit MSI Installer
         uses: actions/download-artifact@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -202,6 +202,10 @@ dockers:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}"
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:latest"
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}"
     dockerfile: ./docker/Dockerfile.ubuntu
     use: buildx
     build_flag_templates:
@@ -225,6 +229,10 @@ dockers:
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:latest"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}"
     dockerfile: ./docker/Dockerfile.ubuntu
     use: buildx
     build_flag_templates:
@@ -246,6 +254,7 @@ dockers:
       - collector
     image_templates:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     dockerfile: ./docker/Dockerfile.ubi8
     use: buildx
     build_flag_templates:
@@ -266,6 +275,7 @@ dockers:
       - collector
     image_templates:
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     dockerfile: ./docker/Dockerfile.ubi8
     use: buildx
     build_flag_templates:
@@ -305,6 +315,31 @@ docker_manifests:
     image_templates:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/observiq-otel-collector:latest"
+    image_templates:
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:latest"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:latest"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/observiq-otel-collector:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}"
+    skip_push: false
+  - name_template: "ghcr.io/observiq/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    image_templates:
+      - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     skip_push: false
 
 # https://goreleaser.com/customization/checksum/


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

Added additional container image tags for pushing to Github's container registry. This will give us flexibility on where we store and pull our images. Dockerhub will continue to be used but we should consider Github to be our primary repository. Pushed images will show up as packages. You can see an example [here](https://github.com/orgs/observIQ/packages?repo_name=bindplane-op).

Changes
- Login to Github container registry in addition to Dockerhub
- Add tags to Goreleaser config.

You can see how we do this in BindPlane's repo
- https://github.com/observIQ/bindplane-op/blob/main/.github/workflows/release.yml#L23
- https://github.com/observIQ/bindplane-op/blob/main/.goreleaser.yml#L204

After running Goreleaser locally, I have the following tags:
```
REPOSITORY                                       TAG           IMAGE ID       CREATED         SIZE
observiq/observiq-otel-collector-arm64           1             7c6fa4ae13f2   6 minutes ago   498MB
observiq/observiq-otel-collector-arm64           1.20          7c6fa4ae13f2   6 minutes ago   498MB
observiq/observiq-otel-collector-arm64           1.20.0        7c6fa4ae13f2   6 minutes ago   498MB
observiq/observiq-otel-collector-arm64           latest        7c6fa4ae13f2   6 minutes ago   498MB
ghcr.io/observiq/observiq-otel-collector-arm64   1             7c6fa4ae13f2   6 minutes ago   498MB
ghcr.io/observiq/observiq-otel-collector-arm64   1.20          7c6fa4ae13f2   6 minutes ago   498MB
ghcr.io/observiq/observiq-otel-collector-arm64   1.20.0        7c6fa4ae13f2   6 minutes ago   498MB
ghcr.io/observiq/observiq-otel-collector-arm64   latest        7c6fa4ae13f2   6 minutes ago   498MB
observiq/observiq-otel-collector-arm64           1.20.0-ubi8   dbb89d02705f   6 minutes ago   636MB
ghcr.io/observiq/observiq-otel-collector-arm64   1.20.0-ubi8   dbb89d02705f   6 minutes ago   636MB
observiq/observiq-otel-collector-amd64           1             c912bb748fa0   6 minutes ago   512MB
observiq/observiq-otel-collector-amd64           1.20          c912bb748fa0   6 minutes ago   512MB
observiq/observiq-otel-collector-amd64           1.20.0        c912bb748fa0   6 minutes ago   512MB
observiq/observiq-otel-collector-amd64           latest        c912bb748fa0   6 minutes ago   512MB
ghcr.io/observiq/observiq-otel-collector-amd64   1             c912bb748fa0   6 minutes ago   512MB
ghcr.io/observiq/observiq-otel-collector-amd64   1.20          c912bb748fa0   6 minutes ago   512MB
ghcr.io/observiq/observiq-otel-collector-amd64   1.20.0        c912bb748fa0   6 minutes ago   512MB
ghcr.io/observiq/observiq-otel-collector-amd64   latest        c912bb748fa0   6 minutes ago   512MB
observiq/observiq-otel-collector-amd64           1.20.0-ubi8   8fcae52c1bd1   6 minutes ago   618MB
ghcr.io/observiq/observiq-otel-collector-amd64   1.20.0-ubi8   8fcae52c1bd1   6 minutes ago   618MB
```

##### Checklist
- [ ] Changes are tested
- [x] CI has passed
