### PR TITLE
fix(install): Fixes Linux reinstallation after manual uninstall

### DIFF
--- a/scripts/install/install_unix.sh
+++ b/scripts/install/install_unix.sh
@@ -582,6 +582,12 @@ install_package()
   fi
 
   info "Installing package..."
+  # if target install directory doesn't exist and we're using dpkg ensure a clean state 
+  # by checking for the package and running purge if it exists.
+  if [ ! -d "/opt/observiq-otel-collector" ] && [ "$package_type" = "deb" ]; then
+    dpkg -s "observiq-otel-collector" > /dev/null 2>&1 && dpkg --purge "observiq-otel-collector" > /dev/null 2>&1
+  fi
+
   unpack_package || error_exit "$LINENO" "Failed to extract package"
   succeeded
 


### PR DESCRIPTION
### Proposed Change
Fixes an issue where config files would be missing on Linux systems using the debian package on reinstall after the `/opt/observiq-otel-collector` directory was deleted.

**Steps to reproduce issue:**
1. Install the collector on a system with `dpkg` via the installation script
2. Uninstall the collector via the installation script using the `-r` flag
3. Remove the collector directory by running `sudo rm -rf /opt/observiq-otel-collector`
4. Install the collector again via the installation script and notice the config files are missing and the service failed to start.

**Fix:**
On install of a debian package check if the collector directory exists. If it does not check if the debian package is still registered with `dpkg`. If it is purge the package for a clean state then install.

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
