### PR TITLE
Tag and push images to google artifact repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
+      - name: Login to Google Artifact Repository
+        uses: docker/login-action@v2
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.ORG_OBSERVIQ_PUBLIC_GCR_JSON_KEY }}
       - name: Retrieve Windows 64-bit MSI Installer
         uses: actions/download-artifact@v3
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -206,6 +206,10 @@ dockers:
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:latest"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}"
     dockerfile: ./docker/Dockerfile.ubuntu
     use: buildx
     build_flag_templates:
@@ -233,6 +237,10 @@ dockers:
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:latest"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}"
     dockerfile: ./docker/Dockerfile.ubuntu
     use: buildx
     build_flag_templates:
@@ -255,6 +263,7 @@ dockers:
     image_templates:
       - "observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     dockerfile: ./docker/Dockerfile.ubi8
     use: buildx
     build_flag_templates:
@@ -276,6 +285,7 @@ dockers:
     image_templates:
       - "observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     dockerfile: ./docker/Dockerfile.ubi8
     use: buildx
     build_flag_templates:
@@ -340,6 +350,31 @@ docker_manifests:
     image_templates:
       - "ghcr.io/observiq/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
       - "ghcr.io/observiq/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:latest"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:latest"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:latest"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:{{ .Major }}"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}"
+    skip_push: false
+  - name_template: "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+    image_templates:
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
+      - "us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-ubi8"
     skip_push: false
 
 # https://goreleaser.com/customization/checksum/


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

In addition to Dockerhub and Github Container Registry, we would like to push images to Google Artifact Repository.

- Added docker login step for GAR using the secret `ORG_OBSERVIQ_PUBLIC_GCR_JSON_KEY`, which has already been configured on this repo.
- Added additional tags to debian and rhel amd64 / arm64 builds
- Added multi arch manifests for new `us-central1-docker.pkg.dev` tags.

Version 1.22 of the collector was pulled and re-tagged with `us-central1-docker.pkg.dev`. You can pull the image with:
```bash
docker pull us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector:1.22.0
```

This PR was based on BindPlane's https://github.com/observIQ/bindplane-op/pull/900/files

Building results in the following image tags:
```bash
➜  observiq-otel-collector git:(google-artifact-registry) ✗ docker images | grep observiq-otel-collector | sort -k1
ghcr.io/observiq/observiq-otel-collector-amd64                                           1.22.0        5453d499d122   About a minute ago   513MB
ghcr.io/observiq/observiq-otel-collector-amd64                                           1.22.0-ubi8   78e05502715a   About a minute ago   634MB
ghcr.io/observiq/observiq-otel-collector-amd64                                           1.22          5453d499d122   About a minute ago   513MB
ghcr.io/observiq/observiq-otel-collector-amd64                                           1             5453d499d122   About a minute ago   513MB
ghcr.io/observiq/observiq-otel-collector-amd64                                           latest        5453d499d122   About a minute ago   513MB
ghcr.io/observiq/observiq-otel-collector-arm64                                           1.22.0        6dcfa7499911   34 seconds ago       499MB
ghcr.io/observiq/observiq-otel-collector-arm64                                           1.22.0-ubi8   e366cf1d2638   About a minute ago   651MB
ghcr.io/observiq/observiq-otel-collector-arm64                                           1.22          6dcfa7499911   34 seconds ago       499MB
ghcr.io/observiq/observiq-otel-collector-arm64                                           1             6dcfa7499911   34 seconds ago       499MB
ghcr.io/observiq/observiq-otel-collector-arm64                                           latest        6dcfa7499911   34 seconds ago       499MB
observiq/observiq-otel-collector-amd64                                                   1.22.0        5453d499d122   About a minute ago   513MB
observiq/observiq-otel-collector-amd64                                                   1.22.0-ubi8   78e05502715a   About a minute ago   634MB
observiq/observiq-otel-collector-amd64                                                   1.22          5453d499d122   About a minute ago   513MB
observiq/observiq-otel-collector-amd64                                                   1             5453d499d122   About a minute ago   513MB
observiq/observiq-otel-collector-amd64                                                   latest        5453d499d122   About a minute ago   513MB
observiq/observiq-otel-collector-arm64                                                   1.22.0        6dcfa7499911   34 seconds ago       499MB
observiq/observiq-otel-collector-arm64                                                   1.22.0-ubi8   e366cf1d2638   About a minute ago   651MB
observiq/observiq-otel-collector-arm64                                                   1.22          6dcfa7499911   34 seconds ago       499MB
observiq/observiq-otel-collector-arm64                                                   1             6dcfa7499911   34 seconds ago       499MB
observiq/observiq-otel-collector-arm64                                                   latest        6dcfa7499911   34 seconds ago       499MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector         1.22.0        0dad4ec2bff5   12 days ago          513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   1.22.0        5453d499d122   About a minute ago   513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   1.22.0-ubi8   78e05502715a   About a minute ago   634MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   1.22          5453d499d122   About a minute ago   513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   1             5453d499d122   About a minute ago   513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   latest        5453d499d122   About a minute ago   513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-amd64   <none>        0dad4ec2bff5   12 days ago          513MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64   1.22.0        6dcfa7499911   34 seconds ago       499MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64   1.22.0-ubi8   e366cf1d2638   About a minute ago   651MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64   1.22          6dcfa7499911   34 seconds ago       499MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64   1             6dcfa7499911   34 seconds ago       499MB
us-central1-docker.pkg.dev/observiq-containers/collector/observiq-otel-collector-arm64   latest        6dcfa7499911   34 seconds ago       499MB
```

##### Checklist
- [x] Changes are tested
- [x] CI has passed
