### PR TITLE
fix: Changed Couchbase metric plugin to use datapoint context

### DIFF
--- a/plugins/couchbase_metrics.yaml
+++ b/plugins/couchbase_metrics.yaml
@@ -1,4 +1,4 @@
-version: 0.0.1
+version: 0.0.2
 title: Couchbase Metrics
 description: Metrics receiver for Couchbase
 parameters:
@@ -124,37 +124,37 @@ template: |
 
     transform/couchbase:
       metric_statements:
-        - context: metric
+        - context: datapoint
           statements:
-          - convert_gauge_to_sum("cumulative", true) where name == "couchbase.bucket.operation.count"
-          - set(description, "Number of operations on the bucket.") where name == "couchbase.bucket.operation.count"
-          - set(unit, "{operations}") where name == "couchbase.bucket.operation.count"
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.operation.count"
+          - set(metric.description, "Number of operations on the bucket.") where metric.name == "couchbase.bucket.operation.count"
+          - set(metric.unit, "{operations}") where metric.name == "couchbase.bucket.operation.count"
 
-          - convert_gauge_to_sum("cumulative", false) where name == "couchbase.bucket.item.count"
-          - set(description, "Number of items that belong to the bucket.") where name == "couchbase.bucket.item.count"
-          - set(unit, "{items}") where name == "couchbase.bucket.item.count"
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.item.count"
+          - set(metric.description, "Number of items that belong to the bucket.") where metric.name == "couchbase.bucket.item.count"
+          - set(metric.unit, "{items}") where metric.name == "couchbase.bucket.item.count"
 
-          - convert_gauge_to_sum("cumulative", false) where name == "couchbase.bucket.vbucket.count"
-          - set(description, "Number of non-resident vBuckets.") where name == "couchbase.bucket.vbucket.count"
-          - set(unit, "{vbuckets}") where name == "couchbase.bucket.vbucket.count"
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.vbucket.count"
+          - set(metric.description, "Number of non-resident vBuckets.") where metric.name == "couchbase.bucket.vbucket.count"
+          - set(metric.unit, "{vbuckets}") where metric.name == "couchbase.bucket.vbucket.count"
 
-          - convert_gauge_to_sum("cumulative", false) where name == "couchbase.bucket.memory.usage"
-          - set(description, "Usage of total memory available to the bucket.") where name == "couchbase.bucket.memory.usage"
-          - set(unit, "By") where name == "couchbase.bucket.memory.usage"
+          - convert_gauge_to_sum("cumulative", false) where metric.name == "couchbase.bucket.memory.usage"
+          - set(metric.description, "Usage of total memory available to the bucket.") where metric.name == "couchbase.bucket.memory.usage"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.usage"
 
-          - convert_gauge_to_sum("cumulative", true) where name == "couchbase.bucket.item.ejection.count"
-          - set(description, "Number of item value ejections from memory to disk.") where name == "couchbase.bucket.item.ejection.count"
-          - set(unit, "{ejections}") where name == "couchbase.bucket.item.ejection.count"
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.item.ejection.count"
+          - set(metric.description, "Number of item value ejections from memory to disk.") where metric.name == "couchbase.bucket.item.ejection.count"
+          - set(metric.unit, "{ejections}") where metric.name == "couchbase.bucket.item.ejection.count"
 
-          - convert_gauge_to_sum("cumulative", true) where name == "couchbase.bucket.error.oom.count"
-          - set(description, "Number of out of memory errors.") where name == "couchbase.bucket.error.oom.count"
-          - set(unit, "{errors}") where name == "couchbase.bucket.error.oom.count"
+          - convert_gauge_to_sum("cumulative", true) where metric.name == "couchbase.bucket.error.oom.count"
+          - set(metric.description, "Number of out of memory errors.") where metric.name == "couchbase.bucket.error.oom.count"
+          - set(metric.unit, "{errors}") where metric.name == "couchbase.bucket.error.oom.count"
 
-          - set(description, "The memory usage at which items will be ejected.") where name == "couchbase.bucket.memory.high_water_mark.limit"
-          - set(unit, "By") where name == "couchbase.bucket.memory.high_water_mark.limit"
+          - set(metric.description, "The memory usage at which items will be ejected.") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.high_water_mark.limit"
 
-          - set(description, "The memory usage at which ejections will stop that were previously triggered by a high water mark breach.") where name == "couchbase.bucket.memory.low_water_mark.limit"
-          - set(unit, "By") where name == "couchbase.bucket.memory.low_water_mark.limit"
+          - set(metric.description, "The memory usage at which ejections will stop that were previously triggered by a high water mark breach.") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
+          - set(metric.unit, "By") where metric.name == "couchbase.bucket.memory.low_water_mark.limit"
 
   service:
     pipelines:


### PR DESCRIPTION
### Proposed Change
Fixed the Couchbase Metrics plugin to use the `datapoint` context rather than `metric` for the transformprocessor.

<details>
  <summary>Metrics Collected:</summary>

```
ResourceMetrics #0
Resource SchemaURL: 
Resource attributes:
     -> service.name: Str(couchbase)
     -> service.instance.id: Str(localhost:8091)
     -> net.host.port: Str(8091)
     -> http.scheme: Str(http)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope  
Metric #0
Descriptor:
     -> Name: couchbase.bucket.memory.high_water_mark.limit
     -> Description: The memory usage at which items will be ejected.
     -> Unit: By
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 178257920.000000
Metric #1
Descriptor:
     -> Name: couchbase.bucket.item.ejection.count
     -> Description: Number of item value ejections from memory to disk.
     -> Unit: {ejections}
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
Metric #2
Descriptor:
     -> Name: couchbase.bucket.operation.count
     -> Description: Number of operations on the bucket.
     -> Unit: {operations}
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(cas)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #1
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(del_ret_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #2
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(incr)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #3
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(set)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 7303.000000
NumberDataPoints #4
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(get)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #5
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(delete)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #6
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(lock)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #7
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(set_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #8
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(set_ret_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #9
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(get_meta_for_set_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #10
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(flush)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #11
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(decr)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #12
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(get_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #13
Data point attributes:
     -> bucket: Str(beer-sample)
     -> op: Str(del_meta)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
Metric #3
Descriptor:
     -> Name: couchbase.bucket.vbucket.count
     -> Description: Number of non-resident vBuckets.
     -> Unit: {vbuckets}
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(active)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 1024.000000
NumberDataPoints #1
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(replica)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #2
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(pending)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #3
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(dead)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
Metric #4
Descriptor:
     -> Name: couchbase.bucket.item.count
     -> Description: Number of items that belong to the bucket.
     -> Unit: {items}
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(active)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 7303.000000
NumberDataPoints #1
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(replica)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #2
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(pending)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
Metric #5
Descriptor:
     -> Name: couchbase.bucket.memory.low_water_mark.limit
     -> Description: The memory usage at which ejections will stop that were previously triggered by a high water mark breach.
     -> Unit: By
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 157286400.000000
Metric #6
Descriptor:
     -> Name: couchbase.bucket.error.oom.count
     -> Description: Number of out of memory errors.
     -> Unit: {errors}
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
     -> error_type: Str(unrecoverable)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
NumberDataPoints #1
Data point attributes:
     -> bucket: Str(beer-sample)
     -> error_type: Str(recoverable)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 0.000000
Metric #7
Descriptor:
     -> Name: couchbase.bucket.memory.usage
     -> Description: Usage of total memory available to the bucket.
     -> Unit: By
     -> DataType: Sum
     -> IsMonotonic: false
     -> AggregationTemporality: Cumulative
NumberDataPoints #0
Data point attributes:
     -> bucket: Str(beer-sample)
     -> state: Str(used)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2023-04-10 16:28:42.756 +0000 UTC
Value: 35162832.000000

```
</details>

##### Checklist
- [X] Changes are tested
- [ ] CI has passed
