### PR TITLE
feat(container): Tighten config file permissions

### DIFF
--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -79,6 +79,10 @@ RUN chown otel:otel \
     /etc/otel/config.yaml \
     /etc/otel/logging.yaml
 
+RUN chmod 0600 \
+    /etc/otel/config.yaml \
+    /etc/otel/logging.yaml
+
 USER otel
 WORKDIR /etc/otel
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -80,6 +80,10 @@ RUN chown otel:otel \
     /etc/otel/config.yaml \
     /etc/otel/logging.yaml
 
+RUN chmod 0600 \
+    /etc/otel/config.yaml \
+    /etc/otel/logging.yaml
+
 USER otel
 WORKDIR /etc/otel
 


### PR DESCRIPTION
<!-- ## Important (read before submitting)
In order for changes to be captured in changelog correctly please add one of the following prefixes to the title. **Note** the parenthesis are optional and so is any text in them.
- `feat(OPTIONAL):` = New features
- `fix(OPTIONAL):` = Bug fixes
- `deps(OPTIONAL):` = Dependency updates, primarily dependabot
-->


### Proposed Change
<!-- Please provide a description of the change here. -->

The configs should only be read by the `otel` user or the `root` user, therefor the permissions can be restricted to rw for the owner only.

`ls -la` give me:
```
-rw------- 1 otel otel 3184 Apr 24 14:34 config.yaml
-rw------- 1 otel otel   27 Apr 24 14:34 logging.yaml
```

Working great for me when running in Kubernetes as a daemonset / deployment.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
