### PR TITLE
feat(exporters): Include awss3exporter from otel-contrib

### DIFF
--- a/docs/exporters.md
+++ b/docs/exporters.md
@@ -8,6 +8,7 @@ Below is a list of supported exporters with links to their documentation pages.
 | AWS CloudWatch Logs Exporter                                      | [awscloudwatchlogsexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/awscloudwatchlogsexporter/README.md) |
 | AWS CloudWatch EMF Exporter                                       | [awsemfexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/awsemfexporter/README.md) |
 | AWS Kinesis Exporter                                              | [awskinesisexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/awskinesisexporter/README.md) |
+| AWS S3 Exporter                                                   | [awss3exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/awss3exporter/README.md) |
 | AWS X-Ray Tracing Exporter                                        | [awsxrayexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/awsxrayexporter/README.md) |
 | Azure Monitor Exporter                                            | [azuremonitorexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/azuremonitorexporter/README.md) |
 | Carbon Exporter                                                   | [carbonexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.76.3/exporter/carbonexporter/README.md) |

--- a/factories/exporters.go
+++ b/factories/exporters.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter"
@@ -56,6 +57,7 @@ var defaultExporters = []exporter.Factory{
 	awscloudwatchlogsexporter.NewFactory(),
 	awsemfexporter.NewFactory(),
 	awskinesisexporter.NewFactory(),
+	awss3exporter.NewFactory(),
 	awsxrayexporter.NewFactory(),
 	azuremonitorexporter.NewFactory(),
 	carbonexporter.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter v0.76.3
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter v0.76.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.76.3
@@ -274,7 +275,7 @@ require (
 	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/aws/aws-sdk-go v1.44.249 // indirect
+	github.com/aws/aws-sdk-go v1.44.253 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.17.8 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.18.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.68/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.45/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.44.249 h1:UbUvh/oYHdAD3vZjNi316M0NIupJsrqAcJckVuhaCB8=
-github.com/aws/aws-sdk-go v1.44.249/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.44.253 h1:iqDd0okcH4ShfFexz2zzf4VmeDFf6NOMm07pHnEb8iY=
+github.com/aws/aws-sdk-go v1.44.253/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.7.0/go.mod h1:tb9wi5s61kTDA5qCkcDbt3KRVV74GGslQkl/DRdX/P4=
 github.com/aws/aws-sdk-go-v2 v1.9.1/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
@@ -1525,6 +1525,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporte
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter v0.76.3/go.mod h1:1SBA8pM33GhbVB3Ka4Xwepys8glgU1BFLwTO2xoS/Es=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter v0.76.3 h1:wpPxii2s9rMf3gJcydP/7l467N46cWqVr3MVrYX9Sm4=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter v0.76.3/go.mod h1:E8O+hew0jkdPb9F8cl8hBfN/W3J8amhSEQImP1C20Ok=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.76.3 h1:1Koe7wUgSt8Fh2fsdDoup9zgTQHU7I1ju+75bTdNs40=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.76.3/go.mod h1:9vixrJkkdIphaofcAn73EUhXXN7UBR8fXhoKPXi9F+0=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.76.3 h1:BztZjNSQtyWmxYoKjUuXexjJSamkQPKASKmUVvsEOnM=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.76.3/go.mod h1:rqs3fc57tKCQLPr6v0VqbWhHmArR+RAMjL+Bjn1eXUU=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter v0.76.3 h1:Yd8yJJn++s4C02ovby5kCm2lSmLfRhnsht8dz7wiFPw=


### PR DESCRIPTION
### Proposed Change
Cherry picked s3 exporter commit from release/v1.25.0 branch as we want it in the v1.24.0 release.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
