### PR TITLE
feat(windows-service-reliability): Windows Service Auto Restarts on Failure

### DIFF
--- a/.github/workflows/manual_msi_build.yml
+++ b/.github/workflows/manual_msi_build.yml
@@ -52,7 +52,7 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.1.0/go-msi.exe
+          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
           curl -f -L -o wix310-binaries.zip http://wixtoolset.org/downloads/v3.10.3.3007/wix310-binaries.zip
           unzip wix310-binaries.zip
         working-directory: C:/build
@@ -111,7 +111,7 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.1.0/go-msi.exe
+          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
           curl -f -L -o wix310-binaries.zip http://wixtoolset.org/downloads/v3.10.3.3007/wix310-binaries.zip
           unzip wix310-binaries.zip
         working-directory: C:/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.1.0/go-msi.exe
+          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
           curl -f -L -o wix310-binaries.zip http://wixtoolset.org/downloads/v3.10.3.3007/wix310-binaries.zip
           unzip wix310-binaries.zip
         working-directory: C:/build
@@ -112,7 +112,7 @@ jobs:
       # Installs go-msi and wix.
       - name: Install Build Tools
         run: |
-          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.1.0/go-msi.exe
+          curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
           curl -f -L -o wix310-binaries.zip http://wixtoolset.org/downloads/v3.10.3.3007/wix310-binaries.zip
           unzip wix310-binaries.zip
         working-directory: C:/build

--- a/windows/scripts/fetch-dependencies.sh
+++ b/windows/scripts/fetch-dependencies.sh
@@ -17,7 +17,7 @@ set -e
 BASEDIR="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 PROJECT_BASE="$BASEDIR/../.."
 
-[ -f go-msi.exe ] || curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.1.0/go-msi.exe
+[ -f go-msi.exe ] || curl -f -L -o go-msi.exe https://github.com/observIQ/go-msi/releases/download/v2.2.0/go-msi.exe
 [ -f ./cinc-auditor.msi ] || curl -f -L -o cinc-auditor.msi http://downloads.cinc.sh/files/stable/cinc-auditor/4.17.7/windows/2012r2/cinc-auditor-4.17.7-1-x64.msi
 
 [ -f ./wix-binaries.zip ] || curl -f -L -o wix-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -8,7 +8,8 @@
     <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
 <?endif?>
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
    <!-- This hardcoded GUID is specifically for the observiq-otel-collector.
         If Id is set to "*", it auto generates an ID, which seems OK, but new MSIs will no longer be able to
         correlate itself with old versions of the installer, and will fail to uninstall old versions properly -->
@@ -101,8 +102,7 @@
                         {{if $f.Service.Delayed}}
                         <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" FailureActionsWhen="failedToStopOrReturnedError"/>
                         {{end}}
-                        <util:ServiceConfig xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
-                                            FirstFailureActionType="restart"
+                        <util:ServiceConfig FirstFailureActionType="restart"
                                             SecondFailureActionType="restart"
                                             ThirdFailureActionType="restart"
                                             ResetPeriodInDays="30"

--- a/windows/templates/product.wxs
+++ b/windows/templates/product.wxs
@@ -99,8 +99,14 @@
                         <ServiceDependency Id="{{$d}}"/>
                         {{end}}
                         {{if $f.Service.Delayed}}
-                        <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes"/>
+                        <ServiceConfig DelayedAutoStart="yes" OnInstall="yes" OnReinstall ="yes" FailureActionsWhen="failedToStopOrReturnedError"/>
                         {{end}}
+                        <util:ServiceConfig xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
+                                            FirstFailureActionType="restart"
+                                            SecondFailureActionType="restart"
+                                            ThirdFailureActionType="restart"
+                                            ResetPeriodInDays="30"
+                                            RestartServiceDelayInSeconds="5"/>
                     </ServiceInstall>
                     <ServiceControl Id="ServiceControl{{$f.ID}}" Name="{{$f.Service.Name}}" Start="install" Stop="both" Remove="uninstall"/>
                     {{end}}


### PR DESCRIPTION
### Proposed Change
- Updated msi builds to use [observIQ/go-msi v2.2.0](https://github.com/observIQ/go-msi/releases/tag/v2.2.0)
- Added Recovery conditions to Windows Service via the [WixUtilExtension ServiceConfig](https://wixtoolset.org/docs/v3/xsd/util/serviceconfig/)
  - Always restarts
  - Waits 5 seconds to restart
  - Clears restart counter after 30 days

New set properties from Service UI:
<img width="404" alt="Screenshot 2023-04-11 at 10 43 03 AM" src="https://user-images.githubusercontent.com/11877763/231203124-384f3764-b581-4735-b7be-c7835e0557d7.png">


### Testing

1. Create an MSI using the [manual_msi_build action](https://github.com/observIQ/observiq-otel-collector/actions/workflows/manual_msi_build.yml) pointing to this branch.
2. Install the MSI on a box
3. Verify in the Collector Service Properties under `Recovery` that the recovery options are set.
4. Trigger recovery by ending the Collector process via task manager.


##### Checklist
- [x] Changes are tested
- [ ] CI has passed
