### PR TITLE
feat(expr): Update with the ability to convert spans and datapoints to a map representation

### DIFF
--- a/expr/datapoint.go
+++ b/expr/datapoint.go
@@ -1,0 +1,122 @@
+// Copyright  observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expr
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	MetricNameField     = "metric_name"
+	DatapointValueField = "datapoint_value"
+)
+
+// Datapoint is the simplified representation of a metric datapoint.
+type Datapoint = map[string]any
+
+func convertMetricToDatapoints(metric pmetric.Metric, resource map[string]any) []Datapoint {
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		dps := metric.Gauge().DataPoints()
+		datapoints := make([]Datapoint, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			datapoints = append(datapoints, convertNumberDatapoint(dps.At(i), resource, metric.Name()))
+		}
+		return datapoints
+	case pmetric.MetricTypeSum:
+		dps := metric.Sum().DataPoints()
+		datapoints := make([]Datapoint, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			datapoints = append(datapoints, convertNumberDatapoint(dps.At(i), resource, metric.Name()))
+		}
+		return datapoints
+	case pmetric.MetricTypeHistogram:
+		dps := metric.Histogram().DataPoints()
+		datapoints := make([]Datapoint, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			datapoints = append(datapoints, convertGenericDatapoint(dps.At(i), resource, metric.Name()))
+		}
+		return datapoints
+	case pmetric.MetricTypeExponentialHistogram:
+		dps := metric.ExponentialHistogram().DataPoints()
+		datapoints := make([]Datapoint, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			datapoints = append(datapoints, convertGenericDatapoint(dps.At(i), resource, metric.Name()))
+		}
+		return datapoints
+	case pmetric.MetricTypeSummary:
+		dps := metric.Summary().DataPoints()
+		datapoints := make([]Datapoint, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			datapoints = append(datapoints, convertGenericDatapoint(dps.At(i), resource, metric.Name()))
+		}
+		return datapoints
+	}
+	return nil
+}
+
+type genericDatapoint interface {
+	Attributes() pcommon.Map
+}
+
+func convertGenericDatapoint[T genericDatapoint](dp T, resource map[string]any, name string) Datapoint {
+	return Datapoint{
+		ResourceField:   resource,
+		AttributesField: dp.Attributes().AsRaw(),
+		MetricNameField: name,
+	}
+}
+
+func convertNumberDatapoint(dp pmetric.NumberDataPoint, resource map[string]any, name string) Datapoint {
+	datapoint := convertGenericDatapoint(dp, resource, name)
+
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeInt:
+		datapoint[DatapointValueField] = dp.IntValue()
+	case pmetric.NumberDataPointValueTypeDouble:
+		datapoint[DatapointValueField] = dp.DoubleValue()
+	}
+
+	return datapoint
+}
+
+type DatapointResourceGroup struct {
+	Resource   map[string]any
+	Datapoints []Datapoint
+}
+
+func ConvertToDatapointResourceGroup(metrics pmetric.Metrics) []DatapointResourceGroup {
+	groups := make([]DatapointResourceGroup, 0, metrics.ResourceMetrics().Len())
+
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		resourceMetrics := metrics.ResourceMetrics().At(i)
+		resource := resourceMetrics.Resource().Attributes().AsRaw()
+		group := DatapointResourceGroup{
+			Resource:   resource,
+			Datapoints: make([]Datapoint, 0, resourceMetrics.ScopeMetrics().Len()),
+		}
+		for j := 0; j < resourceMetrics.ScopeMetrics().Len(); j++ {
+			metricSlice := resourceMetrics.ScopeMetrics().At(j).Metrics()
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				group.Datapoints = append(group.Datapoints, convertMetricToDatapoints(metric, resource)...)
+			}
+		}
+		groups = append(groups, group)
+	}
+
+	return groups
+}

--- a/expr/datapoint.go
+++ b/expr/datapoint.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+// Metric specific fields for use in expressions
 const (
 	MetricNameField     = "metric_name"
 	DatapointValueField = "datapoint_value"
@@ -93,11 +94,13 @@ func convertNumberDatapoint(dp pmetric.NumberDataPoint, resource map[string]any,
 	return datapoint
 }
 
+// DatapointResourceGroup represents a pmetric.ResourceMetrics as native go types
 type DatapointResourceGroup struct {
 	Resource   map[string]any
 	Datapoints []Datapoint
 }
 
+// ConvertToDatapointResourceGroup converts a pmetric.Metrics into a slice of DatapointResourceGroup
 func ConvertToDatapointResourceGroup(metrics pmetric.Metrics) []DatapointResourceGroup {
 	groups := make([]DatapointResourceGroup, 0, metrics.ResourceMetrics().Len())
 

--- a/expr/datapoint_test.go
+++ b/expr/datapoint_test.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expr
 
 import (

--- a/expr/datapoint_test.go
+++ b/expr/datapoint_test.go
@@ -1,0 +1,156 @@
+package expr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestConvertToDatapointResourceGroup(t *testing.T) {
+	now := time.Now().UTC()
+	oneMinuteAgo := now.Add(-time.Minute)
+	testResource1 := map[string]any{
+		"resource": "attributes",
+	}
+	testResource2 := map[string]any{
+		"resource": "attributes",
+	}
+	testAttrs := map[string]any{
+		"attributes": "attributes",
+	}
+
+	metrics := pmetric.NewMetrics()
+	resourceMetrics1 := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics1.Resource().Attributes().FromRaw(testResource1)
+
+	resourceMetrics2 := metrics.ResourceMetrics().AppendEmpty()
+	resourceMetrics2.Resource().Attributes().FromRaw(testResource2)
+
+	metricSlice1 := resourceMetrics1.ScopeMetrics().AppendEmpty().Metrics()
+	sumMetric(t, testAttrs, oneMinuteAgo, now, metricSlice1)
+	gaugeMetric(t, testAttrs, oneMinuteAgo, now, metricSlice1)
+	histogramMetric(t, testAttrs, oneMinuteAgo, now, metricSlice1)
+
+	metricSlice2 := resourceMetrics2.ScopeMetrics().AppendEmpty().Metrics()
+	exponentialHistogramMetric(t, testAttrs, oneMinuteAgo, now, metricSlice2)
+	summaryMetric(t, testAttrs, oneMinuteAgo, now, metricSlice2)
+
+	resourceGroups := ConvertToDatapointResourceGroup(metrics)
+
+	require.Equal(t, []DatapointResourceGroup{
+		{
+			Resource: testResource1,
+			Datapoints: []Datapoint{
+				{
+					MetricNameField:     "sum",
+					ResourceField:       testResource1,
+					AttributesField:     testAttrs,
+					DatapointValueField: float64(300),
+				},
+				{
+					MetricNameField:     "gauge",
+					ResourceField:       testResource1,
+					AttributesField:     testAttrs,
+					DatapointValueField: int64(45),
+				},
+				{
+					MetricNameField: "histogram",
+					ResourceField:   testResource1,
+					AttributesField: testAttrs,
+				},
+			},
+		},
+		{
+			Resource: testResource2,
+			Datapoints: []Datapoint{
+				{
+					MetricNameField: "exponential_histogram",
+					ResourceField:   testResource1,
+					AttributesField: testAttrs,
+				},
+				{
+					MetricNameField: "summary",
+					ResourceField:   testResource1,
+					AttributesField: testAttrs,
+				},
+			},
+		},
+	}, resourceGroups)
+}
+
+func sumMetric(t *testing.T, attrs map[string]any, start, now time.Time, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("sum")
+	dps := metric.SetEmptySum().DataPoints()
+	dp := dps.AppendEmpty()
+
+	require.NoError(t, dp.Attributes().FromRaw(attrs))
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+	dp.SetDoubleValue(300)
+}
+
+func gaugeMetric(t *testing.T, attrs map[string]any, start, now time.Time, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("gauge")
+	dps := metric.SetEmptyGauge().DataPoints()
+	dp := dps.AppendEmpty()
+
+	require.NoError(t, dp.Attributes().FromRaw(attrs))
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+	dp.SetIntValue(45)
+}
+
+func histogramMetric(t *testing.T, attrs map[string]any, start, now time.Time, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("histogram")
+	dps := metric.SetEmptyHistogram().DataPoints()
+	dp := dps.AppendEmpty()
+
+	require.NoError(t, dp.Attributes().FromRaw(attrs))
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+}
+
+func exponentialHistogramMetric(t *testing.T, attrs map[string]any, start, now time.Time, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("exponential_histogram")
+	dps := metric.SetEmptyExponentialHistogram().DataPoints()
+	dp := dps.AppendEmpty()
+
+	require.NoError(t, dp.Attributes().FromRaw(attrs))
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+}
+
+func summaryMetric(t *testing.T, attrs map[string]any, start, now time.Time, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("summary")
+	dps := metric.SetEmptySummary().DataPoints()
+	dp := dps.AppendEmpty()
+
+	require.NoError(t, dp.Attributes().FromRaw(attrs))
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
+}
+
+func emptyMetric(t *testing.T, s pmetric.MetricSlice) {
+	t.Helper()
+
+	metric := s.AppendEmpty()
+	metric.SetName("empty_metric")
+}

--- a/expr/span.go
+++ b/expr/span.go
@@ -1,0 +1,68 @@
+package expr
+
+import (
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+const (
+	SpanKindField          = "trace_kind"
+	SpanStatusCodeField    = "trace_status_code"
+	SpanStatusMessageField = "trace_status_message"
+	SpanDurationField      = "span_duration_ms"
+)
+
+var spanKindToString = map[ptrace.SpanKind]string{
+	ptrace.SpanKindUnspecified: "unspecified",
+	ptrace.SpanKindInternal:    "internal",
+	ptrace.SpanKindClient:      "client",
+	ptrace.SpanKindServer:      "server",
+	ptrace.SpanKindConsumer:    "consumer",
+	ptrace.SpanKindProducer:    "producer",
+}
+
+var spanStatusCodeToString = map[ptrace.StatusCode]string{
+	ptrace.StatusCodeError: "error",
+	ptrace.StatusCodeOk:    "ok",
+	ptrace.StatusCodeUnset: "unset",
+}
+
+type Span = map[string]any
+
+func convertToSpan(span ptrace.Span, resource map[string]any) Span {
+	return Span{
+		ResourceField:          resource,
+		AttributesField:        span.Attributes().AsRaw(),
+		SpanDurationField:      span.EndTimestamp().AsTime().Sub(span.StartTimestamp().AsTime()).Milliseconds(),
+		SpanKindField:          spanKindToString[span.Kind()],
+		SpanStatusCodeField:    spanStatusCodeToString[span.Status().Code()],
+		SpanStatusMessageField: span.Status().Message(),
+	}
+}
+
+type SpanResourceGroup struct {
+	Resource map[string]any
+	Spans    []Span
+}
+
+func ConvertToSpanResourceGroups(logs ptrace.Traces) []SpanResourceGroup {
+	groups := make([]SpanResourceGroup, 0, logs.ResourceSpans().Len())
+
+	for i := 0; i < logs.ResourceSpans().Len(); i++ {
+		resourceLogs := logs.ResourceSpans().At(i)
+		resource := resourceLogs.Resource().Attributes().AsRaw()
+		group := SpanResourceGroup{
+			Resource: resource,
+			Spans:    make([]Span, 0, resourceLogs.ScopeSpans().Len()),
+		}
+		for j := 0; j < resourceLogs.ScopeSpans().Len(); j++ {
+			logs := resourceLogs.ScopeSpans().At(j).Spans()
+			for k := 0; k < logs.Len(); k++ {
+				log := logs.At(k)
+				group.Spans = append(group.Spans, convertToSpan(log, resource))
+			}
+		}
+		groups = append(groups, group)
+	}
+
+	return groups
+}

--- a/expr/span.go
+++ b/expr/span.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expr
 
 import (

--- a/expr/span_test.go
+++ b/expr/span_test.go
@@ -1,0 +1,78 @@
+package expr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestConvertToSpanResourceGroups(t *testing.T) {
+	now := time.Now().UTC()
+	oneMinuteAgo := now.Add(-time.Minute)
+	testResource1 := map[string]any{
+		"resource": "attributes",
+	}
+	testResource2 := map[string]any{
+		"resource": "attributes2",
+	}
+	testAttrs := map[string]any{
+		"attributes": "attributes",
+	}
+
+	traces := ptrace.NewTraces()
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().FromRaw(testResource1)
+
+	span1 := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span1.Attributes().FromRaw(testAttrs)
+	span1.SetStartTimestamp(pcommon.NewTimestampFromTime(oneMinuteAgo))
+	span1.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
+	span1.SetKind(ptrace.SpanKindClient)
+	span1.Status().SetCode(ptrace.StatusCodeOk)
+	span1.Status().SetMessage("Status Message")
+
+	resourceSpans = traces.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().FromRaw(testResource2)
+
+	span2 := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span2.Attributes().FromRaw(testAttrs)
+	span2.SetStartTimestamp(pcommon.NewTimestampFromTime(oneMinuteAgo))
+	span2.SetEndTimestamp(pcommon.NewTimestampFromTime(now))
+	span2.SetKind(ptrace.SpanKindInternal)
+	span2.Status().SetCode(ptrace.StatusCodeError)
+	span2.Status().SetMessage("Second Status Message")
+
+	groups := ConvertToSpanResourceGroups(traces)
+
+	require.Equal(t, groups, []SpanResourceGroup{
+		{
+			Resource: testResource1,
+			Spans: []Span{
+				{
+					ResourceField:          testResource1,
+					AttributesField:        testAttrs,
+					SpanKindField:          "client",
+					SpanStatusCodeField:    "ok",
+					SpanStatusMessageField: "Status Message",
+					SpanDurationField:      time.Minute.Milliseconds(),
+				},
+			},
+		},
+		{
+			Resource: testResource2,
+			Spans: []Span{
+				{
+					ResourceField:          testResource2,
+					AttributesField:        testAttrs,
+					SpanKindField:          "internal",
+					SpanStatusCodeField:    "error",
+					SpanStatusMessageField: "Second Status Message",
+					SpanDurationField:      time.Minute.Milliseconds(),
+				},
+			},
+		},
+	})
+}

--- a/expr/span_test.go
+++ b/expr/span_test.go
@@ -1,3 +1,17 @@
+// Copyright observIQ, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expr
 
 import (


### PR DESCRIPTION
### Proposed Change
* Add ConvertToDatapointResourceGroup and ConvertToSpanResourceGroups functions that convert pdata datapoints and spans into a flattened representation

This change allows us to use these telemetry types in `expr` expressions, which will be necessary to implement a count processor for these two telemetry types.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
