### PR TITLE
fix: Fixed bug with default rules in the mask processor

### DIFF
--- a/processor/maskprocessor/config.go
+++ b/processor/maskprocessor/config.go
@@ -15,14 +15,6 @@
 // Package maskprocessor provides a processor that masks data.
 package maskprocessor
 
-import (
-	"errors"
-	"fmt"
-	"regexp"
-)
-
-var errNoRules = errors.New("no rules defined")
-
 // Config is the configuration for the processor.
 type Config struct {
 	// Rules are the rules used to mask values.
@@ -32,28 +24,10 @@ type Config struct {
 	Exclude []string `mapstructure:"exclude"`
 }
 
-// CompileRules compiles the rules defined in the config.
-func (cfg Config) CompileRules() (map[string]*regexp.Regexp, error) {
-	rules := make(map[string]*regexp.Regexp)
-	for key, expr := range cfg.Rules {
-		rule, err := regexp.Compile(expr)
-		if err != nil {
-			return nil, fmt.Errorf("rule '%s' does not compile as valid regex", key)
-		}
-
-		mask := fmt.Sprintf("[masked_%s]", key)
-		rules[mask] = rule
-	}
-	return rules, nil
-}
-
 // Validate validates the processor configuration.
 func (cfg Config) Validate() error {
-	if len(cfg.Rules) == 0 {
-		return errNoRules
-	}
-
-	if _, err := cfg.CompileRules(); err != nil {
+	if len(cfg.Rules) > 0 {
+		_, err := compileRules(cfg.Rules)
 		return err
 	}
 

--- a/processor/maskprocessor/config_test.go
+++ b/processor/maskprocessor/config_test.go
@@ -28,13 +28,6 @@ func TestConfigValidate(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc: "Default rules",
-			cfg: Config{
-				Rules: defaultRules,
-			},
-			expectedErr: nil,
-		},
-		{
 			desc: "Invalid rule",
 			cfg: Config{
 				Rules: map[string]string{

--- a/processor/maskprocessor/config_test.go
+++ b/processor/maskprocessor/config_test.go
@@ -31,7 +31,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Default rules",
 			cfg: Config{
-				Rules: defaultRules,
+				Rules: createDefaultRules(),
 			},
 			expectedErr: nil,
 		},

--- a/processor/maskprocessor/config_test.go
+++ b/processor/maskprocessor/config_test.go
@@ -16,7 +16,6 @@ package maskprocessor
 
 import (
 	"errors"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +30,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc: "Default rules",
 			cfg: Config{
-				Rules: createDefaultRules(),
+				Rules: defaultRules,
 			},
 			expectedErr: nil,
 		},
@@ -47,7 +46,7 @@ func TestConfigValidate(t *testing.T) {
 		{
 			desc:        "No rules",
 			cfg:         Config{},
-			expectedErr: errNoRules,
+			expectedErr: nil,
 		},
 	}
 
@@ -55,45 +54,6 @@ func TestConfigValidate(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			actualErr := tc.cfg.Validate()
 			assert.Equal(t, tc.expectedErr, actualErr)
-		})
-	}
-}
-
-func TestCompileRules(t *testing.T) {
-	testCases := []struct {
-		desc          string
-		cfg           Config
-		expectedRules map[string]*regexp.Regexp
-		expectedErr   error
-	}{
-		{
-			desc: "Valid rule",
-			cfg: Config{
-				Rules: map[string]string{
-					"test": "test",
-				},
-			},
-			expectedRules: map[string]*regexp.Regexp{
-				"[masked_test]": regexp.MustCompile("test"),
-			},
-			expectedErr: nil,
-		},
-		{
-			desc: "Invalid rule",
-			cfg: Config{
-				Rules: map[string]string{
-					"invalid": `\K`,
-				},
-			},
-			expectedErr: errors.New("rule 'invalid' does not compile as valid regex"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			rules, err := tc.cfg.CompileRules()
-			assert.Equal(t, tc.expectedRules, rules)
-			assert.Equal(t, tc.expectedErr, err)
 		})
 	}
 }

--- a/processor/maskprocessor/factory.go
+++ b/processor/maskprocessor/factory.go
@@ -32,12 +32,6 @@ const (
 var (
 	consumerCapabilities = consumer.Capabilities{MutatesData: true}
 	errInvalidConfigType = errors.New("config is not of type maskprocessor.Config")
-	defaultRules         = map[string]string{
-		"email":       `\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`,
-		"ssn":         `\b\d{3}[- ]\d{2}[- ]\d{4}\b`,
-		"credit_card": `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`,
-		"phone":       `\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`,
-	}
 )
 
 // NewFactory creates a new ProcessorFactory with default configuration

--- a/processor/maskprocessor/factory.go
+++ b/processor/maskprocessor/factory.go
@@ -32,12 +32,10 @@ const (
 var (
 	consumerCapabilities = consumer.Capabilities{MutatesData: true}
 	errInvalidConfigType = errors.New("config is not of type maskprocessor.Config")
-	defaultRules         = map[string]string{
-		"email":       `\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`,
-		"ssn":         `\b\d{3}[- ]\d{2}[- ]\d{4}\b`,
-		"credit_card": `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`,
-		"phone":       `\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`,
-	}
+	emailRule            = `\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`
+	ssnRule              = `\b\d{3}[- ]\d{2}[- ]\d{4}\b`
+	creditCardRule       = `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`
+	phoneRule            = `\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`
 )
 
 // NewFactory creates a new ProcessorFactory with default configuration
@@ -54,7 +52,17 @@ func NewFactory() processor.Factory {
 // createDefaultConfig creates a default config for the mask processor.
 func createDefaultConfig() component.Config {
 	return &Config{
-		Rules: defaultRules,
+		Rules: createDefaultRules(),
+	}
+}
+
+// createDefaultRules creates a default set of rules for the mask processor.
+func createDefaultRules() map[string]string {
+	return map[string]string{
+		"email":       emailRule,
+		"ssn":         ssnRule,
+		"credit_card": creditCardRule,
+		"phone":       phoneRule,
 	}
 }
 

--- a/processor/maskprocessor/factory.go
+++ b/processor/maskprocessor/factory.go
@@ -32,10 +32,12 @@ const (
 var (
 	consumerCapabilities = consumer.Capabilities{MutatesData: true}
 	errInvalidConfigType = errors.New("config is not of type maskprocessor.Config")
-	emailRule            = `\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`
-	ssnRule              = `\b\d{3}[- ]\d{2}[- ]\d{4}\b`
-	creditCardRule       = `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`
-	phoneRule            = `\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`
+	defaultRules         = map[string]string{
+		"email":       `\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`,
+		"ssn":         `\b\d{3}[- ]\d{2}[- ]\d{4}\b`,
+		"credit_card": `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`,
+		"phone":       `\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`,
+	}
 )
 
 // NewFactory creates a new ProcessorFactory with default configuration
@@ -51,19 +53,7 @@ func NewFactory() processor.Factory {
 
 // createDefaultConfig creates a default config for the mask processor.
 func createDefaultConfig() component.Config {
-	return &Config{
-		Rules: createDefaultRules(),
-	}
-}
-
-// createDefaultRules creates a default set of rules for the mask processor.
-func createDefaultRules() map[string]string {
-	return map[string]string{
-		"email":       emailRule,
-		"ssn":         ssnRule,
-		"credit_card": creditCardRule,
-		"phone":       phoneRule,
-	}
+	return &Config{}
 }
 
 // createTracesProcessor creates a mask processor for traces.

--- a/processor/maskprocessor/factory_test.go
+++ b/processor/maskprocessor/factory_test.go
@@ -28,7 +28,12 @@ func TestNewFactory(t *testing.T) {
 	require.Equal(t, typeStr, string(factory.Type()))
 
 	expectedCfg := &Config{
-		Rules: defaultRules,
+		Rules: map[string]string{
+			"email":       emailRule,
+			"ssn":         ssnRule,
+			"credit_card": creditCardRule,
+			"phone":       phoneRule,
+		},
 	}
 
 	cfg, ok := factory.CreateDefaultConfig().(*Config)

--- a/processor/maskprocessor/factory_test.go
+++ b/processor/maskprocessor/factory_test.go
@@ -27,15 +27,7 @@ func TestNewFactory(t *testing.T) {
 	factory := NewFactory()
 	require.Equal(t, typeStr, string(factory.Type()))
 
-	expectedCfg := &Config{
-		Rules: map[string]string{
-			"email":       emailRule,
-			"ssn":         ssnRule,
-			"credit_card": creditCardRule,
-			"phone":       phoneRule,
-		},
-	}
-
+	expectedCfg := &Config{}
 	cfg, ok := factory.CreateDefaultConfig().(*Config)
 	require.True(t, ok)
 	require.Equal(t, expectedCfg, cfg)

--- a/processor/maskprocessor/processor.go
+++ b/processor/maskprocessor/processor.go
@@ -33,6 +33,13 @@ const (
 	bodyField       = "body"
 )
 
+var defaultRules = map[string]*regexp.Regexp{
+	"email":       regexp.MustCompile(`\b[a-z0-9._%\+\-—|]+@[a-z0-9.\-—|]+\.[a-z|]{2,6}\b`),
+	"ssn":         regexp.MustCompile(`\b\d{3}[- ]\d{2}[- ]\d{4}\b`),
+	"credit_card": regexp.MustCompile(`\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`),
+	"phone":       regexp.MustCompile(`\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`),
+}
+
 // maskProcessor is the processor used to mask data.
 type maskProcessor struct {
 	logger           *zap.Logger
@@ -215,7 +222,7 @@ func (p *maskProcessor) createMaskFunc(field string) func(k string, v pcommon.Va
 // createRules creates a map of rules for the processor.
 func (p *maskProcessor) createRules() (map[string]*regexp.Regexp, error) {
 	if len(p.cfg.Rules) == 0 {
-		return compileRules(defaultRules)
+		return defaultRules, nil
 	}
 
 	return compileRules(p.cfg.Rules)

--- a/processor/maskprocessor/processor_test.go
+++ b/processor/maskprocessor/processor_test.go
@@ -16,8 +16,11 @@ package maskprocessor
 
 import (
 	"context"
+	"errors"
+	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -160,4 +163,93 @@ func TestFailedStart(t *testing.T) {
 	err := processor.start(context.Background(), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not compile as valid regex")
+}
+
+func TestCreateRules(t *testing.T) {
+	compiledDefaultRules, err := compileRules(defaultRules)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc          string
+		exprs         map[string]string
+		expectedRules map[string]*regexp.Regexp
+		expectedErr   error
+	}{
+		{
+			desc: "Valid rule",
+			exprs: map[string]string{
+				"test": "test",
+			},
+			expectedRules: map[string]*regexp.Regexp{
+				"[masked_test]": regexp.MustCompile("test"),
+			},
+		},
+		{
+			desc: "Invalid rule",
+			exprs: map[string]string{
+				"invalid": `\k`,
+			},
+			expectedErr: errors.New("rule 'invalid' does not compile"),
+		},
+		{
+			desc:          "No rules",
+			exprs:         map[string]string{},
+			expectedRules: compiledDefaultRules,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			p := &maskProcessor{
+				cfg: &Config{
+					Rules: tc.exprs,
+				},
+			}
+			rules, err := p.createRules()
+
+			switch tc.expectedErr {
+			case nil:
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedRules, rules)
+			default:
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr.Error())
+			}
+		})
+	}
+}
+
+func TestCompileRules(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		exprs         map[string]string
+		expectedRules map[string]*regexp.Regexp
+		expectedErr   error
+	}{
+		{
+			desc: "Valid rule",
+			exprs: map[string]string{
+				"test": "test",
+			},
+			expectedRules: map[string]*regexp.Regexp{
+				"[masked_test]": regexp.MustCompile("test"),
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Invalid rule",
+			exprs: map[string]string{
+				"invalid": `\K`,
+			},
+			expectedErr: errors.New("rule 'invalid' does not compile as valid regex"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rules, err := compileRules(tc.exprs)
+			assert.Equal(t, tc.expectedRules, rules)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
 }

--- a/processor/maskprocessor/processor_test.go
+++ b/processor/maskprocessor/processor_test.go
@@ -166,9 +166,6 @@ func TestFailedStart(t *testing.T) {
 }
 
 func TestCreateRules(t *testing.T) {
-	compiledDefaultRules, err := compileRules(defaultRules)
-	require.NoError(t, err)
-
 	testCases := []struct {
 		desc          string
 		exprs         map[string]string
@@ -194,7 +191,7 @@ func TestCreateRules(t *testing.T) {
 		{
 			desc:          "No rules",
 			exprs:         map[string]string{},
-			expectedRules: compiledDefaultRules,
+			expectedRules: defaultRules,
 		},
 	}
 


### PR DESCRIPTION
### Proposed Change
- Changed the behavior of default rules in the mask processor.
  - Default rules are now set at "runtime" rather than "config time"
  - The previous design was flawed, because otel uses mapstructure to unmarshal configs. When mapstructure unmarshals into a map that already has values, it doesn't wipe that map clean with the incoming map. Instead, it will merge the source and destination. In this scenario, only duplicate keys would be overwritten. This means that if a user configured their own rules in the previous design, the processor would load the union of the two rulesets. This should be considered a bug, since defaults should only apply if a user leaves this field blank. This can be accomplished by moving where the default is set and avoiding mapstructure altogether.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
