### PR TITLE
fix(mask-processor): Fixed Default rules not having correct mask strings

### DIFF
--- a/processor/maskprocessor/README.md
+++ b/processor/maskprocessor/README.md
@@ -16,7 +16,7 @@ This processor is used to detect and mask sensitive data.
 ## Configuration
 | Field        | Type     | Default | Description |
 | ---          | ---      | ---     | ---         |
-| rules        | map      | `email`: `\b[a-z0-9._%\+\-—\|]+@[a-z0-9.\-—\|]+\.[a-z\|]{2,6}\b`<br /><br />`ssn`: `\b\d{3}[- ]\d{2}[- ]\d{4}\b`<br /><br />`credit_card`: `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}\|\d{15,16}))\b`<br /><br />`phone`: `\b((\+\|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]\|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`<br /><br />`ipv4`: `(?:[0-9]{1,3}\.){3}[0-9]{1,3}`|     | A series of key value pairs that define the masking rules of the processor. The key is the name of the rule. The value is the regex to mask. The regex engine used is [standard golang](https://pkg.go.dev/regexp/syntax). |
+| rules        | map      | `email`: `\b[a-z0-9._%\+\-—\|]+@[a-z0-9.\-—\|]+\.[a-z\|]{2,6}\b`<br /><br />`ssn`: `\b\d{3}[- ]\d{2}[- ]\d{4}\b`<br /><br />`credit_card`: `\b(?:(?:(?:\d{4}[- ]?){3}\d{4}\|\d{15,16}))\b`<br /><br />`phone`: `\b((\+\|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]\|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`<br /><br />`ipv4`: `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`|     | A series of key value pairs that define the masking rules of the processor. The key is the name of the rule. The value is the regex to mask. The regex engine used is [standard golang](https://pkg.go.dev/regexp/syntax). |
 | exclude      | []string | `[]`    | A list of json dot notation fields that will be excluded from masking. The prefixes `resource`, `attributes`, and `body` can be used to indicate the root of the field. |
 
 ### Example Config

--- a/processor/maskprocessor/processor.go
+++ b/processor/maskprocessor/processor.go
@@ -38,7 +38,7 @@ var defaultRules = map[string]*regexp.Regexp{
 	"ssn":         regexp.MustCompile(`\b\d{3}[- ]\d{2}[- ]\d{4}\b`),
 	"credit_card": regexp.MustCompile(`\b(?:(?:(?:\d{4}[- ]?){3}\d{4}|\d{15,16}))\b`),
 	"phone":       regexp.MustCompile(`\b((\+|\b)[1l][\-\. ])?\(?\b[\dOlZSB]{3,5}([\-\. ]|\) ?)[\dOlZSB]{3}[\-\. ][\dOlZSB]{4}\b`),
-	"ipv4":        regexp.MustCompile(`(?:[0-9]{1,3}\.){3}[0-9]{1,3}`),
+	"ipv4":        regexp.MustCompile(`\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`),
 }
 
 // maskProcessor is the processor used to mask data.

--- a/processor/maskprocessor/processor_test.go
+++ b/processor/maskprocessor/processor_test.go
@@ -191,7 +191,7 @@ func TestCreateRules(t *testing.T) {
 		{
 			desc:          "No rules",
 			exprs:         map[string]string{},
-			expectedRules: defaultRules,
+			expectedRules: formatRuleMaskName(defaultRules),
 		},
 	}
 
@@ -229,7 +229,7 @@ func TestCompileRules(t *testing.T) {
 				"test": "test",
 			},
 			expectedRules: map[string]*regexp.Regexp{
-				"[masked_test]": regexp.MustCompile("test"),
+				"test": regexp.MustCompile("test"),
 			},
 			expectedErr: nil,
 		},


### PR DESCRIPTION
### Proposed Change
- Fixed and issue where default rules would not mask strings in the form of `[masked_{RULE_NAME}]`
- Also, fixed default regex for IPv4 mask to have word boundaries like other default rules

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
