### PR TITLE
chore: Factor count logic out of logcount processor

### DIFF
--- a/counter/counter.go
+++ b/counter/counter.go
@@ -12,35 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package logcountprocessor
+package counter
 
 import "encoding/json"
 
-// LogCounter tracks the number of times a set of resource and attribute dimensions have been seen.
-type LogCounter struct {
+// TelemetryCounter tracks the number of times a set of resource and attribute dimensions have been seen.
+type TelemetryCounter struct {
 	resources map[string]*ResourceCounter
 }
 
 // NewLogCounter creates a new LogCounter.
-func NewLogCounter() *LogCounter {
-	return &LogCounter{
+func NewTelemetryCounter() *TelemetryCounter {
+	return &TelemetryCounter{
 		resources: make(map[string]*ResourceCounter),
 	}
 }
 
 // Add increments the counter with the supplied dimensions.
-func (l *LogCounter) Add(resource, attributes map[string]any) {
+func (t *TelemetryCounter) Add(resource, attributes map[string]any) {
 	key := getDimensionKey(resource)
-	if _, ok := l.resources[key]; !ok {
-		l.resources[key] = NewResourceCounter(resource)
+	if _, ok := t.resources[key]; !ok {
+		t.resources[key] = NewResourceCounter(resource)
 	}
 
-	l.resources[key].Add(attributes)
+	t.resources[key].Add(attributes)
+}
+
+func (t TelemetryCounter) Resources() map[string]*ResourceCounter {
+	return t.resources
 }
 
 // Reset resets the counter.
-func (l *LogCounter) Reset() {
-	l.resources = make(map[string]*ResourceCounter)
+func (t *TelemetryCounter) Reset() {
+	t.resources = make(map[string]*ResourceCounter)
 }
 
 // ResourceCounter dimensions the counter by resource.
@@ -67,6 +71,14 @@ func (r *ResourceCounter) Add(attributes map[string]any) {
 	r.attributes[key].Add()
 }
 
+func (r ResourceCounter) Attributes() map[string]*AttributeCounter {
+	return r.attributes
+}
+
+func (r ResourceCounter) Values() map[string]any {
+	return r.values
+}
+
 // AttributeCounter dimensions the counter by attributes.
 type AttributeCounter struct {
 	values map[string]any
@@ -83,6 +95,14 @@ func NewAttributeCounter(values map[string]any) *AttributeCounter {
 // Add increments the counter.
 func (a *AttributeCounter) Add() {
 	a.count++
+}
+
+func (a AttributeCounter) Count() int {
+	return a.count
+}
+
+func (a AttributeCounter) Values() map[string]any {
+	return a.values
 }
 
 // getDimensionKey returns a unique key for the dimension.

--- a/counter/counter.go
+++ b/counter/counter.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package counter contains structs used to count telemetry grouped by resource and attributes.
 package counter
 
 import "encoding/json"
@@ -21,7 +22,7 @@ type TelemetryCounter struct {
 	resources map[string]*ResourceCounter
 }
 
-// NewLogCounter creates a new LogCounter.
+// NewTelemetryCounter creates a new TelemetryCounter.
 func NewTelemetryCounter() *TelemetryCounter {
 	return &TelemetryCounter{
 		resources: make(map[string]*ResourceCounter),
@@ -38,6 +39,7 @@ func (t *TelemetryCounter) Add(resource, attributes map[string]any) {
 	t.resources[key].Add(attributes)
 }
 
+// Resources returns a map of resource ID to a counter for that resource.
 func (t TelemetryCounter) Resources() map[string]*ResourceCounter {
 	return t.resources
 }
@@ -71,10 +73,12 @@ func (r *ResourceCounter) Add(attributes map[string]any) {
 	r.attributes[key].Add()
 }
 
+// Attributes returns a map of attribute set ID to a counter for that attribute set.
 func (r ResourceCounter) Attributes() map[string]*AttributeCounter {
 	return r.attributes
 }
 
+// Values returns the raw map value of the resource that this counter counts.
 func (r ResourceCounter) Values() map[string]any {
 	return r.values
 }
@@ -97,10 +101,12 @@ func (a *AttributeCounter) Add() {
 	a.count++
 }
 
+// Count returns the number of counts for this attribute counter.
 func (a AttributeCounter) Count() int {
 	return a.count
 }
 
+// Values returns the attribute map that this counter tracks.
 func (a AttributeCounter) Values() map[string]any {
 	return a.values
 }

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package logcountprocessor
+package counter
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestLogCounter(t *testing.T) {
-	counter := NewLogCounter()
+	counter := NewTelemetryCounter()
 	resourceMap1 := map[string]any{"resource1": "value1"}
 	resourceMap2 := map[string]any{"resource2": "value2"}
 	attrMap1 := map[string]any{"attr1": "value1"}

--- a/counter/go.mod
+++ b/counter/go.mod
@@ -1,0 +1,11 @@
+module github.com/observiq/observiq-otel-collector/counter
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/counter/go.sum
+++ b/counter/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -165,6 +165,7 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.7 // indirect
 	github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928 // indirect
 	github.com/influxdata/influxdb-observability/otel2influx v0.3.4 // indirect
+	github.com/observiq/observiq-otel-collector/counter v1.22.0 // indirect
 	github.com/observiq/observiq-otel-collector/expr v1.22.0 // indirect
 	github.com/panta/machineid v1.0.2 // indirect
 	github.com/shoenig/go-m1cpu v0.1.4 // indirect
@@ -582,6 +583,8 @@ replace github.com/observiq/observiq-otel-collector/processor/metricextractproce
 replace github.com/observiq/observiq-otel-collector/processor/logdeduplicationprocessor => ./processor/logdeduplicationprocessor
 
 replace github.com/observiq/observiq-otel-collector/expr => ./expr
+
+replace github.com/observiq/observiq-otel-collector/counter => ./counter
 
 // Does not build with windows and only used in configschema executable
 // Relevant issue https://github.com/mattn/go-ieproxy/issues/45

--- a/processor/logcountprocessor/go.mod
+++ b/processor/logcountprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/observiq/observiq-otel-collector/processor/logcountprocessor
 go 1.19
 
 require (
+	github.com/observiq/observiq-otel-collector/counter v1.22.0
 	github.com/observiq/observiq-otel-collector/expr v1.22.0
 	github.com/observiq/observiq-otel-collector/receiver/routereceiver v1.22.0
 	github.com/stretchr/testify v1.8.2
@@ -50,3 +51,5 @@ require (
 replace github.com/observiq/observiq-otel-collector/receiver/routereceiver => ../../receiver/routereceiver
 
 replace github.com/observiq/observiq-otel-collector/expr => ../../expr
+
+replace github.com/observiq/observiq-otel-collector/counter => ../../counter


### PR DESCRIPTION
### Proposed Change
* Factor count logic out of the logcount processor, into a shared module so that it can be used in separate datapointcount and tracecount processor.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
