### PR TITLE
chore(ci): Updated runner for windows test and build to 8 core box

### DIFF
--- a/.github/workflows/multi_build.yml
+++ b/.github/workflows/multi_build.yml
@@ -39,7 +39,7 @@ jobs:
           go install github.com/uw-labs/lichen@v0.1.7
           lichen --config=./license.yaml $(find dist/collector_* dist/updater_*)
   build_windows:
-    runs-on: windows-2022
+    runs-on: windows-2022-8-cores
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2022-8-cores]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Sources


### PR DESCRIPTION
### Proposed Change
Updated build and test CI to use `windows-2022-8-cores` larger box to fix OOM errors

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
