### PR TITLE
feat(windows-service-recovery): Apply Recovery actions to existing agents on update

### DIFF
--- a/updater/internal/service/service_windows.go
+++ b/updater/internal/service/service_windows.go
@@ -35,6 +35,11 @@ import (
 const (
 	defaultProductName = "observIQ Distro for OpenTelemetry Collector"
 	defaultServiceName = "observiq-otel-collector"
+
+	// defaultRecoveryDelay is the duration in which to wait between service restarts due to failures
+	defaultRecoveryDelay = 5 * time.Second
+	// defaultResetPeriod is the time in which to reset the service failure count to zero
+	defaultResetPeriod = 30 * 24 * time.Hour
 )
 
 // Option is an extra option for creating a Service
@@ -381,20 +386,17 @@ func setRecoveryActions(s *mgr.Service) error {
 	recoveryActions := []mgr.RecoveryAction{
 		{
 			Type:  mgr.ServiceRestart,
-			Delay: 5 * time.Second,
+			Delay: defaultRecoveryDelay,
 		},
 		{
 			Type:  mgr.ServiceRestart,
-			Delay: 5 * time.Second,
+			Delay: defaultRecoveryDelay,
 		},
 		{
 			Type:  mgr.ServiceRestart,
-			Delay: 5 * time.Second,
+			Delay: defaultRecoveryDelay,
 		},
 	}
 
-	// Reset the counter every 30 days
-	resetDays := 30 * 24 * time.Hour
-
-	return s.SetRecoveryActions(recoveryActions, uint32(resetDays.Seconds()))
+	return s.SetRecoveryActions(recoveryActions, uint32(defaultResetPeriod.Seconds()))
 }

--- a/updater/internal/service/service_windows_test.go
+++ b/updater/internal/service/service_windows_test.go
@@ -530,6 +530,19 @@ func requireServiceConfigMatches(t *testing.T, binaryPath, name string, startTyp
 	assert.Equal(t, expectedBinaryPathName, cfg.BinaryPathName)
 	// We always install as LocalSystem, which is the "super user" of the system
 	assert.Equal(t, "LocalSystem", cfg.ServiceStartName)
+
+	// Check Recovery Actions are set
+	recoveryActions, err := s.RecoveryActions()
+	require.NoError(t, err)
+
+	for _, action := range recoveryActions {
+		assert.Equal(t, mgr.ServiceRestart, action.Type)
+		assert.Equal(t, defaultRecoveryDelay, action.Delay)
+	}
+
+	period, err := s.ResetPeriod()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(defaultResetPeriod.Seconds()), period)
 }
 
 func requireServiceRunningStatus(t *testing.T, running bool) {


### PR DESCRIPTION
### Proposed Change
Added recovery actions to updater binary to match settings in #1023. This will ensure any existing agents will have the recovery actions applied to them on update.

##### Checklist
- [X] Changes are tested
- [x] CI has passed
