### PR TITLE
fix: Fix incorrect build path when copying the build windows binary in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
       - name: Copy Windows Collector Binary
-        run: cp dist/collector_windows_amd64_v1/observiq-otel-collector.exe windows/observiq-otel-collector.exe
+        run: cp dist/windows_amd64/collector_windows_amd64_v1/observiq-otel-collector.exe windows/observiq-otel-collector.exe
       - name: Copy Windows Updater Binary
-        run: cp dist/updater_windows_amd64_v1/updater.exe windows/updater.exe
+        run: cp dist/windows_amd64/updater_windows_amd64_v1/updater.exe windows/updater.exe
       - name: Copy Plugins to MSI Build Directory
         run: cp -r release_deps/plugins windows/
       - name: Copy Example Config
@@ -90,9 +90,9 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GOARCH: "386"
       - name: Copy Windows Collector Binary
-        run: cp dist/collector_windows_386/observiq-otel-collector.exe windows/observiq-otel-collector.exe
+        run: cp dist/windows_386/collector_windows_386/observiq-otel-collector.exe windows/observiq-otel-collector.exe
       - name: Copy Windows Updater Binary
-        run: cp dist/updater_windows_386/updater.exe windows/updater.exe
+        run: cp dist/windows_386/updater_windows_386/updater.exe windows/updater.exe
       - name: Copy Plugins to MSI Build Directory
         run: cp -r release_deps/plugins windows/
       - name: Copy Example Config


### PR DESCRIPTION
### Proposed Change
* Path to the build artifact has changed, maybe related to switching to go-releaser pro.

See the failure here: https://github.com/observIQ/observiq-otel-collector/actions/runs/5006631107/jobs/8972160306

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
