### PR TITLE
chore: Removed amplify trigger from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,11 +222,3 @@ jobs:
           repository: observIQ/otel-collector-installer-testing
           event-type: upstream_prerelease
           client-payload: '{ "version": "${{ github.ref_name }}" }'
-      # Trigger amplify repo
-      - name: Update Amplify Version
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.ORG_GORELEASER_GITHUB_TOKEN }}
-          repository: observIQ/amplify
-          event-type: update_collector_version
-          client-payload: '{ "version": "${{ github.ref_name }}" }'


### PR DESCRIPTION
### Proposed Change
Removed amplify trigger from the release as it doesn't work and is triggering a private github action that counts against our private action balance.

##### Checklist
- [ ] Changes are tested
- [ ] CI has passed
