### PR TITLE
feat: Rename macOS Service

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,7 +89,7 @@ archives:
       - src: release_deps/VERSION.txt
         dst: "."
         strip_parent: true
-      - src: release_deps/com.observiq.collector.plist
+      - src: release_deps/com.bindplane.agent.plist
         dst: "install"
         strip_parent: true
       - src: release_deps/windows_service.json

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ release-prep:
 	@cp -r ./plugins release_deps/
 	@cp config/example.yaml release_deps/config.yaml
 	@cp config/logging.yaml release_deps/logging.yaml
-	@cp service/com.observiq.collector.plist release_deps/com.observiq.collector.plist
+	@cp service/com.bindplane.agent.plist release_deps/com.bindplane.agent.plist
 	@jq ".files[] | select(.service != null)" windows/wix.json >> release_deps/windows_service.json
 	@cp service/observiq-otel-collector.service release_deps/observiq-otel-collector.service
 

--- a/docs/installation-mac.md
+++ b/docs/installation-mac.md
@@ -26,7 +26,7 @@ After installing the `observiq-otel-collector` you can change the configuration 
 
 The default configuration file can be found at `/opt/observiq-otel-collector/config.yaml`.
 
-After changing the configuration file run `sudo launchctl unload /Library/LaunchDaemons/com.observiq.collector.plist; sudo launchctl load /Library/LaunchDaemons/com.observiq.collector.plist` for the changes to take effect.
+After changing the configuration file run `sudo launchctl unload /Library/LaunchDaemons/com.bindplane.agent.plist; sudo launchctl load /Library/LaunchDaemons/com.bindplane.agent.plist` for the changes to take effect.
 
 For more information on configuring the collector, see the [OpenTelemetry docs](https://opentelemetry.io/docs/collector/configuration/).
 
@@ -42,10 +42,10 @@ The collector uses `launchctl` to control the collector lifecycle using the foll
 
 ```sh
 # Start the collector
-sudo launchctl load /Library/LaunchDaemons/com.observiq.collector.plist
+sudo launchctl load /Library/LaunchDaemons/com.bindplane.agent.plist
 
 # Stop the collector
-sudo launchctl unload /Library/LaunchDaemons/com.observiq.collector.plist
+sudo launchctl unload /Library/LaunchDaemons/com.bindplane.agent.plist
 ```
 
 ## Uninstalling

--- a/scripts/install/install_macos.sh
+++ b/scripts/install/install_macos.sh
@@ -16,7 +16,7 @@
 set -e
 
 # Collector Constants
-SERVICE_NAME="com.observiq.collector"
+SERVICE_NAME="com.bindplane.agent"
 DOWNLOAD_BASE="https://github.com/observiq/observiq-otel-collector/releases/download"
 
 # Script Constants
@@ -508,6 +508,14 @@ install_package()
     # Existing service file, we should stop & unload first.
     info "Uninstalling existing service file..."
     launchctl unload -w "/Library/LaunchDaemons/$SERVICE_NAME.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/$SERVICE_NAME.plist"
+    succeeded
+  fi
+
+  # If we're using the old service file then stop the service and remove that
+  if [ -f "/Library/LaunchDaemons/com.observiq.collector.plist" ]; then
+    info "Uninstalling existing service file..."
+    launchctl unload -w "/Library/LaunchDaemons/com.observiq.collector.plist" > /dev/null 2>&1 || error_exit "$LINENO" "Failed to unload service file /Library/LaunchDaemons/com.observiq.collector.plist"
+    rm /Library/LaunchDaemons/com.observiq.collector.plist || error_exit "$LINENO" "Failed to remove old service file /Library/LaunchDaemons/com.observiq.collector.plist"
     succeeded
   fi
 

--- a/service/com.bindplane.agent.plist
+++ b/service/com.bindplane.agent.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.observiq.collector</string>
+    <string>com.bindplane.agent</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>OIQ_OTEL_COLLECTOR_HOME</key>

--- a/updater/internal/service/service_darwin.go
+++ b/updater/internal/service/service_darwin.go
@@ -169,7 +169,13 @@ func (d darwinService) Update() error {
 }
 
 func (d darwinService) Backup() error {
-	if err := file.CopyFileNoOverwrite(d.logger.Named("copy-file"), d.installedServiceFilePath, path.BackupServiceFile(d.installDir)); err != nil {
+	// determine the current service file
+	currentServiceFile, err := d.determineCurrentServiceFilePath()
+	if err != nil {
+		return fmt.Errorf("failed to copy service file: %w", err)
+	}
+
+	if err := file.CopyFileNoOverwrite(d.logger.Named("copy-file"), currentServiceFile, path.BackupServiceFile(d.installDir)); err != nil {
 		return fmt.Errorf("failed to copy service file: %w", err)
 	}
 

--- a/updater/internal/service/testdata/legacy-darwin-service.plist
+++ b/updater/internal/service/testdata/legacy-darwin-service.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>legacy-darwin-service</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>sleep</string>
+        <string>1000</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
### Proposed Change
- Renamed macOS service to `com.bindplane.agent.plist`
  - Updated plist file name
  - Updated label in plist file
- Updated install script to replace legacy service file with new one
- Updater replaces  legacy service file with new one
- Updated macOS documentation

### Testing

#### Scripts
1. Install the collector via the current script 
   ```shell
   sudo sh -c "$(curl -fsSlL https://github.com/observiq/observiq-otel-collector/releases/latest/download/install_macos.sh)" install_macos.sh
   ```
2. Run `make release-test` to create release artifacts with the new script
3. Install with the new script vial the following command (replace `<RELEASE_VERSION>` with the version string of your artifacts
   ```shell
   sudo scripts/install/install_macos.sh -l file:///Users/cphelps/git/observiq-otel-collector/dist/observiq-otel-collector-<RELEASE_VERSION>-darwin-arm64.tar.gz
   ```
4. Observe the new service via `sudo launchctl list | grep bindplane` and `sudo cat /Library/LaunchDaemons/com.bindplane.agent.plist`
5. Observe the new service via `sudo launchctl list | grep observiq` and `sudo cat /Library/LaunchDaemons/com.observiq.collector.plist`

#### OpAMP
1. Install the collector via the BindPlaneOP installation command 
2.  Run `make release-test` to create release artifacts with the new `updater`
3. Upload these release artifacts to BindPlaneOP either manually or by using the offline agent upgrades feature in Enterprise
4. Upgrade the collector in BindPlaneOP UI.
5. Observe the new service via `sudo launchctl list | grep bindplane` and `sudo cat /Library/LaunchDaemons/com.bindplane.agent.plist`
6. Observe the new service via `sudo launchctl list | grep observiq` and `sudo cat /Library/LaunchDaemons/com.observiq.collector.plist`

##### Checklist
- [x] Changes are tested
- [ ] CI has passed
