### PR TITLE
feat(plugin): Add Severity parsing to Kubernetes container logs

### DIFF
--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -1,4 +1,4 @@
-version: 0.4.1
+version: 0.5.0
 title: Kubernetes Container Logs
 description: Log parser for Kubernetes Container logs. This plugin is meant to be used with the OpenTelemetry Operator for Kubernetes (https://github.com/open-telemetry/opentelemetry-operator).
 parameters:
@@ -138,16 +138,43 @@ template: |
             from: attributes.log
             to: body
 
+          # Initial severity is derived from the stream field, which can be
+          # "stderr" or "stdout"
+          - type: severity_parser
+            parse_from: attributes.stream
+            mapping:
+              info: stdout
+              error: stderr
+
           # Parse body as json if the body appears to be json
           {{ if .body_json_parsing }}
           - type: json_parser
             if: body matches "^{.*}\\s*$"
             parse_from: body
             parse_to: body
+
+          # After parsing the log body as json, parse severity
+          # or level if present, with severity taking precedence.
+          - type: router
+            default: file_name_parser
+            routes:
+              - expr: 'body.severity != nil'
+                output: body_severity_parser
+              - expr: 'body.level != nil'
+                output: body_level_parser
+          - type: severity_parser
+            id: body_severity_parser
+            parse_from: body.severity
+            output: file_name_parser
+          - type: severity_parser
+            id: body_level_parser
+            parse_from: body.level
+            output: file_name_parser
           {{ end }}
 
           # Detect pod, namespace, and container names from the file name.
           - type: regex_parser
+            id: file_name_parser
             regex: '^(?P<pod>[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)_(?P<namespace>[^_]+)_(?P<container>.+)-'
             parse_from: attributes["log.file.name"]
             cache:

--- a/plugins/container_logs.yaml
+++ b/plugins/container_logs.yaml
@@ -101,7 +101,7 @@ template: |
           # 2022-06-18T16:52:59.639114537Z stdout F {"message":"registered Stackdriver tracing","severity":"info","timestamp":"2022-06-18T16:52:59.639034532Z"}
           - id: containerd_cri_parser
             type: regex_parser
-            regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w)?\s*?(?P<log>.*)'
+            regex: '^(?P<time>[^\s]+) (?P<stream>\w+) (?P<partial>\w)? ?(?P<log>.*)'
           - type: recombine
             source_identifier: attributes["log.file.name"]
             combine_field: attributes.log


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The container logs plugin does not contain severity parsing. In an effort to fall in line with [Google's GKE log agent](https://cloud.google.com/blog/products/management-tools/using-logging-your-apps-running-kubernetes-engine), I have added the following:
- parse `attributes.stream` for basic severity
- parse `body.severity` if present, using default mappings
- parse `body.level` if `severity` is not present, using default mappings

This PR handles common severity cases. Support for more advanced options could come in the future, such as custom severity field / custom mapping, etc.

Before:
![Screenshot from 2023-04-20 16-07-59](https://user-images.githubusercontent.com/23043836/233476483-e4fc30ca-b85a-44b1-b1fe-28f9741debdd.png)

After:
- steam: stdout (info log)
- stream: stderr (error log)
- body.severity (debug log)
![steam-info](https://user-images.githubusercontent.com/23043836/233476765-9aac348e-942d-4f85-a56f-541c4bd1a037.png)
![stream_error](https://user-images.githubusercontent.com/23043836/233476779-237d7dd6-fa53-4432-b589-66d0217afaee.png)
![body_debug](https://user-images.githubusercontent.com/23043836/233476786-7e704c9c-bfd0-4add-94a9-26ce4be6061a.png)


##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
